### PR TITLE
Fixes debug information, bug #2230

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -75,7 +75,7 @@ function output_page($contents)
 			}
 
 			$other = "PHP version: $phpversion / Server Load: $serverload / GZip Compression: $gzipen";
-			$debugstuff = "Generated in $totaltime seconds ($percentphp% PHP / $percentsql% MySQL)<br />SQL Queries: $db->query_count /  Global Parsing Time: $globaltime$memory_usage<br />$other<br />[<a href=\"$debuglink\" target=\"_blank\">advanced details</a>]<br />";
+			$debugstuff = "Generated in $totaltime seconds ($percentphp% PHP / $percentsql% ".$mybb->config['database']['type'].")<br />SQL Queries: $db->query_count /  Global Parsing Time: $globaltime$memory_usage<br />$other<br />[<a href=\"$debuglink\" target=\"_blank\">advanced details</a>]<br />";
 			$contents = str_replace("<debugstuff>", $debugstuff, $contents);
 		}
 


### PR DESCRIPTION
Bug #2230 shows that the string "MySQL" is hardcoded into the debug information, whereas it should show the database type used in the installation. My solution was to just concat the database type onto the string - I felt this was less expensive than "prettifying" the string (as an administrator there should be no need - it's debug information). Alternatively, it could be replaced with a generic string such as "Database".
