### PR TITLE
Fixes #2281 Signature nofollow doesn't work in user profile

### DIFF
--- a/member.php
+++ b/member.php
@@ -1523,6 +1523,11 @@ if($mybb->input['action'] == "profile")
 			"filter_badwords" => 1
 		);
 
+		if($memperms['signofollow'])
+		{
+			$sig_parser['nofollow_on'] = 1;
+		}
+
 		$memprofile['signature'] = $parser->parse_message($memprofile['signature'], $sig_parser);
 		eval("\$signature = \"".$templates->get("member_profile_signature")."\";");
 	}


### PR DESCRIPTION
Fixes Signature nofollow doesn't work in user profile that I've reported [here](http://dev.mybb.com/issues/2281). For 1.8
