### PR TITLE
Fixes #1415 Stats Collection

### DIFF
--- a/inc/functions_serverstats.php
+++ b/inc/functions_serverstats.php
@@ -255,11 +255,11 @@ function build_server_stats($is_install=1, $prev_version='', $current_version=''
 
 	if(function_exists('sha1'))
 	{
-		$info['id'] = sha1($id);
+		$info['clientid'] = sha1($id);
 	}
 	else
 	{
-		$info['id'] = md5($id);
+		$info['clientid'] = md5($id);
 	}
 
 	$string = "";
@@ -270,7 +270,7 @@ function build_server_stats($is_install=1, $prev_version='', $current_version=''
 		$amp = "&amp;";
 	}
 
-	$server_stats_url = 'http://community.mybb.com/stats.php?'.$string;
+	$server_stats_url = 'http://community.mybb.com/server_stats.php?'.$string;
 
 	$return = array();
 	$return['info_sent_success'] = false;


### PR DESCRIPTION
id was changed to clientid because now server_stats.php (located on the community forums) runs from MyBB and id is typecasted to integer by default and the 'id' field here is not an integer. So we're using clientid now.
