### PR TITLE
functions.php - hardcoded HTML (1.8 - beta 3)

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3056,8 +3056,8 @@ function build_clickable_smilies()
 				{
 					if($counter == 0)
 					{
-						$smilies .=  "<tr>\n";
-					}
+				          	$smilies .= $templates->get("smilieinsert_wrapper_start");
+				 	}
 
 					$find = htmlspecialchars_uni($find);
 
@@ -3070,7 +3070,7 @@ function build_clickable_smilies()
 					if($counter == $mybb->settings['smilieinsertercols'])
 					{
 						$counter = 0;
-						$smilies .= "</tr>\n";
+				        	 $smilies .= $templates->get("smilieinsert_wrapper_end");
 					}
 				}
 			}
@@ -3078,7 +3078,7 @@ function build_clickable_smilies()
 			if($counter != 0)
 			{
 				$colspan = $mybb->settings['smilieinsertercols'] - $counter;
-				$smilies .= "<td colspan=\"{$colspan}\">&nbsp;</td>\n</tr>\n";
+				 $smilies .= $templates->get("smilieinsert_empty");
 			}
 
 			eval("\$clickablesmilies = \"".$templates->get("smilieinsert")."\";");


### PR DESCRIPTION
After revamping new thread template i have noticed that w3 validator is returning error reports on few areas. I have double checked my templates i have noticed that smilieinsert_smilie has a tr tag wrapped around it (for 3 smilies in each row), since all hardcoded HTML was pushed into templates i started to digg around and found out that that area still has some hardcoded HTML. (mybb 1.8 - beta 3) http://community.mybb.com/thread-156762-post-1089240.html#pid1089240
