### PR TITLE
Fix 1175

### DIFF
--- a/install/resources/upgrade30.php
+++ b/install/resources/upgrade30.php
@@ -1669,10 +1669,6 @@ function upgrade30_dbchanges_smilies()
 	{
 		$db->modify_column("smilies", "find", "text", "set");
 	}
-	else if($db->type == 'sqlite')
-	{
-		$db->modify_column("smilies", "find", "TEXT NOT NULL");
-	}
 	else
 	{
 		$db->modify_column("smilies", "find", "text NOT NULL");


### PR DESCRIPTION
#1175

It doesn't matter whether SQLite columns have `text` or `TEXT` as type so I've removed that part and added the PgSQL part.
