### PR TITLE
Fixed Bug #2275

### DIFF
--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -1349,8 +1349,8 @@ class PostDataHandler extends DataHandler
 				$lang->load($this->language_file, true);
 
 				$modoptions = $thread['modoptions'];
-				$modlogdata['fid'] = $this->tid;
-				$modlogdata['tid'] = $thread['tid'];
+				$modlogdata['fid'] = $thread['fid'];
+				$modlogdata['tid'] = $this->tid;
 
 				// Close the thread.
 				if($modoptions['closethread'] == 1)


### PR DESCRIPTION
Corrected mismatched forum and thread ID in moderator logs when sticking/closing thread during posting.
