### PR TITLE
Fixes #1374 Class methods called by hooks cannot accept arguments by reference

### DIFF
--- a/inc/class_plugins.php
+++ b/inc/class_plugins.php
@@ -130,7 +130,7 @@ class pluginSystem
 
 					if(array_key_exists('class_method', $hook))
 					{
-						$return_args = call_user_func($hook['class_method'], $arguments);
+						$return_args = call_user_func_array($hook['class_method'], array(&$arguments));
 					}
 					else
 					{


### PR DESCRIPTION
Fixes #1374 Class methods called by hooks cannot accept arguments by reference
