### PR TITLE
Update class_mailhandler.php

### DIFF
--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -122,12 +122,12 @@ class MailHandler
 
 			if($mybb->settings['mail_handler'] == 'smtp')
 			{
-				$this->from = $mybb->settings['adminemail'];
+				$this->from = $mybb->settings['returnemail'];
 			}
 			else
 			{
 				$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
-				$this->from .= " <{$mybb->settings['adminemail']}>";
+				$this->from .= " <{$mybb->settings['returnemail']}>";
 			}
 		}
 

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -92,6 +92,23 @@ class MailHandler
 	public $parse_format = 'text';
 
 	/**
+	 * Selects between AdminEmail and ReturnEmail, dependant on if ReturnEmail is filled.
+	 */
+	function from_select()
+	{
+		global $mybb;
+		
+		if($mybb->settings['returnemail'])
+		{
+			return "returnemail";
+		}
+		else
+		{
+			return "adminemail";
+		}
+	}
+
+	/**
 	 * Builds the whole mail.
 	 * To be used by the different email classes later.
 	 *
@@ -122,26 +139,12 @@ class MailHandler
 
 			if($mybb->settings['mail_handler'] == 'smtp')
 			{
-				if($mybb->settings['returnemail'])
-				{
-					$this->from = $mybb->settings['returnemail'];
-				}
-				else
-				{
-					$this->from = $mybb->settings['adminemail'];
-				}
+				$this->from = $mybb->settings[$this->from_select()];
 			}
 			else
 			{
 				$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
-				if($mybb->settings['returnemail'])
-				{
-					$this->from .= " <{$mybb->settings['returnemail']}>";
-				}
-				else
-				{
-					$this->from .= " <{$mybb->settings['adminemail']}>";
-				}
+				$this->from .= " <".$mybb->settings[$this->from_select()].">";
 			}
 		}
 
@@ -152,14 +155,7 @@ class MailHandler
 		else
 		{
 			$this->return_email = "";
-			if($mybb->settings['returnemail'])
-			{
-				$this->return_email = $mybb->settings['returnemail'];
-			}
-			else
-			{
-				$this->return_email = $mybb->settings['adminemail'];
-			}
+			$this->return_email = $mybb->settings[$this->from_select()];
 		}
 
 		$this->set_to($to);

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -122,12 +122,26 @@ class MailHandler
 
 			if($mybb->settings['mail_handler'] == 'smtp')
 			{
-				$this->from = $mybb->settings['returnemail'];
+				if($mybb->settings['returnemail'])
+				{
+					$this->from = $mybb->settings['returnemail'];
+				}
+				else
+				{
+					$this->from = $mybb->settings['adminemail'];
+				}
 			}
 			else
 			{
 				$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
-				$this->from .= " <{$mybb->settings['returnemail']}>";
+				if($mybb->settings['returnemail'])
+				{
+					$this->from .= " <{$mybb->settings['returnemail']}>";
+				}
+				else
+				{
+					$this->from .= " <{$mybb->settings['adminemail']}>";
+				}
 			}
 		}
 

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -240,7 +240,7 @@ class MailHandler
 		$this->to = $this->cleanup($to);
 	}
 
-	/**a
+	/**
 	 * Sets the plain headers, text/plain
 	 */
 	function set_plain_headers()

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -94,18 +94,20 @@ class MailHandler
 	/**
 	 * Selects between AdminEmail and ReturnEmail, dependant on if ReturnEmail is filled.
 	 */
-	function from_select()
+	function get_from_email()
 	{
 		global $mybb;
 		
-		if($mybb->settings['returnemail'])
+		if(trim($mybb->settings['returnemail']))
 		{
-			return "returnemail";
+			$email = $mybb->settings['returnemail'];
 		}
 		else
 		{
-			return "adminemail";
+			$email = $mybb->settings['adminemail'];
 		}
+		
+		return $email;
 	}
 
 	/**
@@ -139,12 +141,12 @@ class MailHandler
 
 			if($mybb->settings['mail_handler'] == 'smtp')
 			{
-				$this->from = $mybb->settings[$this->from_select()];
+				$this->from = $this->get_from_email();
 			}
 			else
 			{
 				$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
-				$this->from .= " <".$mybb->settings[$this->from_select()].">";
+				$this->from .= " <".$this->get_from_email().">";
 			}
 		}
 
@@ -155,7 +157,7 @@ class MailHandler
 		else
 		{
 			$this->return_email = "";
-			$this->return_email = $mybb->settings[$this->from_select()];
+			$this->return_email = $this->get_from_email();
 		}
 
 		$this->set_to($to);
@@ -238,7 +240,7 @@ class MailHandler
 		$this->to = $this->cleanup($to);
 	}
 
-	/**
+	/**a
 	 * Sets the plain headers, text/plain
 	 */
 	function set_plain_headers()

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -133,23 +133,16 @@ class MailHandler
 		$this->message = '';
 		$this->headers = $headers;
 
-		if($from)
+		$this->from = "";
+
+		if($mybb->settings['mail_handler'] == 'smtp')
 		{
-			$this->from = $from;
+			$this->from = $this->get_from_email();
 		}
 		else
 		{
-			$this->from = "";
-
-			if($mybb->settings['mail_handler'] == 'smtp')
-			{
-				$this->from = $this->get_from_email();
-			}
-			else
-			{
-				$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
-				$this->from .= " <".$this->get_from_email().">";
-			}
+			$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
+			$this->from .= " <".$this->get_from_email().">";
 		}
 
 		if($return_email)

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -93,6 +93,8 @@ class MailHandler
 
 	/**
 	 * Selects between AdminEmail and ReturnEmail, dependant on if ReturnEmail is filled.
+	 * 
+	 * @return string
 	 */
 	function get_from_email()
 	{

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -132,17 +132,23 @@ class MailHandler
 
 		$this->message = '';
 		$this->headers = $headers;
-
-		$this->from = "";
-
-		if($mybb->settings['mail_handler'] == 'smtp')
+		
+		if($from)
 		{
-			$this->from = $this->get_from_email();
+			$this->from = $from;
 		}
 		else
 		{
-			$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
-			$this->from .= " <".$this->get_from_email().">";
+			$this->from = "";
+			if($mybb->settings['mail_handler'] == 'smtp')
+			{
+				$this->from = $this->get_from_email();
+			}
+			else
+			{
+				$this->from = '"'.$this->utf8_encode($mybb->settings['bbname']).'"';
+				$this->from .= " <".$this->get_from_email().">";
+			}
 		}
 
 		if($return_email)


### PR DESCRIPTION
When a user changes their password, an email is received from the board administrator. This "functionality" exposes the administrator's email to anyone who registers.

Thus, this change allows a person to set ReturnEmail to donotreply@domain.com and AdminEmail to adminemail@domain.com, the emails from Contact Us, etc will still work fine and be delivered to the administrator, yet any other emails not specifically defined as From anyone will be sent via donotreply@domain.com.

For example, the original file does this:
* A user uses the Contact Us link, the email is delivered to AdminEmail received from the user's own email address.
* A user registers, the email is delivered to the user's own email address, received from **AdminEmail**.

These changes do:
* A user uses the Contact Us link, the email is delivered to AdminEmail received from the user's own email address.
* A user registers, the email is delivered to the user's own Email Address, received from **ReturnEmail**.