### PR TITLE
Fix #1756 missing array definition

### DIFF
--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -623,7 +623,7 @@ class DB_MySQL
 	}
 
 	/**
-	 * Lists all functions in the database.
+	 * Lists all tables in the database.
 	 *
 	 * @param string The database name.
 	 * @param string Prefix of the table (optional)

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -620,7 +620,7 @@ class DB_MySQLi
 	}
 
 	/**
-	 * Lists all functions in the database.
+	 * Lists all tables in the database.
 	 *
 	 * @param string The database name.
 	 * @param string Prefix of the table (optional)

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -601,7 +601,7 @@ class DB_PgSQL
 	}
 
 	/**
-	 * Lists all functions in the database.
+	 * Lists all tables in the database.
 	 *
 	 * @param string The database name.
 	 * @param string Prefix of the table (optional)

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -471,7 +471,7 @@ class DB_SQLite
 	}
 
 	/**
-	 * Lists all functions in the database.
+	 * Lists all tables in the database.
 	 *
 	 * @param string The database name.
 	 * @param string Prefix of the table (optional)

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1198,7 +1198,7 @@ function user_permissions($uid=0)
 }
 
 /**
- * Fetch the usergroup permissions for a specic group or series of groups combined
+ * Fetch the usergroup permissions for a specific group or series of groups combined
  *
  * @param mixed A list of groups (Can be a single integer, or a list of groups separated by a comma)
  * @return array Array of permissions generated for the groups
@@ -1214,11 +1214,12 @@ function usergroup_permissions($gid=0)
 
 	$groups = explode(",", $gid);
 
-
 	if(count($groups) == 1)
 	{
 		return $groupscache[$gid];
 	}
+	
+	$usergroup = array();
 
 	foreach($groups as $gid)
 	{


### PR DESCRIPTION
Define `$usergroup` as an array just in case there is nothing to return
to avoid PHP warnings.

https://github.com/mybb/mybb/issues/1756