### PR TITLE
Fix: #736 Merging two users removes both from the board stats

### DIFF
--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -2023,8 +2023,6 @@ if($mybb->input['action'] == "merge")
 				$db->update_query("users", array('regdate' => $source_user['regdate']), "uid='{$destination_user['uid']}'");
 			}
 
-			update_stats(array('numusers' => '-1'));
-
 			$plugins->run_hooks("admin_user_users_merge_commit");
 
 			// Log admin action


### PR DESCRIPTION
Fix #736

Before this https://github.com/mybb/mybb/commit/13c4d442acb1e4ca3b38c12caf6aaa3e6d2cca35
used code below to deletion of user in merge user

```
// Delete the old user
$db->delete_query("users", "uid='{$source_user['uid']}'");
$db->delete_query("banned", "uid='{$source_user['uid']}'");
```

https://github.com/mybb/mybb/blob/130f284199ba24db58844939b6bfeee1208ac5cb/admin/modules/user/users.php#L1992
but now to deletion of user in merge user using code below (now is function)

```
// Delete the old user
$userhandler->delete_user($source_user['uid']);
```

https://github.com/mybb/mybb/blob/feature/admin/modules/user/users.php#L1995
if you see function "$userhandler->delete_user"
already has "update_stats(array('numusers' => '-'.(int)$this->deleted_users));" so no need duplicate "update_stats" that causing removal of one user more in stats.
