### PR TITLE
Added missing plugin hooks

### DIFF
--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -2578,6 +2578,8 @@ document.write('".str_replace("/", "\/", $field_select)."');
 		$form->end();
 
 		echo "</div>\n";
+
+		$plugins->run_hooks("admin_forum_management_start_graph");
 	}
 
 	$page->output_footer();

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -1450,6 +1450,8 @@ if($mybb->input['action'] == "edit")
 	$form_container->end();
 	echo "</div>\n";
 
+	$plugins->run_hooks("admin_user_users_edit_graph");
+
 	$buttons[] = $form->generate_submit_button($lang->save_user);
 	$form->output_submit_wrapper($buttons);
 


### PR DESCRIPTION
A while back, I added several plugin hooks including two that allow you to add tabs when editing a user and managing a forum. However I forgot to include these two hooks that are kinda necessary when adding a tab (via plugin) to the edit user and manage forum page.
