### PR TITLE
Improve collapsed style

### DIFF
--- a/global.php
+++ b/global.php
@@ -785,6 +785,7 @@ if($colcookie)
 		$collapsed[$co] = "display: show;";
 		$collapsed[$ex] = "display: none;";
 		$collapsedimg[$val] = "_collapsed";
+		$collapsedthead[$val] = " thead_collapsed";
 	}
 }
 

--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -412,11 +412,13 @@ function build_forumbits($pid=0, $depth=1)
 			{
 				$expcolimage = "collapse_collapsed.png";
 				$expdisplay = "display: none;";
+				$expthead = " thead_collapsed";
 				$expaltext = "[+]";
 			}
 			else
 			{
 				$expcolimage = "collapse.png";
+				$expthead = "";
 				$expaltext = "[-]";
 			}
 
@@ -427,12 +429,12 @@ function build_forumbits($pid=0, $depth=1)
 			eval("\$forum_list .= \"".$templates->get("forumbit_depth$depth$forumcat")."\";");
 		}
 	}
-	
+
 	if(!isset($parent_lastpost))
 	{
 		$parent_lastpost = 0;
 	}
-	
+
 	if(!isset($lightbulb))
 	{
 		$lightbulb = '';

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -1860,6 +1860,15 @@ tr td.trow_shaded:last-child {
 	border-top-right-radius: 6px;
 }
 
+.thead_collapsed {
+	-moz-border-radius-bottomleft: 6px;
+	-moz-border-radius-bottomright: 6px;
+	-webkit-border-bottom-left-radius: 6px;
+	-webkit-border-bottom-right-radius: 6px;
+	border-bottom-left-radius: 6px;
+	border-bottom-right-radius: 6px;
+}
+
 .thead_left {
     border-top-right-radius: 0;
 }
@@ -3185,10 +3194,10 @@ a.button {
 	{$gobutton}
 </form>
 </div>]]></template>
-		<template name="forumbit_depth1_cat" version="1400"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+		<template name="forumbit_depth1_cat" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 <thead>
 <tr>
-<td class="thead" colspan="5">
+<td class="thead{$expthead}" colspan="5">
 <div class="expcolimage"><img src="{$theme['imgdir']}/{$expcolimage}" id="cat_{$forum['fid']}_img" class="expander" alt="{$expaltext}" title="{$expaltext}" /></div>
 <div><strong><a href="{$forum_url}">{$forum['name']}</a></strong><br /><div class="smalltext">{$forum['description']}</div></div>
 </td>
@@ -3750,7 +3759,7 @@ a.button {
 		<template name="index_boardstats" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 <thead>
 <tr>
-<td class="thead">
+<td class="thead{$collapsedthead['boardstats']}">
 <div class="expcolimage"><img src="{$theme['imgdir']}/collapse{$collapsedimg['boardstats']}.png" id="boardstats_img" class="expander" alt="[-]" title="[-]" /></div>
 <div><strong>{$lang->boardstats}</strong></div>
 </td>
@@ -5046,10 +5055,10 @@ a.button {
 {$footer}
 </body>
 </html>]]></template>
-		<template name="misc_help_section" version="1400"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder" style="clear: both;">
+		<template name="misc_help_section" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder" style="clear: both;">
 <thead>
 <tr>
-<td class="thead"><div class="expcolimage"><img src="{$theme['imgdir']}/{$expcolimage}" id="sid_{$section['sid']}_img" class="expander" alt="[-]" title="[-]" /></div><div><strong>{$section['name']}</strong></div></td>
+<td class="thead{$expthead}"><div class="expcolimage"><img src="{$theme['imgdir']}/{$expcolimage}" id="sid_{$section['sid']}_img" class="expander" alt="[-]" title="[-]" /></div><div><strong>{$section['name']}</strong></div></td>
 </tr>
 </thead>
 <tbody style="{$expdisplay}" id="sid_{$section['sid']}_e">

--- a/jscripts/general.js
+++ b/jscripts/general.js
@@ -383,12 +383,14 @@ var expandables = {
 
 		if(expandedItem.length && collapsedItem.length)
 		{
+			// Expanding
 			if(expandedItem.is(":hidden"))
 			{
 				expandedItem.toggle("fast");
 				collapsedItem.toggle("fast");
 				this.saveCollapsed(controls);
 			}
+			// Collapsing
 			else
 			{
 				expandedItem.toggle("fast");
@@ -398,20 +400,24 @@ var expandables = {
 		}
 		else if(expandedItem.length && !collapsedItem.length)
 		{
+			// Expanding
 			if(expandedItem.is(":hidden"))
 			{
 				expandedItem.toggle("fast");
 				element.attr("src", element.attr("src").replace("collapse_collapsed.png", "collapse.png"))
 									.attr("alt", "[-]")
 									.attr("title", "[-]");
+				element.parent().parent('.thead').removeClass('thead_collapsed');
 				this.saveCollapsed(controls);
 			}
+			// Collapsing
 			else
 			{
 				expandedItem.toggle("fast");
 				element.attr("src", element.attr("src").replace("collapse.png", "collapse_collapsed.png"))
 									.attr("alt", "[+]")
 									.attr("title", "[+]");
+				element.parent().parent('.thead').addClass('thead_collapsed');
 				this.saveCollapsed(controls, 1);
 			}
 		}

--- a/misc.php
+++ b/misc.php
@@ -276,10 +276,12 @@ elseif($mybb->input['action'] == "help")
 					{
 						$expcolimage = "collapse_collapsed.png";
 						$expdisplay = "display: none;";
+						$expthead = " thead_collapsed";
 					}
 					else
 					{
 						$expcolimage = "collapse.png";
+						$expthead = "";
 					}
 				}
 				eval("\$sections .= \"".$templates->get("misc_help_section")."\";");


### PR DESCRIPTION
Currently if a user was to collapse a table with a thead, the bottom corners have no border radius, but the container does leaving it looking out of place.
![Old look](https://f.cloud.github.com/assets/2552068/2118054/596b593e-90f1-11e3-9311-c9dcdf44e474.png)
This commit adds the thead_collapsed class to the .thead (if present) when collapsed or when set as collapsed from a cookie.
![New look](https://f.cloud.github.com/assets/2552068/2118053/54f1d680-90f1-11e3-95d0-672b31483e30.png)
