### PR TITLE
Fixes #1215 Add readonly option to generate_text_area()

### DIFF
--- a/admin/inc/class_form.php
+++ b/admin/inc/class_form.php
@@ -209,9 +209,13 @@ class DefaultForm
 		{
 			$textarea .= " style=\"{$options['style']}\"";
 		}
-		if(isset($options['disabled']))
+		if(isset($options['disabled']) && $options['disabled'] !== false)
 		{
 			$textarea .= " disabled=\"disabled\"";
+		}
+		if(isset($options['readonly']) && $options['readonly'] !== false)
+		{
+			$textarea .= " readonly=\"readonly\"";
 		}
 		if(isset($options['maxlength']))
 		{


### PR DESCRIPTION
In some cases 'disabled' option in textarea is not sufficient because it blocks copying from this field.
