### PR TITLE
Fix #1811 upgrade issues

### DIFF
--- a/install/resources/upgrade32.php
+++ b/install/resources/upgrade32.php
@@ -23,6 +23,11 @@ $upgrade_detail = array(
 function upgrade32_dbchanges()
 {
 	global $db, $output;
+	
+	// Unset old ACP cookies from front-end since they're not needed anymore
+	my_unsetcookie('adminsid');
+	my_unsetcookie('acploginattempts');
+	my_unsetcookie('acp_view');
 
 	$output->print_header("Updating Database");
 	echo "<p>Performing necessary upgrade queries...</p>";
@@ -50,11 +55,6 @@ function upgrade32_dbchanges()
 	$db->delete_query("forumpermissions", "fid NOT IN(SELECT fid FROM {$db->table_prefix}forums)");
 
 	$db->update_query("settings", array('optionscode' => 'select\r\n0=No CAPTCHA\r\n1=MyBB Default CAPTCHA\r\n2=reCAPTCHA\r\n3=Are You a Human\r\n4=NoCAPTCHA reCAPTCHA'), "name='captchaimage'");
-
-	// Unset old ACP cookies from front-end since they're not needed anymore
-	my_unsetcookie('adminsid');
-	my_unsetcookie('acploginattempts');
-	my_unsetcookie('acp_view');
 	
 	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
 	$output->print_footer("32_done");

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -596,7 +596,7 @@ function buildcaches()
 
 function upgradedone()
 {
-	global $db, $output, $mybb, $lang, $config;
+	global $db, $output, $mybb, $lang, $config, $plugins;
 
 	ob_start();
 	$output->print_header("Upgrade Complete");


### PR DESCRIPTION
Moved the cookie unset code to avoid headers already sent warnings.

Added forgotten `$plugins` globalization to the `upgradedone()` function
to prevent `add_hook()` error.

https://github.com/mybb/mybb/issues/1811