### PR TITLE
Fix searching for Users by IP with IP range in ModCP

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -3689,12 +3689,12 @@ if($mybb->input['action'] == "ipsearch")
 				$ip = false;
 				if(is_array($ip_range))
 				{
-					if(strcmp($ip_range[0], $ipaddress['regip']) >= 0 && strcmp($ip_range[1], $ipaddress['regip']) <= 0)
+					if(strcmp($ip_range[0], $ipaddress['regip']) <= 0 && strcmp($ip_range[1], $ipaddress['regip']) >= 0)
 					{
 						eval("\$subject = \"".$templates->get("modcp_ipsearch_result_regip")."\";");
 						$ip = my_inet_ntop($db->unescape_binary($ipaddress['regip']));
 					}
-					elseif(strcmp($ip_range[0], $ipaddress['lastip']) >= 0 && strcmp($ip_range[1], $ipaddress['lastip']) <= 0)
+					elseif(strcmp($ip_range[0], $ipaddress['lastip']) <= 0 && strcmp($ip_range[1], $ipaddress['lastip']) >= 0)
 					{
 						eval("\$subject = \"".$templates->get("modcp_ipsearch_result_lastip")."\";");
 						$ip = my_inet_ntop($db->unescape_binary($ipaddress['lastip']));


### PR DESCRIPTION
The problem is explained in the thread http://community.mybb.com/thread-163625.html

If a mod attempts to use IP ranges (like 123.123.123.\* which would mean "all ips from 123.123.123.0 to 123.123.123.255) in the IP search feature of the modcp, he will never get any user results, because no last IP nor registration IP can satisfy the original conditions in those if blocks.
