### PR TITLE
Template group Admin Log support

### DIFF
--- a/admin/modules/style/templates.php
+++ b/admin/modules/style/templates.php
@@ -752,11 +752,11 @@ if($mybb->input['action'] == "edit_template_group")
 					'isdefault' => 0
 				);
 
-				$gid = $db->update_query('templategroups', $update_array, "gid = '{$template_group['gid']}'");
+				$db->update_query('templategroups', $update_array, "gid = '{$template_group['gid']}'");
 
 				$plugins->run_hooks('admin_style_templates_edit_template_group_commit');
 
-				log_admin_action($gid, $title);
+				log_admin_action($template_group['gid'], $title);
 				flash_message($lang->success_template_group_saved, 'success');
 				admin_redirect("index.php?module=style-templates&amp;sid={$sid}");
 			}
@@ -1332,7 +1332,7 @@ if($mybb->input['action'] == "delete_template_group")
 	}
 	else
 	{
-		$page->output_confirm_action("index.php?module=style-templates&amp;action=delete_template_group&amp;gid={$group['gid']}&amp;sid={$sid}", $lang->confirm_template_group_delete);
+		$page->output_confirm_action("index.php?module=style-templates&amp;action=delete_template_group&amp;gid={$template_group['gid']}&amp;sid={$sid}", $lang->confirm_template_group_delete);
 	}
 }
 

--- a/inc/languages/english/admin/tools_adminlog.lang.php
+++ b/inc/languages/english/admin/tools_adminlog.lang.php
@@ -167,6 +167,9 @@ $l['admin_log_style_templates_edit_template'] = "Edited template #{1} ({2}) from
 $l['admin_log_style_templates_edit_template_global'] = "Edited template #{1} ({2}) from the global template set";
 $l['admin_log_style_templates_search_replace'] = "Searched templates for '{1}' and replaced with '{2}'";
 $l['admin_log_style_templates_revert'] = "Reverted template #{1} ({2}) in template set #{3} ({4})";
+$l['admin_log_style_templates_add_template_group'] = "Added template group #{1} ({2})";
+$l['admin_log_style_templates_edit_template_group'] = "Edited template group #{1} ({2})";
+$l['admin_log_style_templates_delete_template_group'] = "Deleted template group #{1} ({2})";
 
 $l['admin_log_style_themes_import'] = "Imported theme #{1}";
 $l['admin_log_style_themes_add'] = "Created theme #{2} ({1})";


### PR DESCRIPTION
The Admin Log language strings for adding/editing/deleting a template group are missing. This commit adds them.

This commit also fixes two minor bugs I found when you edit a template group (the gid wasn't being logged correctly) and when you delete one (the gid variable was wrong causing an error that the gid was missing).
