### PR TITLE
Fix #1210 soft deleted posts with showthread.php?pid=x#pidx 2

### DIFF
--- a/showthread.php
+++ b/showthread.php
@@ -120,7 +120,9 @@ if(is_moderator($fid))
 }
 else
 {
-	$ismod = false;
+	$ismod = false;	$ismod = false;
+	$visibleonly = " AND visible=1";
+	$visibleonly2 = "AND p.visible=1 AND t.visible=1";
 }
 
 // Make sure we are looking at a real thread here.

--- a/showthread.php
+++ b/showthread.php
@@ -120,7 +120,7 @@ if(is_moderator($fid))
 }
 else
 {
-	$ismod = false;	$ismod = false;
+	$ismod = false;
 	$visibleonly = " AND visible=1";
 	$visibleonly2 = "AND p.visible=1 AND t.visible=1";
 }


### PR DESCRIPTION
Fix #1210 soft deleted posts with showthread.php?pid=x#pidx

I'm unsure why `$visibleonly` and `$visibleonly2` weren't set in the core for normal users?

https://github.com/Sama34/mybb/blob/fix-1210/showthread.php#L744