### PR TITLE
fix: error message showthread.php?pid=x for deleted posts, refs #947

### DIFF
--- a/showthread.php
+++ b/showthread.php
@@ -45,6 +45,13 @@ if(!empty($mybb->input['pid']) && !isset($mybb->input['tid']))
 		);
 		$query = $db->simple_select("posts", "tid", "pid=".$mybb->get_input('pid', 1), $options);
 		$post = $db->fetch_array($query);
+		
+		if(empty($post))
+		{
+			// post does not exist --> show corresponding error
+			error($lang->error_invalidpost);
+		}
+		
 		$mybb->input['tid'] = $post['tid'];
 	}
 }


### PR DESCRIPTION
fix: error message showthread.php?pid=x for deleted posts, refs #947
- showthread.php
  - added check if post with set pid exists before a thread with tid null is searched in the db
