### PR TITLE
Fixes #1356 Delete post dialog has too big button padding

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -1643,7 +1643,7 @@ div.jqi .jqibuttons {
 
 div.jqi .jqibuttons button {
 	margin: 0;
-	padding: 15px 20px;
+	padding: 6px 20px;
 	background-color: transparent;
 	font-weight: normal;
 	border: none;


### PR DESCRIPTION
Delete post dialog has too big button padding.
Changed to 6px
#1356
