### PR TITLE
Adds "Display posts in classic mode" option when editing user in Admin CP

### DIFF
--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -451,6 +451,7 @@ if($mybb->input['action'] == "edit")
 			"invisible" => $mybb->input['invisible'],
 			"dstcorrection" => $mybb->input['dstcorrection'],
 			"threadmode" => $mybb->input['threadmode'],
+			"classicpostbit" => $mybb->input['classicpostbit'],
 			"showsigs" => $mybb->input['showsigs'],
 			"showavatars" => $mybb->input['showavatars'],
 			"showquickreply" => $mybb->input['showquickreply'],
@@ -1122,6 +1123,7 @@ if($mybb->input['action'] == "edit")
 	}
 
 	$thread_options = array(
+		$form->generate_check_box("classicpostbit", 1, $lang->show_classic_postbit, array("checked" => $mybb->input['classicpostbit'])),
 		$form->generate_check_box("showsigs", 1, $lang->display_users_sigs, array("checked" => $mybb->input['showsigs'])),
 		$form->generate_check_box("showavatars", 1, $lang->display_users_avatars, array("checked" => $mybb->input['showavatars'])),
 		$form->generate_check_box("showquickreply", 1, $lang->show_quick_reply, array("checked" => $mybb->input['showquickreply'])),

--- a/inc/languages/english/admin/user_users.lang.php
+++ b/inc/languages/english/admin/user_users.lang.php
@@ -197,6 +197,7 @@ $l['show_all_threads'] = "Show all threads";
 $l['threads_per_page'] = "Threads Per Page";
 $l['default_thread_age_view'] = "Default Thread Age View";
 $l['forum_display_options'] = "Forum Display Options";
+$l['show_classic_postbit'] = "Display posts in classic mode";
 $l['display_users_sigs'] = "Display users' signatures in their posts";
 $l['display_users_avatars'] = "Display users' avatars in their posts";
 $l['show_quick_reply'] = "Show the quick reply box at the bottom of the thread view";


### PR DESCRIPTION
Currently there isn't an option to edit the user option "Display posts in classic mode" when editing a user in the Admin CP, this adds that option.

From a suggestion posted [here](http://community.mybb.com/thread-144765.html).
