### PR TITLE
Fixes #1268 - Smilies are displayed as codes

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3076,7 +3076,7 @@ function build_clickable_smilies()
 					
 					$find = htmlspecialchars_uni($smilie['find']);
 
-					$onclick = ' onclick="console.log(MyBBEditor); MyBBEditor.insertText(\' '.$smilie['find'].' \');"';
+					$onclick = ' onclick="MyBBEditor.insertText(\' '.$smilie['find'].' \');"';
 					eval('$smilie = "'.$templates->get('smilie', 1, 0).'";');
 					eval("\$smilies .= \"".$templates->get("smilieinsert_smilie")."\";");
 					++$i;


### PR DESCRIPTION
Smilies are displayed as codes in WYSIWYG Editor Mode

Fixes #1268 - thx to @Mohammad-Za
