### PR TITLE
Fixes #148 ajax delete post in MyBB 1.8

### DIFF
--- a/editpost.php
+++ b/editpost.php
@@ -274,7 +274,7 @@ if($mybb->input['action'] == "deletepost" && $mybb->request_method == "post")
 				if($mybb->input['ajax'] == 1)
 				{
 					header("Content-type: application/json; charset={$lang->settings['charset']}");
-					if($mybb->settings['soft_delete'] == 1)
+					if($mybb->settings['soft_delete'] == 1 && is_moderator($fid))
 					{
 						echo json_encode(array("data" => '1'));
 					}
@@ -325,7 +325,7 @@ if($mybb->input['action'] == "deletepost" && $mybb->request_method == "post")
 				if($mybb->input['ajax'] == 1)
 				{
 					header("Content-type: application/json; charset={$lang->settings['charset']}");
-					if($mybb->settings['soft_delete'] == 1)
+					if($mybb->settings['soft_delete'] == 1 && is_moderator($fid))
 					{
 						echo json_encode(array("data" => '1'));
 					}


### PR DESCRIPTION
before this pull:
before delete:
![1](https://cloud.githubusercontent.com/assets/3256261/2741584/fd57a240-c6ee-11e3-82e7-a401f09865c9.gif)
after ajax delete: ( a non-moderator user )
![2](https://cloud.githubusercontent.com/assets/3256261/2741586/0ca66b0a-c6ef-11e3-98da-8d49e0502c5a.gif)
after refresh the page:
![3](https://cloud.githubusercontent.com/assets/3256261/2741587/135b489e-c6ef-11e3-96e9-cd646d5821e2.gif)
after this pull:
before delete:
![1](https://cloud.githubusercontent.com/assets/3256261/2741588/1a201178-c6ef-11e3-93d7-64aa8e7a2d8a.gif)
after ajax delete: ( a non-moderator user )
![3](https://cloud.githubusercontent.com/assets/3256261/2741590/23d856c6-c6ef-11e3-9c95-21469970616c.gif)
