### PR TITLE
Fix #1830 installation/upgrade error

### DIFF
--- a/admin/inc/functions_themes.php
+++ b/admin/inc/functions_themes.php
@@ -965,8 +965,11 @@ function update_theme_stylesheet_list($tid, $theme = false, $update_disporders =
 				}
 			}
 		}
-
-		$plugins->run_hooks('update_theme_stylesheet_list_set_css_url', $css_url);
+		
+		if(is_object($plugins))
+		{
+			$plugins->run_hooks('update_theme_stylesheet_list_set_css_url', $css_url);
+		}
 
 		$attachedto = $stylesheet['attachedto'];
 		if(!$attachedto)

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8161,7 +8161,7 @@ function copy_file_to_cdn($file_path = '', &$uploaded_path = null)
 
 	$success = false;
 
-	$file_path = (string) $file_path;
+	$file_path = (string)$file_path;
 
 	$real_file_path = realpath($file_path);
 
@@ -8193,7 +8193,7 @@ function copy_file_to_cdn($file_path = '', &$uploaded_path = null)
 			{
 				if(($cdn_upload_path = realpath($cdn_upload_path)) !== false)
 				{
-					$success = @copy($file_path, $cdn_upload_path . DIRECTORY_SEPARATOR . $file_name);
+					$success = @copy($file_path, $cdn_upload_path.DIRECTORY_SEPARATOR.$file_name);
 
 					if($success)
 					{
@@ -8203,15 +8203,18 @@ function copy_file_to_cdn($file_path = '', &$uploaded_path = null)
 			}
 		}
 
-		$hook_args = array(
-			'file_path' => &$file_path,
-			'real_file_path' => &$real_file_path,
-			'file_name' => &$file_name,
-			'uploaded_path' => &$uploaded_path,
-			'success' => &$success,
-		);
+		if(is_object($plugins))
+		{
+			$hook_args = array(
+				'file_path' => &$file_path,
+				'real_file_path' => &$real_file_path,
+				'file_name' => &$file_name,
+				'uploaded_path' => &$uploaded_path,
+				'success' => &$success,
+			);
 
-		$plugins->run_hooks('copy_file_to_cdn_end', $hook_args);
+			$plugins->run_hooks('copy_file_to_cdn_end', $hook_args);
+		}
 	}
 
 	return $success;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8173,7 +8173,7 @@ function copy_file_to_cdn($file_path = '', &$uploaded_path = null)
 
 	if(file_exists($file_path))
 	{
-		if ($mybb->settings['usecdn'] && !empty($mybb->settings['cdnpath']))
+		if($mybb->settings['usecdn'] && !empty($mybb->settings['cdnpath']))
 		{
 			$cdn_path = rtrim($mybb->settings['cdnpath'], '/\\');
 


### PR DESCRIPTION
Fix installation/error caused by `$plugins->run_hook()` usage without
access to `$plugins` by checking if the object exists. I think it's
better than defining `$plugins` in several files.

https://github.com/mybb/mybb/issues/1830