### PR TITLE
Adds "admin_settings_print_peekers" hook

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1527,13 +1527,7 @@ function print_setting_peekers()
 
 	$peekers = $plugins->run_hooks("admin_settings_print_peekers", $peekers);
 
-	$setting_peekers = '';
-	foreach($peekers as $peeker)
-	{
-		$setting_peekers .= $peeker."\n";
-	}
-
-	$setting_peekers = substr($setting_peekers, 0, -2);
+	$setting_peekers = implode("\n			", $peekers);
 
 	echo '<script type="text/javascript" src="./jscripts/peeker.js"></script>
 	<script type="text/javascript">


### PR DESCRIPTION
This pull request adds a hook to the setting peekers output and is a valuable change for plugin developers wishing to add their own setting peekers.
I am aware that there will be some changes to this function for the jQuery conversion, but the read code hasn't been changed at all. When this is converted to jQuery there shouldn't be a problem for the developer.
##### Example usage (with old Prototype code)

``` php
$plugins->add_hook('admin_settings_print_peekers', 'plugin_name_print_peekers');
function plugin_name_print_peekers(&$peekers)
{
    $peekers[] = 'new Peeker($("setting_example_select_box"), $("row_setting_example_potentially_hidden_text_field"), /show_hidden_field_if_select_equals_me/, false)';
}
```
##### Example usage (with new shiny jQuery code)

``` php
$plugins->add_hook('admin_settings_print_peekers', 'plugin_name_print_peekers');
function plugin_name_print_peekers(&$peekers)
{
    // To be continued... ;)
}
```
