### PR TITLE
Automatic URLs can contain unnecessary brackets

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1062,7 +1062,7 @@ class postParser
 	function mycode_auto_url($message)
 	{
 		$message = " ".$message;
-		$message = preg_replace("#([\>\s\(\)])(http|https|ftp|news){1}://([^\/\"\s\<\[\.]+\.([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/[^\"\s<\[]*)?)#i", "$1[url]$2://$3[/url]", $message);
+		$message = preg_replace("#([\>\s\(\)])(http|https|ftp|news){1}://([^\/\"\s\<\[\.]+\.([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/[^\"\s<\[()]*)?)#i", "$1[url]$2://$3[/url]", $message);
 		$message = preg_replace("#([\>\s\(\)])(www|ftp)\.(([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/[^\"\s<\[]*)?)#i", "$1[url]$2.$3[/url]", $message);
 		$message = my_substr($message, 1);
 


### PR DESCRIPTION
The automatic URLs filter doesn't prevent brackets to be included in the URLs themselves, breaking the links. This patch adds "(" and ")" chars to the "exclude" part of the pattern to correctly handle URLs in strings like the following:

```
(http://example.com/example.php?action=test)
```
