### PR TITLE
Fix #1592 and #1555

### DIFF
--- a/admin/inc/class_form.php
+++ b/admin/inc/class_form.php
@@ -894,7 +894,7 @@ class DefaultFormContainer
 	/**
 	 * Initialise the new form container.
 	 *
-	 * @param string The title of the forum container
+	 * @param string The title of the form container
 	 * @param string An additional class to apply if we have one.
 	 */
 	function __construct($title='', $extra_class='')
@@ -1051,4 +1051,3 @@ class DefaultFormContainer
 		}
 	}
 }
-

--- a/admin/inc/class_page.php
+++ b/admin/inc/class_page.php
@@ -97,7 +97,7 @@ class DefaultPage
 		echo "	<title>".$title."</title>\n";
 		echo "	<meta name=\"author\" content=\"MyBB Group\" />\n";
 		echo "	<meta name=\"copyright\" content=\"Copyright ".COPY_YEAR." MyBB Group.\" />\n";
-		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/main.css?ver=1802\" type=\"text/css\" />\n";
+		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/main.css?ver=1803\" type=\"text/css\" />\n";
 		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/modal.css\" type=\"text/css\" />\n";
 
 		// Load stylesheet for this module if it has one

--- a/admin/inc/class_page.php
+++ b/admin/inc/class_page.php
@@ -97,7 +97,7 @@ class DefaultPage
 		echo "	<title>".$title."</title>\n";
 		echo "	<meta name=\"author\" content=\"MyBB Group\" />\n";
 		echo "	<meta name=\"copyright\" content=\"Copyright ".COPY_YEAR." MyBB Group.\" />\n";
-		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/main.css\" type=\"text/css\" />\n";
+		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/main.css?ver=1802\" type=\"text/css\" />\n";
 		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/modal.css\" type=\"text/css\" />\n";
 
 		// Load stylesheet for this module if it has one

--- a/admin/inc/class_page.php
+++ b/admin/inc/class_page.php
@@ -97,7 +97,7 @@ class DefaultPage
 		echo "	<title>".$title."</title>\n";
 		echo "	<meta name=\"author\" content=\"MyBB Group\" />\n";
 		echo "	<meta name=\"copyright\" content=\"Copyright ".COPY_YEAR." MyBB Group.\" />\n";
-		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/main.css?ver=1803\" type=\"text/css\" />\n";
+		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/main.css?ver=1804\" type=\"text/css\" />\n";
 		echo "	<link rel=\"stylesheet\" href=\"styles/".$this->style."/modal.css\" type=\"text/css\" />\n";
 
 		// Load stylesheet for this module if it has one

--- a/admin/jscripts/codemirror/theme/mybb.css
+++ b/admin/jscripts/codemirror/theme/mybb.css
@@ -1,6 +1,6 @@
 .cm-s-mybb { font:13px/1.4em Trebuchet, Verdana, sans-serif; }	/* - customized editor font - */
 
