### PR TITLE
Allow irc protocol in auto URL

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1231,7 +1231,7 @@ class postParser
 	function mycode_auto_url($message)
 	{
 		$message = " ".$message;
-		$message = preg_replace("#([\>\s\(\)])(http|https|ftp|news|irc){1}://([^\/\"\s\<\[\.]+\.([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/[^\"\s<\[()]*)?)#i", "$1[url]$2://$3[/url]", $message);
+		$message = preg_replace("#([\>\s\(\)])(http|https|ftp|news|irc|ircs|irc6){1}://([^\/\"\s\<\[\.]+\.([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/[^\"\s<\[()]*)?)#i", "$1[url]$2://$3[/url]", $message);
 		$message = preg_replace("#([\>\s\(\)])(www|ftp)\.(([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/[^\"\s<\[]*)?)#i", "$1[url]$2.$3[/url]", $message);
 		$message = my_substr($message, 1);
 


### PR DESCRIPTION
This Pull Request parses urls like `irc://irc.frenode.net/mybb` automatically, meaning that you don't need to use the URL MyCode to link to an IRC network/channel.
