### PR TITLE
Fix localized date time input

### DIFF
--- a/admin/modules/forum/announcements.php
+++ b/admin/modules/forum/announcements.php
@@ -230,14 +230,12 @@ if($mybb->input['action'] == "add")
 
 	if(!$mybb->input['starttime_time'])
 	{
-		$start_time = explode("-", gmdate("g-i-a", TIME_NOW));
-		$mybb->input['starttime_time'] = $start_time[0].":".$start_time[1]." ".$start_time[2];
+		$mybb->input['starttime_time'] = gmdate($mybb->settings['timeformat'], TIME_NOW);
 	}
 
 	if(!$mybb->input['endtime_time'])
 	{
-		$end_time = explode("-", gmdate("g-i-a", TIME_NOW));
-		$mybb->input['endtime_time'] = $end_time[0].":".$end_time[1]." ".$end_time[2];
+		$mybb->input['endtime_time'] = gmdate($mybb->settings['timeformat'], TIME_NOW);
 	}
 
 	if($mybb->input['starttime_day'])
@@ -619,8 +617,7 @@ if($mybb->input['action'] == "edit")
 			admin_redirect("index.php?module=forum-announcements");
 		}
 
-		$start_time = explode("-", gmdate("g-i-a", $announcement['startdate']));
-		$mybb->input['starttime_time'] = $start_time[0].":".$start_time[1]." ".$start_time[2];
+		$mybb->input['starttime_time'] = gmdate( $mybb->settings['timeformat'], $announcement['startdate']);
 
 		$startday = gmdate("j", $announcement['startdate']);
 
@@ -641,8 +638,7 @@ if($mybb->input['action'] == "edit")
 			$endtime_checked[1] = "checked=\"checked\"";
 			$endtime_checked[2] = "";
 
-			$end_time = explode("-", gmdate("g-i-a", $announcement['enddate']));
-			$mybb->input['endtime_time'] = $end_time[0].":".$end_time[1]." ".$end_time[2];
+			$mybb->input['endtime_time'] = gmdate( $mybb->settings['timeformat'],$announcement['enddate']);
 
 			$endday = gmdate("j", $announcement['enddate']);
 

--- a/admin/modules/user/banning.php
+++ b/admin/modules/user/banning.php
@@ -285,7 +285,7 @@ if($mybb->input['action'] == "edit")
 	{
 		if($time != '---')
 		{
-			$friendly_time = my_date("D, jS M Y @ g:ia", ban_date2timestamp($time));
+			$friendly_time = my_date("D, jS M Y @ {$mybb->settings['timeformat']}", ban_date2timestamp($time));
 			$period = "{$period} ({$friendly_time})";
 		}
 		$length_list[$time] = $period;
@@ -545,7 +545,7 @@ if(!$mybb->input['action'])
 	{
 		if($time != "---")
 		{
-			$friendly_time = my_date("D, jS M Y @ g:ia", ban_date2timestamp($time));
+			$friendly_time = my_date("D, jS M Y @ {$mybb->settings['timeformat']}", ban_date2timestamp($time));
 			$period = "{$period} ({$friendly_time})";
 		}
 		$length_list[$time] = $period;

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -2621,7 +2621,7 @@ if($mybb->input['action'] == "inline_edit")
 			{
 				if($time != '---')
 				{
-					$friendly_time = my_date("D, jS M Y @ g:ia", ban_date2timestamp($time));
+					$friendly_time = my_date("D, jS M Y @ {$mybb->settings['timeformat']}", ban_date2timestamp($time));
 					$period = "{$period} ({$friendly_time})";
 				}
 				$length_list[$time] = $period;

--- a/calendar.php
+++ b/calendar.php
@@ -945,7 +945,7 @@ if($mybb->input['action'] == "editevent")
 		{
 			$privatecheck = '';
 		}
-		$start_date = explode("-", gmdate("j-n-Y-g:i A", $event['starttime']+$event['timezone']*3600));
+		$start_date = explode("-", gmdate("j-n-Y", $event['starttime']+$event['timezone']*3600));
 		$single_day = $start_date[0];
 		$single_month[$start_date[1]] = " selected=\"selected\"";
 		$single_year = $start_date[2];
@@ -962,7 +962,7 @@ if($mybb->input['action'] == "editevent")
 		}
 		if($event['endtime'])
 		{
-			$end_date = explode("-", gmdate("j-n-Y-g:i A", $event['endtime']+$event['timezone']*3600));
+			$end_date = explode("-", gmdate("j-n-Y", $event['endtime']+$event['timezone']*3600));
 			$end_day = $end_date[0];
 			$end_month[$end_date[1]] = " selected=\"selected\"";
 			$end_year = $end_date[2];

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -5714,7 +5714,7 @@ function get_event_date($event)
 	global $mybb;
 
 	$event_date = explode("-", $event['date']);
-	$event_date = mktime(0, 0, 0, $event_date[1], $event_date[0], $event_date[2]);
+	$event_date = gmmktime(0, 0, 0, $event_date[1], $event_date[0], $event_date[2]);
 	$event_date = my_date($mybb->settings['dateformat'], $event_date);
 
 	return $event_date;

--- a/moderation.php
+++ b/moderation.php
@@ -148,14 +148,16 @@ switch($mybb->input['action'])
 	case "delayedmoderation":
 		// Verify incoming POST request
 		verify_post_check($mybb->get_input('my_post_key'));
+		
+		$localized_time_offset = $mybb->user['timezone']*3600 + $mybb->user['dst']*3600;
 
 		if(!$mybb->get_input('date_day', MyBB::INPUT_INT))
 		{
-			$mybb->input['date_day'] = date('d', TIME_NOW);
+			$mybb->input['date_day'] = gmdate('d', TIME_NOW + $localized_time_offset);
 		}
 		if(!$mybb->get_input('date_month', MyBB::INPUT_INT))
 		{
-			$mybb->input['date_month'] = date('m', TIME_NOW);
+			$mybb->input['date_month'] = gmdate('m', TIME_NOW + $localized_time_offset);
 		}
 
 		// Assume in-line moderation if TID is not set
@@ -255,7 +257,7 @@ switch($mybb->input['action'])
 				$errors[] = $lang->error_delayedmoderation_invalid_date_month;
 			}
 
-			if($mybb->input['date_year'] < gmdate('Y', TIME_NOW))
+			if($mybb->input['date_year'] < gmdate('Y', TIME_NOW + $localized_time_offset))
 			{
 				$errors[] = $lang->error_delayedmoderation_invalid_date_year;
 			}
@@ -272,7 +274,7 @@ switch($mybb->input['action'])
 				}
 			}
 
