### PR TITLE
extend options in generate_text_area

### DIFF
--- a/admin/inc/class_form.php
+++ b/admin/inc/class_form.php
@@ -213,6 +213,10 @@ class DefaultForm
 		{
 			$textarea .= " disabled=\"disabled\"";
 		}
+		if(isset($options['readonly']))
+		{
+			$textarea .= " readonly=\"readonly\"";
+		}
 		if(isset($options['maxlength']))
 		{
 			$textarea .= " maxlength=\"{$options['maxlength']}\"";


### PR DESCRIPTION
Sometime user need to copy something from textarea,
(eg. language files editor - when editing with other language file, some variables may contain complex links which are hard to retype. Its more easy to simply copy paste it, however its impossible with disabled option, Therefore - optional readonly option would be usefull here)

_Tested it with my other pullrequest ( Improvement of language packs editor #1130 ) and works well,
however since 'readonly' option ( extend options in generate_text_area #1131 ) is a proposition and not merged yet, its also not included yet in language pack editor pull request. (theres still 'disable' used instead of 'readonly' which is very uncomfortable. Thats where from this idea came.)_
