### PR TITLE
Fix the display of future timestamps in "relative" mode

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -400,7 +400,7 @@ function my_date($format, $stamp="", $offset="", $ty=1, $adodb=false)
 	if($format == 'relative')
 	{
 		// Relative formats both date and time
-		if($ty != 2 && (TIME_NOW - $stamp) < 3600)
+		if($ty != 2 && abs(TIME_NOW - $stamp) < 3600)
 		{
 			$diff = TIME_NOW - $stamp;
 			$relative = array('prefix' => '', 'minute' => 0, 'plural' => $lang->rel_minutes_plural, 'suffix' => $lang->rel_ago);
@@ -428,7 +428,7 @@ function my_date($format, $stamp="", $offset="", $ty=1, $adodb=false)
 
 			$date = $lang->sprintf($lang->rel_time, $relative['prefix'], $relative['minute'], $relative['plural'], $relative['suffix']);
 		}
-		elseif($ty != 2 && (TIME_NOW - $stamp) >= 3600 && (TIME_NOW - $stamp) < 43200)
+		elseif($ty != 2 && abs(TIME_NOW - $stamp) < 43200)
 		{
 			$diff = TIME_NOW - $stamp;
 			$relative = array('prefix' => '', 'hour' => 0, 'plural' => $lang->rel_hours_plural, 'suffix' => $lang->rel_ago);


### PR DESCRIPTION
When a future timestamp is displayed in relative format, it would always be displayed in minutes. This fixes the problem and allows future timestamps to be displayed in minutes, hours and minutes, or as a normal date/time depending on how close it is to the current time.

Corresponding Thread in the forums: http://community.mybb.com/thread-166148.html