### PR TITLE
Add option to force redirects

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -912,8 +912,8 @@ function redirect($url, $message="", $title="")
 		$title = $mybb->settings['bbname'];
 	}
 
-	// Show redirects only if both ACP and UCP settings are enabled, or ACP is enabled, and user is a guest.
-	if($mybb->settings['redirects'] == 1 && ($mybb->user['showredirect'] == 1 || !$mybb->user['uid']))
+	// Show redirects only if ACP is forced, or both ACP and UCP settings are enabled, or ACP is enabled, and user is a guest.
+	if($mybb->settings['redirects'] == 2 || ($mybb->settings['redirects'] == 1 && ($mybb->user['showredirect'] == 1 || !$mybb->user['uid'])))
 	{
 		$url = str_replace("&amp;", "&", $url);
 		$url = htmlspecialchars_uni($url);

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -11001,7 +11001,7 @@ document.write('<br /><span class="smalltext"><a href="#" onclick="UserCP.openBu
 <input type="submit" class="button" name="submit" value="{$lang->update_notepad}" />
 </div>
 </form>]]></template>
-		<template name="usercp_options" version="1600"><![CDATA[<html>
+		<template name="usercp_options" version="1800"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->edit_options}</title>
 {$headerinclude}
@@ -11174,10 +11174,7 @@ document.write('<br /><span class="smalltext"><a href="#" onclick="UserCP.openBu
 <fieldset class="trow2">
 <legend><strong>{$lang->other_options}</strong></legend>
 <table cellspacing="0" cellpadding="2">
-<tr>
-<td valign="top" width="1"><input type="checkbox" class="checkbox" name="showredirect" id="showredirect" value="1" {$showredirectcheck} /></td>
-<td><span class="smalltext"><label for="showredirect">{$lang->show_redirect}</label></span></td>
-</tr>
+{$showredirects}
 <tr>
 <td valign="top" width="1"><input type="checkbox" class="checkbox" name="showcodebuttons" id="showcodebuttons" value="1" {$showcodebuttonscheck} /></td>
 <td><span class="smalltext"><label for="showcodebuttons">{$lang->show_codebuttons}</label></span></td>
@@ -11237,6 +11234,11 @@ document.write('<br /><span class="smalltext"><a href="#" onclick="UserCP.openBu
 {$tppoptions}
 </select>
 </td>
+</tr>]]></template>
+		<template name="usercp_options_showredirects" version="1800"><![CDATA[
+<tr>
+<td valign="top" width="1"><input type="checkbox" class="checkbox" name="showredirect" id="showredirect" value="1" {$showredirectcheck} /></td>
+<td><span class="smalltext"><label for="showredirect">{$lang->show_redirect}</label></span></td>
 </tr>]]></template>
 		<template name="usercp_password" version="1400"><![CDATA[<html>
 <head>

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -315,7 +315,11 @@ no=Disabled]]></optionscode>
 			<title>Friendly Redirection Pages</title>
 			<description><![CDATA[This will enable friendly redirection pages instead of bumping the user directly to the page.]]></description>
 			<disporder>6</disporder>
-			<optionscode><![CDATA[onoff]]></optionscode>
+			<optionscode><![CDATA[select
+0=No
+1=Yes
+2=Force
+]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
 			<isdefault>1</isdefault>
 			<helpkey></helpkey>

--- a/install/resources/upgrade28.php
+++ b/install/resources/upgrade28.php
@@ -249,6 +249,13 @@ function upgrade28_dbchanges()
 
 	echo "<p>Added {$added_tasks} new tasks.</p>";
 
+	// Update settings
+	echo "<p>Updating settings...</p>";
+	$db->update_query('settings', array('optionscode' => $db->escape_string("select
+0=No
+1=Yes
+2=Force")), "name='redirects'");
+
 	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
 	$output->print_footer("28_dbchanges_ip");
 }

--- a/usercp.php
+++ b/usercp.php
@@ -708,7 +708,6 @@ if($mybb->input['action'] == "do_options" && $mybb->request_method == "post")
 		"daysprune" => $mybb->get_input('daysprune', 1),
 		"showcodebuttons" => $mybb->get_input('showcodebuttons', 1),
 		"pmnotify" => $mybb->get_input('pmnotify', 1),
-		"showredirect" => $mybb->get_input('showredirect', 1),
 		"classicpostbit" => $mybb->get_input('classicpostbit', 1)
 	);
 
@@ -720,6 +719,11 @@ if($mybb->input['action'] == "do_options" && $mybb->request_method == "post")
 	if($mybb->settings['userpppoptions'])
 	{
 		$user['options']['ppp'] = $mybb->get_input('ppp', 1);
+	}
+
+	if($mybb->settings['redirects'] == 1)
+	{
+		$user['options']['showredirect'] = $mybb->get_input('showredirect', 1);
 	}
 
 	$userhandler->set_data($user);
@@ -884,13 +888,19 @@ if($mybb->input['action'] == "options")
 		$showcodebuttonscheck = "";
 	}
 
-	if(isset($user['showredirect']) && $user['showredirect'] != 0)
+	// Show option for show redirects only if it will take effect
+	if($mybb->settings['redirects'] == 1)
 	{
-		$showredirectcheck = "checked=\"checked\"";
-	}
-	else
-	{
-		$showredirectcheck = "";
+		if(isset($user['showredirect']) && $user['showredirect'] != 0)
+		{
+			$showredirectcheck = "checked=\"checked\"";
+		}
+		else
+		{
+			$showredirectcheck = "";
+		}
+
+		eval("\$showredirects = \"".$templates->get("usercp_options_showredirects")."\";");
 	}
 
 	if(isset($user['pmnotify']) && $user['pmnotify'] != 0)


### PR DESCRIPTION
This new option allows administrators to force friendly redirect pages on users regardless of their setting. This also only displays the option in the User CP if it will take effect (thus avoiding confusion if behaviour is different to their setting).
