### PR TITLE
Fixes #421 Moderators can't add announcements in modcp

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1466,9 +1466,9 @@ function get_moderator_permissions($fid, $uid="0", $parentslist="")
 
 	$mod_cache = $cache->read("moderators");
 
-	foreach($mod_cache as $fid => $forum)
+	foreach($mod_cache as $forumid => $forum)
 	{
-		if(!is_array($forum) || !in_array($fid, $parentslist))
+		if(!is_array($forum) || !in_array($forumid, $parentslist))
 		{
 			// No perms or we're not after this forum
 			continue;


### PR DESCRIPTION
$fid was used for two different things...
