### PR TITLE
Fix #379 User(s) browsing this thread incorrect when linking to post

### DIFF
--- a/inc/class_session.php
+++ b/inc/class_session.php
@@ -548,7 +548,7 @@ class session
 				$array[2] = $post['tid'];
 			}
 
-			$thread = get_thread(intval($array[2]));
+			$thread = get_thread($array[2]);
 			$array[1] = $thread['fid'];
 		}
 		return $array;


### PR DESCRIPTION
There are a few changes here, but the main one is setting `$array[2]` to `$post['tid']`. I've also removed some pid logic as we don't seem to need it.
