### PR TITLE
Fix #377 Installer suggests incorrect cookie domain

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1825,7 +1825,7 @@ function configure()
 		}
 
 		// IP addresses and hostnames are not valid
-		if($cookiedomain == '.localhost' || my_inet_pton($cookiedomain) !== false || strpos($cookiedomain, '.') === false)
+		if($cookiedomain == '.localhost' || my_inet_pton($cookiedomain) === false || strpos($cookiedomain, '.') !== false)
 		{
 			$cookiedomain = '';
 		}


### PR DESCRIPTION
The logic for this was backwards. If `my_inet_pton($cookiedomain)` returns false, or `strpos($cookiedomain, '.')` returns anything but true, we have an invalid cookie domain.
