### PR TITLE
Backup Module Addition

### DIFF
--- a/admin/modules/tools/backupdb.php
+++ b/admin/modules/tools/backupdb.php
@@ -214,7 +214,15 @@ if($mybb->input['action'] == "backup")
 
 			if($mybb->input['contents'] != 'structure')
 			{
-				$query = $db->simple_select($table);
+				if($db->engine == 'mysqli')
+				{
+					$query = mysqli_query($db->read_link, "SELECT * FROM {$db->table_prefix}{$table}", MYSQLI_USE_RESULT);
+				}
+				else
+				{
+					$query = $db->simple_select($table);
+				}
+
 				while($row = $db->fetch_array($query))
 				{
 					$insert = "INSERT INTO {$table} ($fields) VALUES (";
@@ -224,6 +232,10 @@ if($mybb->input['action'] == "backup")
 						if(!isset($row[$field]) || is_null($row[$field]))
 						{
 							$insert .= $comma."NULL";
+						}
+						else if($db->engine == 'mysqli')
+						{
+							$insert .= $comma."'".mysqli_real_escape_string($db->read_link, $row[$field])."'";
 						}
 						else
 						{
@@ -235,6 +247,7 @@ if($mybb->input['action'] == "backup")
 					$contents .= $insert;
 					clear_overflow($fp, $contents);
 				}
+				$db->free_result($query);
 			}
 		}
 


### PR DESCRIPTION
Background info in this thread: http://community.mybb.com/thread-128397-post-997156.html#pid997156

With the backup task, there is a high risk of it timing out and leaving you with an incomplete backup. Currently there is no feedback given whatsoever, you don't know whether a backup file is complete or not until you open it and check.

For this reason I propose a new naming scheme for backup files; they start out as *.incomplete.sql.gz and are only renamed to *.sql.gz on completion of the task. I also added the creation date to the filename so it's easy to locate the latest backup even if the file timestamps were lost in FTP transmission.

I also optimized the backup task for mysqli databases (which is what most if not all MyBB forums are currently using). It uses a less memory expensive query method, explicitely frees queries, and circumvents $db->escape_string() which is too expensive for the million calls or so made to it during the backup (esp. since the recent UTF-8 validation changes).

I also suggest (but did not include here) a lowering of the gzip level ('w9' to 'wb4' or 'wb5'). For my 180M (uncompressed) SQL backup, gzip level 9 only saves just one extra MB compared to gzip level 5 (44.6M instead of 43.7M) while taking nearly twice the CPU time (4.2s instead of 7.8s). There just isn't much point in the higher gzip levels. This isn't the main culprit for backup tasks timing out on shared hosting, but every little bit helps...
