### PR TITLE
Fixes #870 Not any last poster name in forumdisplay after splitting a/some post(s) (master)

### DIFF
--- a/inc/class_moderation.php
+++ b/inc/class_moderation.php
@@ -1266,6 +1266,7 @@ class Moderation
 		// Get the icon for the first split post
 		$query = $db->simple_select("posts", "icon, visible", "pid=".intval($pids[0]));
 		$post_info = $db->fetch_array($query);
+		$last_post_info = get_post(end($pids));
 
 		$icon = $post_info['icon'];
 		$visible = $post_info['visible'];
@@ -1283,8 +1284,9 @@ class Moderation
 				"uid" => intval($thread['uid']),
 				"username" => $db->escape_string($thread['username']),
 				"dateline" => intval($thread['dateline']),
-				"lastpost" => intval($thread['lastpost']),
-				"lastposter" => $db->escape_string($thread['lastposter']),
+				"lastpost" => (int)$last_post_info['dateline'],
+				"lastposter" => $db->escape_string($last_post_info['username']),
+				"lastposteruid" => (int)$last_post_info['uid'],
 				"replies" => count($pids)-1,
 				"visible" => intval($visible),
 				"notes" => ''


### PR DESCRIPTION
Fixes #870 Not any last poster name in forumdisplay after splitting
a/some post(s)
Master branch (1.6)
