### PR TITLE
Fix #1341 Closed board message should load language string, fallback to custom reason if set.

### DIFF
--- a/archive/global.php
+++ b/archive/global.php
@@ -188,6 +188,11 @@ if($mybb->settings['boardclosed'] == 1)
 {
 	if($mybb->usergroup['canviewboardclosed'] != 1)
 	{
+		if(!$mybb->settings['boardclosed_reason'])
+		{
+			$mybb->settings['boardclosed_reason'] = $lang->boardclosed_reason;
+		}
+
 		$lang->error_boardclosed .= "<blockquote>".$mybb->settings['boardclosed_reason']."</blockquote>";
 		archive_error($lang->error_boardclosed);
 	}

--- a/global.php
+++ b/global.php
@@ -885,6 +885,11 @@ $closed_bypass = array(
 if($mybb->settings['boardclosed'] == 1 && $mybb->usergroup['canviewboardclosed'] != 1 && !in_array($current_page, $closed_bypass) && (!is_array($closed_bypass[$current_page]) || !in_array($mybb->get_input('action'), $closed_bypass[$current_page])))
 {
 	// Show error
+	if(!$mybb->settings['boardclosed_reason'])
+	{
+		$mybb->settings['boardclosed_reason'] = $lang->boardclosed_reason;
+	}
+
 	$lang->error_boardclosed .= "<blockquote>{$mybb->settings['boardclosed_reason']}</blockquote>";
 	
 	if(!$mybb->get_input('modal')) 

--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -560,3 +560,5 @@ $l['sfs_error_username'] = 'username';
 $l['sfs_error_ip'] = 'IP';
 $l['sfs_error_email'] = 'email';
 $l['sfs_error_or'] = 'or';
+
+$l['boardclosed_reason'] = 'These forums are currently closed for maintenance. Please check back later';

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -11,7 +11,7 @@
 		</setting>
 		<setting name="boardclosed_reason">
 			<title>Board Closed Reason</title>
-			<description><![CDATA[If your forum is closed, you can set a message here that your visitors will be able to see when they visit your forums.]]></description>
+			<description><![CDATA[If your forum is closed, you can set a message here that your visitors will be able to see when they visit your forums. You can leave this empty to use the language files.]]></description>
 			<disporder>2</disporder>
 			<optionscode><![CDATA[textarea]]></optionscode>
 			<settingvalue><![CDATA[These forums are currently closed for maintenance. Please check back later.]]></settingvalue>


### PR DESCRIPTION
Fix #1341 Closed board message should load language string, fallback to custom reason if set.