### PR TITLE
Fixes #626 SCEditor textarea expander bug

### DIFF
--- a/jscripts/general.js
+++ b/jscripts/general.js
@@ -72,7 +72,10 @@ var MyBB = {
 
 	popupWindow: function(url, options, root)
 	{
-		if(!options) options = { fadeDuration: 250 }
+		if(!options) options = {
+			fadeDuration: 250,
+			zIndex: 5
+		}
 		if(root != true)
 			url = rootpath + url;
 		

--- a/jscripts/sceditor/editor_themes/buttons.css
+++ b/jscripts/sceditor/editor_themes/buttons.css
@@ -293,7 +293,7 @@ div.sceditor-grip:before {
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 .sceditor-container {
-  /*position: relative;*/
+  position: relative;
   background: #fff;
   border: 1px solid #d9d9d9;
   font-size: 13px;

--- a/jscripts/sceditor/editor_themes/default.css
+++ b/jscripts/sceditor/editor_themes/default.css
@@ -155,7 +155,7 @@ div.sceditor-grip {
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 .sceditor-container {
-  /*position: relative;*/
+  position: relative;
   background: #fff;
   border: 1px solid #d9d9d9;
   font-size: 13px;

--- a/jscripts/sceditor/editor_themes/modern.css
+++ b/jscripts/sceditor/editor_themes/modern.css
@@ -166,7 +166,7 @@ div.sceditor-grip {
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 .sceditor-container {
-  /*position: relative;*/
+  position: relative;
   background: #fff;
   border: 1px solid #d9d9d9;
   font-size: 13px;

--- a/jscripts/sceditor/editor_themes/monocons.css
+++ b/jscripts/sceditor/editor_themes/monocons.css
@@ -282,7 +282,7 @@ div.sceditor-grip:before {
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 .sceditor-container {
-  /*position: relative;*/
+  position: relative;
   background: #fff;
   border: 1px solid #d9d9d9;
   font-size: 13px;

--- a/jscripts/sceditor/editor_themes/mybb.css
+++ b/jscripts/sceditor/editor_themes/mybb.css
@@ -218,7 +218,7 @@ div.sceditor-grip  {
     
 }
 .sceditor-container {
-    /*position: relative;*/
+    position: relative;
     background: #fff;
     border: 1px solid #d9d9d9;
     padding: 0 4px;

--- a/jscripts/sceditor/editor_themes/office-toolbar.css
+++ b/jscripts/sceditor/editor_themes/office-toolbar.css
@@ -164,7 +164,7 @@ div.sceditor-grip {
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 .sceditor-container {
-  /*position: relative;*/
+  position: relative;
   background: #fff;
   border: 1px solid #d9d9d9;
   font-size: 13px;

--- a/jscripts/sceditor/editor_themes/office.css
+++ b/jscripts/sceditor/editor_themes/office.css
@@ -173,7 +173,7 @@ div.sceditor-grip {
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 .sceditor-container {
-  /*position: relative;*/
+  position: relative;
   background: #fff;
   border: 1px solid #d9d9d9;
   font-size: 13px;

--- a/jscripts/sceditor/editor_themes/square.css
+++ b/jscripts/sceditor/editor_themes/square.css
@@ -169,7 +169,7 @@ div.sceditor-grip {
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 .sceditor-container {
-  /*position: relative;*/
+  position: relative;
   background: #fff;
   border: 1px solid #d9d9d9;
   font-size: 13px;


### PR DESCRIPTION
less intrusive method to fix #626 compared to solution of #671.
the #671 solution modifies the modal plugin, this not. Ie, will not cause problems when upgrading to the new version modal plugin.
So i will close #671.

Problem occurred (conflict with modal and sceditor) because sceditor use zindex 3 and modal use zindex 2.
I increase value of zindex of modal.
And removed comment in position: relative; to solve problem with editor expander bug.
