### PR TITLE
fix: Warning time error (#1283)

### DIFF
--- a/inc/datahandlers/warnings.php
+++ b/inc/datahandlers/warnings.php
@@ -212,36 +212,32 @@ class WarningsHandler extends DataHandler
 
 			$warning['points'] = round($warning['custom_points']);
 
-			// Build expiry date
-			if($warning['expires'])
+			// Build expiry date				
+			if($warning['expires_period'] == "hours")
 			{
-				if($warning['expires_period'] == "hours")
-				{
-					$warning['expires'] = $warning['expires']*3600;
-				}
-				else if($warning['expires_period'] == "days")
-				{
-					$warning['expires'] = $warning['expires']*86400;
-				}
-				else if($warning['expires_period'] == "weeks")
-				{
-					$warning['expires'] = $warning['expires']*604800;
-				}
-				else if($warning['expires_period'] == "months")
-				{
-					$warning['expires'] = $warning['expires']*2592000;
-				}
-
-				// Add on current time and we're there!
-				if($warning['expires_period'] != "never" && $warning['expires'])
-				{
-					$warning['expires'] += TIME_NOW;
-				}
+				$warning['expires'] = $warning['expires']*3600 + TIME_NOW;
 			}
-
-			if($warning['expires'] <= TIME_NOW)
+			else if($warning['expires_period'] == "days")
+			{
+				$warning['expires'] = $warning['expires']*86400 + TIME_NOW;
+			}
+			else if($warning['expires_period'] == "weeks")
+			{
+				$warning['expires'] = $warning['expires']*604800 + TIME_NOW;
+			}
+			else if($warning['expires_period'] == "months")
+			{
+				$warning['expires'] = $warning['expires']*2592000 + TIME_NOW;
+			}
+			else if($warning['expires_period'] == "never")
 			{
 				$warning['expires'] = 0;
+			}
+			else
+			{
+				// unkown expires_period
+				$this->set_error('error_invalid_expires_period');
+				return false;
 			}
 		}
 		// Using a predefined warning type

--- a/inc/languages/english/datahandler_warnings.lang.php
+++ b/inc/languages/english/datahandler_warnings.lang.php
@@ -15,3 +15,4 @@ $l['warnings_error_invalid_type'] = "You have selected an invalid warning type."
 $l['warnings_error_cant_custom_warn'] = "You do not have permission to give custom warnings to users.";
 $l['warnings_error_no_custom_reason'] = "You did not enter a reason for your custom warning.";
 $l['warnings_error_invalid_custom_points'] = "You did not enter a valid number of points to add to this users warning level. You need to enter a numeric value greater than 0 but not greater than {1}.";
+$l['warnings_error_invalid_expires_period'] = "You entered an invalid expiry type.";

--- a/warnings.php
+++ b/warnings.php
@@ -77,7 +77,7 @@ if($mybb->input['action'] == "do_warn" && $mybb->request_method == "post")
 		'custom_reason' => $mybb->get_input('custom_reason'),
 		'custom_points' => $mybb->get_input('custom_points', 1),
 		'expires' => $mybb->get_input('expires', 1),
-		'expires_period' => $mybb->get_input('expires_period', 1)
+		'expires_period' => $mybb->get_input('expires_period')
 	);
 
 	// Is this warning being given for a post?


### PR DESCRIPTION
fix: Warning time error, refs #1283
- warnings.php
  - expires_period was accessed as numeric value, but is a string
- inc/datahandlers/warnings.php
  - improved handling of expiry for custom warning reasons
- inc/languages/english/datahandler_warnings.lang.php
  - added error message for invalid expires_period
