### PR TITLE
Fixes #1309 gitignore ect (feature)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ inc/config.php
 inc/config.default.php
 inc/settings.php
 
+# MyBB Admin Backups
+admin/backups/*
+!admin/backups/index.html
+
 # Cache Directory
 cache/*
 
@@ -13,6 +17,13 @@ uploads/*
 install/lock
 error.log
 .htaccess
+.htgroup
+.htpasswd
+
+# Eclipse IDE files
+.settings
+.project
+.buildpath
 
 # Generic OS stuff
 .DS_Store


### PR DESCRIPTION
Adds to .gitignore admin/backups folder (excluding index.html), some
files like .htpasswd and Eclipse IDE project files. #1309
