### PR TITLE
Fix #1373 profile field permissions

### DIFF
--- a/admin/modules/config/profile_fields.php
+++ b/admin/modules/config/profile_fields.php
@@ -148,7 +148,6 @@ if($mybb->input['action'] == "add")
 				break;
 			default:
 				$mybb->input['viewableby'] = '';
-				break;
 		}
 
 		switch($mybb->input['editableby'])
@@ -161,7 +160,6 @@ if($mybb->input['action'] == "add")
 				break;
 			default:
 				$mybb->input['editableby'] = '';
-				break;
 		}
 
 		$page->output_inline_error($errors);
@@ -178,12 +176,12 @@ if($mybb->input['action'] == "add")
 
 	if(empty($mybb->input['viewableby']))
 	{
-		$mybb->input['viewableby'] = '';
+		$mybb->input['viewableby'] = -1;
 	}
 
 	if(empty($mybb->input['editableby']))
 	{
-		$mybb->input['editableby'] = '';
+		$mybb->input['editableby'] = -1;
 	}
 
 	$form_container = new FormContainer($lang->add_new_profile_field);
@@ -465,7 +463,6 @@ if($mybb->input['action'] == "edit")
 				break;
 			default:
 				$mybb->input['viewableby'] = '';
-				break;
 		}
 
 		switch($mybb->input['editableby'])
@@ -478,7 +475,6 @@ if($mybb->input['action'] == "edit")
 				break;
 			default:
 				$mybb->input['editableby'] = '';
-				break;
 		}
 
 		$page->output_inline_error($errors);

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -340,7 +340,7 @@ if($mybb->input['action'] == "add")
 			"additionalgroups" => $additionalgroups,
 			"displaygroup" => $mybb->input['displaygroup'],
 			"profile_fields" => $mybb->input['profile_fields'],
-			"profile_fields_editable" => true,
+			"profile_fields_editable" => true
 		);
 
 		// Set the data of the user in the datahandler.

--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -576,8 +576,9 @@ class UserDataHandler extends DataHandler
 					{
 						$this->set_error('max_limit_reached', array($profilefield['name'], $profilefield['maxlength']));
 					}
-
-					if(!empty($profilefield['regex']) && !preg_match("#".$profilefield['regex']."#i", $profile_fields[$field]))
+					
+					// Check regex only when the field is filled or required
+					if(!empty($profilefield['regex']) && ($profile_fields[$field] || $profilefield['required']) && !preg_match("#".$profilefield['regex']."#i", $profile_fields[$field]))
 					{
 						$this->set_error('bad_profile_field_value', array($profilefield['name']));
 					}

--- a/member.php
+++ b/member.php
@@ -2452,14 +2452,14 @@ if($mybb->input['action'] == "profile")
 	$query = $db->simple_select("userfields", "*", "ufid = '{$uid}'");
 	$userfields = $db->fetch_array($query);
 
-	// If this user is an Administrator or a Moderator then we wish to show all profile fields
 	$pfcache = $cache->read('profilefields');
 
 	if(is_array($pfcache))
 	{
 		foreach($pfcache as $customfield)
 		{
-			if($mybb->usergroup['cancp'] != 1 && $mybb->usergroup['issupermod'] != 1 && $mybb->usergroup['canmodcp'] != 1 && !is_member($customfield['viewableby']))
+			if(!$customfield['profile'] || !is_member($customfield['viewableby']) ||
+			!is_member($customfield['editableby'], array('usergroup' => $memprofile['usergroup'], 'additionalgroups' => $memprofile['additionalgroups'])) || $memprofile['postnum'] < $customfield['postnum'])
 			{
 				continue;
 			}

--- a/showthread.php
+++ b/showthread.php
@@ -763,22 +763,6 @@ if($mybb->input['action'] == "thread")
 		}
 	}
 
-	// Fetch profile fields to display on postbit
-	$pfcache = $cache->read('profilefields');
-
-	if(is_array($pfcache))
-	{
-		foreach($pfcache as $profilefield)
-		{
-			if($profilefield['postbit'] != 1)
-			{
-				continue;
-			}
-
-			$profile_fields[$profilefield['fid']] = $profilefield;
-		}
-	}
-
 	// Which thread mode is our user using by default?
 	if(!empty($mybb->user['threadmode']))
 	{


### PR DESCRIPTION
Adds missing `viewableby`/`editableby`/`postnum` checks.

Hides empty fields on postbit and fields that shouldn't be displayed on
profile.

`viewableby`/`editableby` set to All for new fields by default (not sure
why they were None in the first place).

Fixes regex error when a field is not required and not filled.

EDIT: also modified the ACP/MCP/registration check in userhandler, but not sure if it's a good solution..

https://github.com/mybb/mybb/issues/1373
