### PR TITLE
Fix #1108

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1507,15 +1507,6 @@ function create_tables()
 \$config['hide_admin_links'] = 0;
 
 /**
- * Admin CP Secret PIN
- *  If you wish to request a PIN
- *  when someone tries to login
- *  on your Admin CP, enter it below.
- */
-
-\$config['secret_pin'] = '';
-
-/**
  * Data-cache configuration
  *  The data cache is a temporary cache
  *  of the most commonly accessed data in MyBB.
@@ -1577,7 +1568,7 @@ function create_tables()
 	'promotion_logs' => 180 // Promotion logs
 );
 
-?>";
+";
 
 	$file = fopen(MYBB_ROOT.'inc/config.php', 'w');
 	fwrite($file, $configdata);
@@ -2018,6 +2009,22 @@ EOF;
 		write_settings();
 
 		echo $lang->sprintf($lang->admin_step_insertesettings, $settingcount, $groupcount);
+
+		// Save the acp pin
+		$pin = addslashes($mybb->get_input('pin'));
+
+		$file = @fopen(MYBB_ROOT."inc/config.php", "a");
+
+		@fwrite($file, "/**
+ * Admin CP Secret PIN
+ *  If you wish to request a PIN
+ *  when someone tries to login
+ *  on your Admin CP, enter it below.
+ */
+
+\$config['secret_pin'] = '{$pin}';");
+
+		@fclose($file);
 
 		include_once MYBB_ROOT."inc/functions_task.php";
 		$tasks = file_get_contents(INSTALL_ROOT.'resources/tasks.xml');

--- a/install/resources/language.lang.php
+++ b/install/resources/language.lang.php
@@ -255,6 +255,13 @@ $l['config_step_table'] = '<p>It is now time for you to configure the basic sett
 					<td class="first"><label for="contactemail">Contact Email:</label></td>
 					<td class="last alt_col"><input type="text" class="text_input" name="contactemail" id="contactemail" value="{7}" /></td>
 				</tr>
+				<tr>
+					<th colspan="2" class="first last">Security Settings</th>
+				</tr>
+				<tr class="last">
+					<td class="first"><label for="acppin">ACP PIN:</label><br />Leave this empty if you don\'t want to set one</td>
+					<td class="last alt_col"><input type="password" class="text_input" name="pin" id="acppin" value="" /></td>
+				</tr>
 				</tbody>
 			</table>
 		</div>

--- a/install/resources/upgrade30.php
+++ b/install/resources/upgrade30.php
@@ -2423,6 +2423,8 @@ function upgrade30_acppin_submit()
 	}
 	else
 	{
+		$pin = addslashes($mybb->get_input('pin'));
+
 		$file = @fopen(MYBB_ROOT."inc/config.php", "r+");
 
 		// Set the pointer before the closing php tag to remove it
@@ -2435,7 +2437,7 @@ function upgrade30_acppin_submit()
  *  on your Admin CP, enter it below.
  */
 
-\$config['secret_pin'] = '{$mybb->input['pin']}';");
+\$config['secret_pin'] = '{$pin}';");
 
 		@fclose($file);
 


### PR DESCRIPTION
#1108

This removes the closing php tag from `config.php` and adds a new page to the upgrader where you can enter an acp pin.
The board configuration page in the installer got a new field where you also can enter the acp pin.

Note: if there's already a `security_pin` in the config array or `config.php` is not writable it will skip this step.
