### PR TITLE
Fixes #520 - Peekers Not Working When Editing Custom Profile Fields In ACP

### DIFF
--- a/admin/modules/config/profile_fields.php
+++ b/admin/modules/config/profile_fields.php
@@ -274,9 +274,9 @@ if($mybb->input['action'] == "edit")
 	echo '<script type="text/javascript" src="./jscripts/peeker.js"></script>
 	<script type="text/javascript">
 		Event.observe(window, "load", function() {
-				var maxlength_peeker = new Peeker("fieldtype", "row_maxlength", /text|textarea/);
-				var fieldlength_peeker = new Peeker("fieldtype", "row_fieldlength", /select|multiselect/);
-				var options_peeker = new Peeker("fieldtype", "row_options", /select|radio|checkbox/);
+				var maxlength_peeker = new Peeker($("fieldtype"), $("row_maxlength"), /text|textarea/);
+				var fieldlength_peeker = new Peeker($("fieldtype"), $("row_fieldlength"), /select|multiselect/);
+				var options_peeker = new Peeker($("fieldtype"), $("row_options"), /select|radio|checkbox/);
 				// Add a star to the extra row since the "extra" is required if the box is shown
 				add_star("row_maxlength");
 				add_star("row_fieldlength");


### PR DESCRIPTION
Peekers Not Working When Editing Custom Profile Fields In ACP
