### PR TITLE
Add support for ISO 8601.

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -284,7 +284,9 @@ $date_formats = array(
 	9 => "F jS, Y",
 	10 => "l, F jS, Y",
 	11 => "jS F, Y",
-	12 => "l, jS F, Y"
+	12 => "l, jS F, Y",
+	// ISO 8601
+	13 => "Y-d-m"
 );
 
 // An array of valid time formats (Used for user selections etc)


### PR DESCRIPTION
![This should be an xkcd image, but because of GitHub issues, it's not.](http://imgs.xkcd.com/comics/iso_8601.png)

This commit introduces ISO 8601 date format, as an alternative to other date formats.