-.cm-s-mybb.CodeMirror { background: #fafafa; color: black; height: 500px; }
+.cm-s-mybb.CodeMirror { background: #fafafa; color: black; height: 500px; width: 100%; max-width: 100%; }
 .cm-s-mybb div.CodeMirror-selected { background: #b3c6d3 !important; }
 .cm-s-mybb .CodeMirror-gutters { background: #1F4661; border-right: 7px solid #3E7087; }
 .cm-s-mybb .CodeMirror-linenumber { color: white; }

--- a/admin/modules/style/templates.php
+++ b/admin/modules/style/templates.php
@@ -255,7 +255,7 @@ if($mybb->input['action'] == "add_template")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
@@ -620,7 +620,7 @@ if($mybb->input['action'] == "edit_template")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
@@ -1154,7 +1154,7 @@ if($mybb->input['action'] == "search_replace")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>

--- a/admin/modules/style/templates.php
+++ b/admin/modules/style/templates.php
@@ -255,7 +255,7 @@ if($mybb->input['action'] == "add_template")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
@@ -288,7 +288,7 @@ if($mybb->input['action'] == "add_template")
 
 	$form = new Form("index.php?module=style-templates&amp;action=add_template{$expand_str}", "post", "add_template");
 
-	$form_container = new FormContainer($lang->add_template);
+	$form_container = new FormContainer($lang->add_template, 'tfixed');
 	$form_container->output_row($lang->template_name, $lang->template_name_desc, $form->generate_text_box('title', $template['title'], array('id' => 'title')), 'title');
 	$form_container->output_row($lang->template_set, $lang->template_set_desc, $form->generate_select_box('sid', $template_sets, $sid), 'sid');
 	$form_container->output_row("", "", $form->generate_text_area('template', $template['template'], array('id' => 'template', 'class' => '', 'style' => 'width: 100%; height: 500px;')), 'template');
@@ -303,15 +303,17 @@ if($mybb->input['action'] == "add_template")
 
 	if($admin_options['codepress'] != 0)
 	{
-		echo "<script type=\"text/javascript\">
-			var editor = CodeMirror.fromTextArea(document.getElementById(\"template\"), {
+		echo '<script type="text/javascript">
+			var editor = CodeMirror.fromTextArea(document.getElementById("template"), {
 				lineNumbers: true,
 				lineWrapping: true,
-				mode: \"text/html\",
-				tabMode: \"indent\",
-				theme: \"mybb\"
+				viewportMargin: Infinity,
+				indentWithTabs: true,
+				indentUnit: 4,
+				mode: "text/html",
+				theme: "mybb"
 			});
-		</script>";
+		</script>';
 	}
 
 	$page->output_footer();
@@ -618,7 +620,7 @@ if($mybb->input['action'] == "edit_template")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
@@ -684,7 +686,7 @@ if($mybb->input['action'] == "edit_template")
 		echo $form->generate_hidden_field('from', "diff_report");
 	}
 
-	$form_container = new FormContainer($lang->edit_template_breadcrumb.$template['title']);
+	$form_container = new FormContainer($lang->edit_template_breadcrumb.$template['title'], 'tfixed');
 	$form_container->output_row($lang->template_name, $lang->template_name_desc, $form->generate_text_box('title', $template['title'], array('id' => 'title')), 'title');
 
 	// Force users to save the default template to a specific set, rather than the "global" templates - where they can delete it
@@ -707,15 +709,17 @@ if($mybb->input['action'] == "edit_template")
 
 	if($admin_options['codepress'] != 0)
 	{
-		echo "<script type=\"text/javascript\">
-			var editor = CodeMirror.fromTextArea(document.getElementById(\"template\"), {
+		echo '<script type="text/javascript">
+			var editor = CodeMirror.fromTextArea(document.getElementById("template"), {
 				lineNumbers: true,
 				lineWrapping: true,
-				mode: \"text/html\",
-				tabMode: \"indent\",
-				theme: \"mybb\"
+				viewportMargin: Infinity,
+				indentWithTabs: true,
+				indentUnit: 4,
+				mode: "text/html",
+				theme: "mybb"
 			});
-		</script>";
+		</script>';
 	}
 
 	$page->output_footer();
@@ -1150,7 +1154,7 @@ if($mybb->input['action'] == "search_replace")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
@@ -1172,7 +1176,7 @@ if($mybb->input['action'] == "search_replace")
 	$form = new Form("index.php?module=style-templates&amp;action=search_replace", "post", "do_template");
 	echo $form->generate_hidden_field('type', "templates");
 
-	$form_container = new FormContainer($lang->search_replace);
+	$form_container = new FormContainer($lang->search_replace, 'tfixed');
 	$form_container->output_row($lang->search_for, "", $form->generate_text_area('find', $mybb->input['find'], array('id' => 'find', 'class' => '', 'style' => 'width: 100%; height: 200px;')));
 
 	$form_container->output_row($lang->replace_with, "", $form->generate_text_area('replace', $mybb->input['replace'], array('id' => 'replace', 'class' => '', 'style' => 'width: 100%; height: 200px;')));
@@ -1206,23 +1210,27 @@ if($mybb->input['action'] == "search_replace")
 
 	if($admin_options['codepress'] != 0)
 	{
-		echo "<script type=\"text/javascript\">
-			var editor1 = CodeMirror.fromTextArea(document.getElementById(\"find\"), {
+		echo '<script type="text/javascript">
+			var editor1 = CodeMirror.fromTextArea(document.getElementById("find"), {
 				lineNumbers: true,
 				lineWrapping: true,
-				mode: \"text/html\",
-				tabMode: \"indent\",
-				theme: \"mybb\"
+				viewportMargin: Infinity,
+				indentWithTabs: true,
+				indentUnit: 4,
+				mode: "text/html",
+				theme: "mybb"
 			});
 
-			var editor2 = CodeMirror.fromTextArea(document.getElementById(\"replace\"), {
+			var editor2 = CodeMirror.fromTextArea(document.getElementById("replace"), {
 				lineNumbers: true,
 				lineWrapping: true,
-				mode: \"text/html\",
-				tabMode: \"indent\",
-				theme: \"mybb\"
+				viewportMargin: Infinity,
+				indentWithTabs: true,
+				indentUnit: 4,
+				mode: "text/html",
+				theme: "mybb"
 			});
-		</script>";
+		</script>';
 	}
 
 	$page->output_footer();
@@ -1685,7 +1693,7 @@ if($mybb->input['sid'] && !$mybb->input['action'])
 	$template_groups = array();
 	while($templategroup = $db->fetch_array($query))
 	{
-		$templategroup['title'] = $lang->sprintf($lang->templates, $lang->parse($templategroup['title']));
+		$templategroup['title'] = $lang->parse($templategroup['title'])." ".$lang->templates;
 		if($mybb->input['expand'] == 'all')
 		{
 			$expand_array[] = $templategroup['gid'];

--- a/admin/modules/style/templates.php
+++ b/admin/modules/style/templates.php
@@ -255,16 +255,20 @@ if($mybb->input['action'] == "add_template")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1804" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>
 <script src="./jscripts/codemirror/mode/htmlmixed/htmlmixed.js"></script>
-<link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet" >
+<link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/addon/dialog/dialog.js"></script>
 <script src="./jscripts/codemirror/addon/search/searchcursor.js"></script>
 <script src="./jscripts/codemirror/addon/search/search.js"></script>
+<script src="./jscripts/codemirror/addon/fold/foldcode.js"></script>
+<script src="./jscripts/codemirror/addon/fold/xml-fold.js"></script>
+<script src="./jscripts/codemirror/addon/fold/foldgutter.js"></script>
+<link href="./jscripts/codemirror/addon/fold/foldgutter.css" rel="stylesheet">
 ';
 	}
 
@@ -307,6 +311,8 @@ if($mybb->input['action'] == "add_template")
 			var editor = CodeMirror.fromTextArea(document.getElementById("template"), {
 				lineNumbers: true,
 				lineWrapping: true,
+				foldGutter: true,
+				gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
 				viewportMargin: Infinity,
 				indentWithTabs: true,
 				indentUnit: 4,
@@ -620,16 +626,20 @@ if($mybb->input['action'] == "edit_template")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1804" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>
 <script src="./jscripts/codemirror/mode/htmlmixed/htmlmixed.js"></script>
-<link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet" >
+<link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/addon/dialog/dialog.js"></script>
 <script src="./jscripts/codemirror/addon/search/searchcursor.js"></script>
 <script src="./jscripts/codemirror/addon/search/search.js"></script>
+<script src="./jscripts/codemirror/addon/fold/foldcode.js"></script>
+<script src="./jscripts/codemirror/addon/fold/xml-fold.js"></script>
+<script src="./jscripts/codemirror/addon/fold/foldgutter.js"></script>
+<link href="./jscripts/codemirror/addon/fold/foldgutter.css" rel="stylesheet">
 ';
 	}
 
@@ -713,6 +723,8 @@ if($mybb->input['action'] == "edit_template")
 			var editor = CodeMirror.fromTextArea(document.getElementById("template"), {
 				lineNumbers: true,
 				lineWrapping: true,
+				foldGutter: true,
+				gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
 				viewportMargin: Infinity,
 				indentWithTabs: true,
 				indentUnit: 4,
@@ -1154,16 +1166,20 @@ if($mybb->input['action'] == "search_replace")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1804" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/xml/xml.js"></script>
 <script src="./jscripts/codemirror/mode/javascript/javascript.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>
 <script src="./jscripts/codemirror/mode/htmlmixed/htmlmixed.js"></script>
-<link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet" >
+<link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/addon/dialog/dialog.js"></script>
 <script src="./jscripts/codemirror/addon/search/searchcursor.js"></script>
 <script src="./jscripts/codemirror/addon/search/search.js"></script>
+<script src="./jscripts/codemirror/addon/fold/foldcode.js"></script>
+<script src="./jscripts/codemirror/addon/fold/xml-fold.js"></script>
+<script src="./jscripts/codemirror/addon/fold/foldgutter.js"></script>
+<link href="./jscripts/codemirror/addon/fold/foldgutter.css" rel="stylesheet">
 ';
 	}
 
@@ -1214,6 +1230,8 @@ if($mybb->input['action'] == "search_replace")
 			var editor1 = CodeMirror.fromTextArea(document.getElementById("find"), {
 				lineNumbers: true,
 				lineWrapping: true,
+				foldGutter: true,
+				gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
 				viewportMargin: Infinity,
 				indentWithTabs: true,
 				indentUnit: 4,
@@ -1224,6 +1242,8 @@ if($mybb->input['action'] == "search_replace")
 			var editor2 = CodeMirror.fromTextArea(document.getElementById("replace"), {
 				lineNumbers: true,
 				lineWrapping: true,
+				foldGutter: true,
+				gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
 				viewportMargin: Infinity,
 				indentWithTabs: true,
 				indentUnit: 4,

--- a/admin/modules/style/templates.php
+++ b/admin/modules/style/templates.php
@@ -1693,7 +1693,7 @@ if($mybb->input['sid'] && !$mybb->input['action'])
 	$template_groups = array();
 	while($templategroup = $db->fetch_array($query))
 	{
-		$templategroup['title'] = $lang->parse($templategroup['title'])." ".$lang->templates;
+		$templategroup['title'] = $lang->sprintf($lang->templates, $lang->parse($templategroup['title']));
 		if($mybb->input['expand'] == 'all')
 		{
 			$expand_array[] = $templategroup['gid'];

--- a/admin/modules/style/themes.php
+++ b/admin/modules/style/themes.php
@@ -2319,7 +2319,7 @@ if($mybb->input['action'] == "edit_stylesheet" && $mybb->input['mode'] == "advan
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1804" rel="stylesheet">
 <link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>
@@ -2592,7 +2592,7 @@ if($mybb->input['action'] == "add_stylesheet")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1804" rel="stylesheet">
 <link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>

--- a/admin/modules/style/themes.php
+++ b/admin/modules/style/themes.php
@@ -2319,7 +2319,7 @@ if($mybb->input['action'] == "edit_stylesheet" && $mybb->input['mode'] == "advan
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
 <link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>
@@ -2592,7 +2592,7 @@ if($mybb->input['action'] == "add_stylesheet")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1803" rel="stylesheet">
 <link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>

--- a/admin/modules/style/themes.php
+++ b/admin/modules/style/themes.php
@@ -2319,7 +2319,7 @@ if($mybb->input['action'] == "edit_stylesheet" && $mybb->input['mode'] == "advan
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
 <link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>
@@ -2379,7 +2379,7 @@ if($mybb->input['action'] == "edit_stylesheet" && $mybb->input['mode'] == "advan
 	$table = new Table;
 	$table->construct_cell($form->generate_text_area('stylesheet', $stylesheet['stylesheet'], array('id' => 'stylesheet', 'style' => 'width: 99%;', 'class' => '', 'rows' => '30')));
 	$table->construct_row();
-	$table->output("{$lang->full_stylesheet_for} ".htmlspecialchars_uni($stylesheet['name']));
+	$table->output($lang->full_stylesheet_for.' '.htmlspecialchars_uni($stylesheet['name']), 1, 'tfixed');
 
 	$buttons[] = $form->generate_submit_button($lang->save_changes, array('id' => 'save', 'name' => 'save'));
 	$buttons[] = $form->generate_submit_button($lang->save_changes_and_close, array('id' => 'save_close', 'name' => 'save_close'));
@@ -2390,13 +2390,16 @@ if($mybb->input['action'] == "edit_stylesheet" && $mybb->input['mode'] == "advan
 
 	if($admin_options['codepress'] != 0)
 	{
-		echo "<script type=\"text/javascript\">
-			var editor = CodeMirror.fromTextArea(document.getElementById(\"stylesheet\"), {
+		echo '<script type="text/javascript">
+			var editor = CodeMirror.fromTextArea(document.getElementById("stylesheet"), {
 				lineNumbers: true,
-				tabMode: \"indent\",
-				theme: \"mybb\",
-				lineWrapping: true
-			});</script>";
+				lineWrapping: true,
+				viewportMargin: Infinity,
+				indentWithTabs: true,
+				indentUnit: 4,
+				mode: "text/css",
+				theme: "mybb"
+			});</script>';
 	}
 
 	$page->output_footer();
@@ -2589,7 +2592,7 @@ if($mybb->input['action'] == "add_stylesheet")
 	{
 		$page->extra_header .= '
 <link href="./jscripts/codemirror/lib/codemirror.css" rel="stylesheet">
-<link href="./jscripts/codemirror/theme/mybb.css" rel="stylesheet">
+<link href="./jscripts/codemirror/theme/mybb.css?ver=1802" rel="stylesheet">
 <link href="./jscripts/codemirror/addon/dialog/dialog-mybb.css" rel="stylesheet">
 <script src="./jscripts/codemirror/lib/codemirror.js"></script>
 <script src="./jscripts/codemirror/mode/css/css.js"></script>
@@ -2812,7 +2815,7 @@ if($mybb->input['action'] == "add_stylesheet")
 
 	echo $form->generate_hidden_field("sid", $stylesheet['sid'])."<br />\n";
 
-	$form_container = new FormContainer("{$lang->add_stylesheet_to} ".htmlspecialchars_uni($theme['name']));
+	$form_container = new FormContainer($lang->add_stylesheet_to.' '.htmlspecialchars_uni($theme['name']), 'tfixed');
 	$form_container->output_row($lang->file_name, $lang->file_name_desc, $form->generate_text_box('name', $mybb->input['name'], array('id' => 'name', 'style' => 'width: 200px;')), 'name');
 
 	$form_container->output_row($lang->attached_to, $lang->attached_to_desc, $actions);
@@ -2846,13 +2849,16 @@ if($mybb->input['action'] == "add_stylesheet")
 
 	if($admin_options['codepress'] != 0)
 	{
-		echo "<script type=\"text/javascript\">
-			var editor = CodeMirror.fromTextArea(document.getElementById(\"stylesheet\"), {
+		echo '<script type="text/javascript">
+			var editor = CodeMirror.fromTextArea(document.getElementById("stylesheet"), {
 				lineNumbers: true,
-				tabMode: \"indent\",
-				theme: \"mybb\",
-				lineWrapping: true
-			});</script>";
+				lineWrapping: true,
+				viewportMargin: Infinity,
+				indentWithTabs: true,
+				indentUnit: 4,
+				mode: "text/css",
+				theme: "mybb"
+			});</script>';
 	}
 
 	echo '<script type="text/javascript" src="./jscripts/themes.js"></script>';

--- a/admin/styles/default/main.css
+++ b/admin/styles/default/main.css
@@ -320,6 +320,7 @@ table.general tr:last-child td:last-child {
 .tfixed {
 	table-layout: fixed;
 	word-wrap: break-word;
+	width: 100%;
 }
 
 /* Page Footer */

--- a/admin/styles/default/main.css
+++ b/admin/styles/default/main.css
@@ -317,6 +317,11 @@ table.general tr:last-child td:last-child {
 	-webkit-border-bottom-right-radius: 5px;
 }
 
+.tfixed {
+	table-layout: fixed;
+	word-wrap: break-word;
+}
+
 /* Page Footer */
 #footer {
 	clear: both;


### PR DESCRIPTION
Allows users to search CodeMirror content with browser by introducing the `viewportMargin: Infinity` option:
https://github.com/mybb/mybb/issues/1592

Ensures that the CodeMirror is always max. 100% width:
https://github.com/mybb/mybb/issues/1555

Also fixed tabbing issue (2 spaces were inserted instead of a tab due to outdated CodeMirror option usage) and a small typo in comment.