-			$rundate = mktime((int)$date_time[0], (int)$date_time[1], date('s', TIME_NOW), $mybb->get_input('date_month', MyBB::INPUT_INT), $mybb->get_input('date_day', MyBB::INPUT_INT), $mybb->get_input('date_year', MyBB::INPUT_INT));
+			$rundate = gmmktime((int)$date_time[0], (int)$date_time[1], date('s', TIME_NOW), $mybb->get_input('date_month', MyBB::INPUT_INT), $mybb->get_input('date_day', MyBB::INPUT_INT), $mybb->get_input('date_year', MyBB::INPUT_INT)) - $localized_time_offset;
 
 			if(!$errors)
 			{
@@ -464,9 +466,10 @@ switch($mybb->input['action'])
 					");
 			}
 		}
+		
 		while($delayedmod = $db->fetch_array($query))
 		{
-			$delayedmod['dateline'] = my_date("jS M Y, G:i", $delayedmod['delaydateline']);
+			$delayedmod['dateline'] = my_date("jS M Y, {$mybb->settings['timeformat']}", $delayedmod['delaydateline']);
 			$delayedmod['username'] = htmlspecialchars_uni($delayedmod['username']);
 			$delayedmod['profilelink'] = build_profile_link($delayedmod['username'], $delayedmod['uid']);
 			$delayedmod['action'] = $actions[$delayedmod['type']];
@@ -582,8 +585,8 @@ switch($mybb->input['action'])
 
 		eval('$datemonth = "'.$templates->get('moderation_delayedmoderation_date_month').'";');
 
-		$dateyear = gmdate('Y', TIME_NOW);
-		$datetime = gmdate('g:i a', TIME_NOW);
+		$dateyear = gmdate('Y', TIME_NOW  + $localized_time_offset);
+		$datetime = gmdate($mybb->settings['timeformat'], TIME_NOW + $localized_time_offset);
 
 		$plugins->run_hooks("moderation_delayedmoderation");
 


### PR DESCRIPTION
Related Thread on Forum: http://community.mybb.com/thread-165257.html

The target of this pull request was two-fold:

1. Respect the "$mybb->settings['timeformat']" value (set in Admin-CP) at all locations that display time or allow the input of time as text (and don't/can't use my_date for date/time formatting). This affects:
Admin-CP Forum Announcement creation/editing
Admin-CP User banning preset bantimes selectbox entries
Admin-CP Mass Mail creation/editing
Mod-CP Forum Announcement creation/editing
Delayed Moderation

2. Respect current user timezone and dst when entering date/time. This affects:
Admin-CP Mass Mail creation/editing
Mod-CP Forum Announcement creation/editing
Delayed Moderation (original reason for this pull request as mentioned in the corresponding thread)
(Admin-CP Forum Announcement creation was intentionally left "GMT" only, because there is a label that states that inputs are always interpreted as GMT.)
(The Calendar already offers to set the used timezone explicitely, therefore I didn't touch the logic there. I only shortened the time patterns at two  locations, because the hour/minute part that is generated isn't used at these locations at all.)

3. In addition minor related bugs are fixed:
Admin-CP Mass Mail added the current users timezone when saving data. If at all, the timezone data should have been subtracted at that point. This bug lead to strange behaviour, where repeatedly editing and saving the same mass-mail would push its delivery time further into the future (when timezone offset is positive) or the past (the other case).
Admin-CP Mass Mail would interpret "11:00 PM" as "11:00", because the matching for "pm" only checked for lowercase "pm". Everywhere else the same logic was case insensitive, now it is here too.
The function  get_event_date($event) in functions.php would have applied timezones twice, if the server has a timezone/location set that's not "+0", because mktime is used where gmmktime should've been used (The correct timezone information is applied one line later during a call to "my_date"). This method seems to not be used at all currently.