### PR TITLE
Show PHP warnings only to administrators

### DIFF
--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -381,6 +381,11 @@ class errorHandler {
 	{
 		global $mybb, $parser;
 
+		if(!empty($mybb->usergroup) && $mybb->settings['useerrorperm'] == 1 && $mybb->usergroup['cancp'] != 1)
+		{
+			exit(1);
+		}
+
 		if(!$mybb->settings['bbname'])
 		{
 			$mybb->settings['bbname'] = "MyBB";

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -298,7 +298,7 @@ function parse_page($contents)
 		$contents = str_replace("<html", "<html xml:lang=\"".$lang->settings['htmllang']."\" lang=\"".$lang->settings['htmllang']."\"", $contents);
 	}
 
-	if($error_handler->warnings)
+	if($error_handler->warnings && ($mybb->settings['useerrorperm'] == 1 && $mybb->usergroup['cancp'] == 1 || $mybb->settings['useerrorperm'] != 1))
 	{
 		$contents = str_replace("<body>", "<body>\n".$error_handler->show_warnings(), $contents);
 	}

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -377,10 +377,19 @@ no=Disabled]]></optionscode>
 			<isdefault>1</isdefault>
 			<helpkey></helpkey>
 		</setting>
+		<setting name="useerrorperm">
+			<title>Show error only to administrators?</title>
+			<description><![CDATA[Do you want to show errors only to users with ACP access?]]></description>
+			<disporder>13</disporder>
+			<optionscode><![CDATA[yesno]]></optionscode>
+			<settingvalue><![CDATA[0]]></settingvalue>
+			<isdefault>1</isdefault>
+			<helpkey></helpkey>
+		</setting>
 		<setting name="errorlogmedium">
 			<title>Error Logging Medium</title>
 			<description><![CDATA[The type of the error handling to use.]]></description>
-			<disporder>13</disporder>
+			<disporder>14</disporder>
 			<optionscode><![CDATA[select
 none=Neither
 log=Log errors
@@ -394,7 +403,7 @@ both=Log and email errors
 		<setting name="errortypemedium">
 			<title>Error Type Medium</title>
 			<description><![CDATA[The type of errors to show.]]></description>
-			<disporder>14</disporder>
+			<disporder>15</disporder>
 			<optionscode><![CDATA[select
 warning=Warnings
 error=Errors
@@ -408,7 +417,7 @@ none=Hide Errors and Warnings
 		<setting name="errorloglocation">
 			<title>Error Logging Location</title>
 			<description><![CDATA[The location of the log to send errors to, if specified.]]></description>
-			<disporder>15</disporder>
+			<disporder>16</disporder>
 			<optionscode><![CDATA[text]]></optionscode>
 			<settingvalue><![CDATA[./error.log]]></settingvalue>
 			<isdefault>1</isdefault>
@@ -417,7 +426,7 @@ none=Hide Errors and Warnings
 		<setting name="enableforumjump">
 			<title>Enable Forum Jump Menu?</title>
 			<description><![CDATA[The forum jump menu is shown on the forum and thread view pages. It can add significant load to your forums if you have a large amount of forums. Set to 'No' to disable it.]]></description>
-			<disporder>16</disporder>
+			<disporder>17</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
 			<isdefault>1</isdefault>
@@ -426,7 +435,7 @@ none=Hide Errors and Warnings
 		<setting name="ip_forwarded_check">
 			<title>Scrutinize User's IP address?</title>
 			<description><![CDATA[Do you want to check a user's IP address for HTTP_X_FORWARDED_FOR or HTTP_X_REAL_IP headers? If you're unsure, set this to no.]]></description>
-			<disporder>17</disporder>
+			<disporder>18</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
 			<isdefault>1</isdefault>


### PR DESCRIPTION
In my opinion, only administrators should be able to see those ugly PHP warnings. If it affects an user, this should be reported and administrators should test with the appropriate test account.

This mostly to prevent users from seeing sensitive information.
