### PR TITLE
Fixes #310 Smilies shouldn't have same display order value

### DIFF
--- a/admin/modules/config/smilies.php
+++ b/admin/modules/config/smilies.php
@@ -184,7 +184,7 @@ if($mybb->input['action'] == "edit")
 		}
 		else
 		{
-			$query = $db->simple_select("smilies", "sid", "disporder= '".$mybb->input['disporder']."' AND sid != '".(int)$mybb->input['sid']."'");
+			$query = $db->simple_select("smilies", "sid", "disporder= '".$mybb->input['disporder']."' AND sid != '".$mybb->input['sid']."'");
 			$duplicate_disporder = (int)$db->fetch_field($query, 'sid');
 
 			if($duplicate_disporder)


### PR DESCRIPTION
#310, Fixed issue where you couldn't edit a smilie due to the display order.
