### PR TITLE
Fix ISO 8601.

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -287,7 +287,7 @@ $date_formats = array(
 	11 => "jS F, Y",
 	12 => "l, jS F, Y",
 	// ISO 8601
-	13 => "Y-d-m"
+	13 => "Y-m-d"
 );
 
 // An array of valid time formats (Used for user selections etc)


### PR DESCRIPTION
While pushing ISO 8601 change, I did a mistake, swapping d and m. This is a bugfix (the format I pushed doesn't make any sense), so it should be applied in my opinion in MyBB 1.8.1.
