### PR TITLE
thread.js event stopPropagation to preventDefault

### DIFF
--- a/jscripts/thread.js
+++ b/jscripts/thread.js
@@ -264,7 +264,7 @@ var Thread = {
 		{
 			$(this).bind("click", function(e)
 			{
-				e.stopPropagation();
+				e.preventDefault();
 
 				// Take pid out of the id attribute
 				id = $(this).attr('id');


### PR DESCRIPTION
I am trying to bind an event to this selector but it won't fire as e.stopPropagation(); has been used, so the events won't bubble up; as far as I can see, changing it to e.preventDefault(); will not have any adverse affects, but will allow other events to fire.

In fact, I'm not sure we even need this line at all, as the href tag is already is already "javascript:;" which should mean the link won't go anywhere. 
