### PR TITLE
Apply DST based on the timestamp instead of the current date.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -344,7 +344,7 @@ function my_date($format, $stamp="", $offset="", $ty=1, $adodb=false)
 		if(isset($mybb->user['uid']) && $mybb->user['uid'] != 0 && array_key_exists("timezone", $mybb->user))
 		{
 			$offset = $mybb->user['timezone'];
-			$dstcorrection = $mybb->user['dst'];
+			$dstcorrection = $mybb->user['dstcorrection'];
 		}
 		elseif(defined("IN_ADMINCP"))
 		{
@@ -357,8 +357,8 @@ function my_date($format, $stamp="", $offset="", $ty=1, $adodb=false)
 			$dstcorrection = $mybb->settings['dstcorrection'];
 		}
 
-		// If DST correction is enabled, add an additional hour to the timezone.
-		if($dstcorrection == 1)
+		// If DST correction is enabled and the date falls into DST, add an additional hour to the timezone.
+		if($dstcorrection == 1 || ($dstcorrection == 2 && date('I', $stamp) == 1))
 		{
 			++$offset;
 			if(my_substr($offset, 0, 1) != "-")


### PR DESCRIPTION
Related thread on the forums: http://community.mybb.com/newreply.php?tid=162091

When "my_date" applies DST in "Automatically detect DST"-Mode (value 2), it doesn't check/respect the timestamps value at all and simply applies DST always/never, based on the current time. This is certainly wrong and potentially confusing, as it retroactively changes the displayed post timestamps (and other dates) whenever the current date switches to/from DST.