### PR TITLE
Fix #334 Update from 1.6.8 to 1.6.10 failed

### DIFF
--- a/install/resources/upgrade26.php
+++ b/install/resources/upgrade26.php
@@ -34,7 +34,7 @@ function upgrade26_dbchanges()
 
 	if($db->field_exists('failedlogin', 'users'))
 	{
-		$db->write_query("ALTER TABLE ".TABLE_PREFIX."users DROP failedlogin;");
+		$db->drop_column("users", "failedlogin");
 	}
 
 	// We don't need the posthash after the post is inserted into the database


### PR DESCRIPTION
#334

Instead of using the query function directly we should always use the correct database method.
Note that you can't upgrade to 1.6.x as the SQLite driver was broken. To test this you need to upgrade to 1.8 (.2 in my case)
