### PR TITLE
Fixes #1340 ACP login form language

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -444,6 +444,14 @@ $page->style = $cp_style;
 // Do not have a valid Admin user, throw back to login page.
 if(!isset($mybb->user['uid']) || $logged_out == true)
 {
+	// Try to assume user language for login form before he is loged in.
+	if(!empty($mybb->cookies['mybb']['frontendlang']) && file_exists(MYBB_ROOT."inc/languages/".basename($mybb->cookies['mybb']['frontendlang'])."/admin/global.lang.php"))
+	{
+		$cp_language = basename($mybb->cookies['mybb']['frontendlang']);
+		$lang->set_language($cp_language, "admin");
+		$lang->load("global");
+	}
+	
 	if($logged_out == true)
 	{
 		$page->show_login($lang->success_logged_out);

--- a/global.php
+++ b/global.php
@@ -90,6 +90,9 @@ else if(!isset($mybb->settings['bblanguage']))
 	$mybb->settings['bblanguage'] = 'english';
 }
 
+// Remember last used FrontEnd language for ACP LoginForm
+my_setcookie("mybb[frontendlang]", $mybb->settings['bblanguage']);
+
 // Load language
 $lang->set_language($mybb->settings['bblanguage']);
 $lang->load('global');


### PR DESCRIPTION
Its impossible to know what is user preferred language for ACP LoginForm before he actualy login there.
however we may assume that he expect to see the same language as he used in frontend.
Therefore we remember language that was used on front end in `mybb[frontendlang]` and then ACP LoginForm can optionally use it to assume language that should be used.
#1340
