### PR TITLE
Individual ACP Language Setting

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -34,11 +34,16 @@ require_once MYBB_ADMIN_DIR."inc/class_table.php";
 require_once MYBB_ADMIN_DIR."inc/functions.php";
 require_once MYBB_ROOT."inc/functions_user.php";
 
-if(!file_exists(MYBB_ROOT."inc/languages/".$mybb->settings['cplanguage']."/admin/home_dashboard.lang.php"))
+// Session class required for customizing ACP language
+require_once MYBB_ROOT.'inc/class_session.php';
+$session = new session;
+$session->init();
+
+if(!$mybb->user['language'])
 {
-	$mybb->settings['cplanguage'] = "english";
+        $mybb->user['language'] = "english";
 }
-$lang->set_language($mybb->settings['cplanguage'], "admin");
+$lang->set_language($mybb->user['language'], "admin");
 
 // Load global language phrases
 $lang->load("global");

--- a/inc/class_language.php
+++ b/inc/class_language.php
@@ -102,21 +102,15 @@ class MyLanguage
 		{
 			if(!is_dir($this->path."/".$language."/{$area}"))
 			{
-				if(!is_dir($this->path."/".$mybb->settings['cplanguage']."/{$area}"))
+				if(!is_dir($this->path."/english/{$area}"))
 				{
-					if(!is_dir($this->path."/english/{$area}"))
-					{
-						die("Your forum does not contain an Administration set. Please reupload the english language administration pack.");
-					}
-					else
-					{
-						$language = "english";
-					}
+					die("Your forum does not contain an Administration set. Please reupload the english language administration pack.");
 				}
 				else
 				{
-					$language = $mybb->settings['cplanguage'];
+					$language = "english";
 				}
+
 			}
 			$this->language = $language."/{$area}";
 			$this->fallback = $this->fallback."/{$area}";


### PR DESCRIPTION
This update will automatically translate the ACP into the language
chosen by  users from their User CP. If the selected language pack
doesn't have an /admin folder, it will fallback on English. Also, this
update removes the need for a Global ACP Language setting which should
be removed from settings.xml
