### PR TITLE
Typo fix in functions.php comment

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1914,7 +1914,7 @@ function my_set_array_cookie($name, $id, $value, $expires="")
  */
 function my_unserialize($data)
 {
-	// Do no unserialize objects
+	// Do not unserialize objects
 	if(substr($data, 0, 1) == 'O')
 	{
 		return array();


### PR DESCRIPTION
Saw this while looking for what might cause repeated warnings:

```
Type: 2
File: inc/functions.php (Line no. 1927)
Message
substr() expects parameter 1 to be string, array given
```
