### PR TITLE
Fix #1947 checkbox optionscode doesn't work

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -935,7 +935,7 @@ if($mybb->input['action'] == "change")
 				// All checkboxes deselected = no $mybb->input['upsetting'] for them, we need to initialize it manually then, but only on pages where the setting is shown
 				if(empty($mybb->input['upsetting'][$multisetting['name']]) && isset($mybb->input["isvisible_{$multisetting['name']}"]))
 				{
-					$mybb->input['upsetting'][$multisetting['name']] = '';
+					$mybb->input['upsetting'][$multisetting['name']] = array();
 				}
 			}
 			else

--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -439,7 +439,7 @@ if($mybb->input['action'] == "add")
 	echo '<script type="text/javascript" src="./jscripts/peeker.js?ver=1804"></script>
 	<script type="text/javascript">
 		$(document).ready(function() {
-			var peeker = new Peeker($("#type"), $("#row_extra"), /select|radio|checkbox|php/, false);
+			new Peeker($("#type"), $("#row_extra"), /^(select|radio|checkbox|php)$/, false);
 		});
 		// Add a star to the extra row since the "extra" is required if the box is shown
 		add_star("row_extra");
@@ -655,7 +655,7 @@ if($mybb->input['action'] == "edit")
 	echo '<script type="text/javascript" src="./jscripts/peeker.js?ver=1804"></script>
 	<script type="text/javascript">
 		$(document).ready(function() {
-			var peeker = new Peeker($("#type"), $("#row_extra"), /select|radio|checkbox|php/, false);
+			new Peeker($("#type"), $("#row_extra"), /^(select|radio|checkbox|php)$/, false);
 		});
 		// Add a star to the extra row since the "extra" is required if the box is shown
 		add_star("row_extra");


### PR DESCRIPTION
As the title says - it worked like radios since 1.6 - only one value was saved. Multiple selections are saved to database separated with a comma now. A bit hacky solution with a hidden field, but it works and I don't think there is anything simplier than that.
https://github.com/mybb/mybb/issues/1947

Also added some missing fields that shouldn't be used as a hidden captcha.
EDIT: and fixed 2 peeker regexes to check for a complete match rather than a partial match.