### PR TITLE
Fix #1993 is_numeric check in DB classes.

### DIFF
--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -1292,7 +1292,7 @@ class DB_MySQL implements DB_Base
 			}
 			else
 			{
-				$values .= $comma."`".$column."`='".$value."'";
+				$values .= $comma."`".$column."`=".$this->quote_val("'", $value);
 			}
 
 			$comma = ',';

--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -788,7 +788,9 @@ class DB_MySQL implements DB_Base
 			}
 			else
 			{
-				$array[$field] = "'{$value}'";
+				$quoted_value = $this->quote_val("'", $value);
+
+				$array[$field] = "{$quoted_value}";
 			}
 		}
 
@@ -837,7 +839,8 @@ class DB_MySQL implements DB_Base
 				}
 				else
 				{
-					$values[$field] = "'{$value}'";
+					$quoted_value = $this->quote_val("'", $value);
+					$values[$field] = "{$quoted_value}";
 				}
 			}
 			$insert_rows[] = "(".implode(",", $values).")";
@@ -892,14 +895,9 @@ class DB_MySQL implements DB_Base
 			}
 			else
 			{
-				if(is_numeric($value))
-				{
-					$query .= $comma."`".$field."`={$value}";
-				}
-				else
-				{
-					$query .= $comma."`".$field."`={$quote}{$value}{$quote}";
-				}
+				$quoted_val = $this->quote_val($quote, $value);
+
+				$query .= $comma."`".$field."`={$quoted_val}";
 			}
 			$comma = ', ';
 		}
@@ -918,6 +916,20 @@ class DB_MySQL implements DB_Base
 			UPDATE {$this->table_prefix}$table
 			SET $query
 		");
+	}
+
+	private function quote_val($quote, $value)
+	{
+		if(is_int($value))
+		{
+			$quoted = $value;
+		}
+		else
+		{
+			$quoted = $quote . $value . $quote;
+		}
+
+		return $quoted;
 	}
 
 	/**

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -1275,7 +1275,7 @@ class DB_MySQLi implements DB_Base
 			}
 			else
 			{
-				$values .= $comma."`".$column."`='".$value."'";
+				$values .= $comma."`".$column."`=".$this->quote_val("'", $value);
 			}
 
 			$comma = ',';

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -788,7 +788,9 @@ class DB_MySQLi implements DB_Base
 			}
 			else
 			{
-				$array[$field] = "'{$value}'";
+				$quoted_value = $this->quote_val("'", $value);
+
+				$array[$field] = "{$quoted_value}";
 			}
 		}
 
@@ -837,7 +839,9 @@ class DB_MySQLi implements DB_Base
 				}
 				else
 				{
-					$values[$field] = "'{$value}'";
+					$quoted_value = $this->quote_val("'", $value);
+
+					$values[$field] = "{$quoted_value}";
 				}
 			}
 			$insert_rows[] = "(".implode(",", $values).")";
@@ -892,14 +896,9 @@ class DB_MySQLi implements DB_Base
 			}
 			else
 			{
-				if(is_numeric($value))
-				{
-					$query .= $comma."`".$field."`={$value}";
-				}
-				else
-				{
-					$query .= $comma."`".$field."`={$quote}{$value}{$quote}";
-				}
+				$quoted_value = $this->quote_val($quote, $value);
+
+				$query .= $comma."`".$field."`={$quoted_value}";
 			}
 			$comma = ', ';
 		}
@@ -918,6 +917,20 @@ class DB_MySQLi implements DB_Base
 			UPDATE {$this->table_prefix}$table
 			SET $query
 		");
+	}
+
+	private function quote_val($quote, $value)
+	{
+		if(is_int($value))
+		{
+			$quoted = $value;
+		}
+		else
+		{
+			$quoted = $quote . $value . $quote;
+		}
+
+		return $quoted;
 	}
 
 	/**

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1319,7 +1319,8 @@ class DB_PgSQL implements DB_Base
 				}
 				else
 				{
-					$search_bit[] = "{$field} = '".$replacements[$field]."'";
+					$quoted_val = $this->quote_val("'", $replacements[$field]);
+					$search_bit[] = "{$field} = ".$quoted_val;
 				}
 			}
 
@@ -1352,7 +1353,8 @@ class DB_PgSQL implements DB_Base
 			}
 			else
 			{
-				return $this->update_query($table, $replacements, "{$main_field}='".$replacements[$main_field]."'");
+				$quoted_val = $this->quote_val("'", $replacements[$main_field]);
+				return $this->update_query($table, $replacements, "{$main_field}=".$quoted_val);
 			}
 		}
 		else

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -760,7 +760,9 @@ class DB_PgSQL implements DB_Base
 			}
 			else
 			{
-				$array[$field] = "'{$value}'";
+				$quoted_value = $this->quote_val("'", $value);
+
+				$array[$field] = "{$quoted_value}";
 			}
 		}
 
@@ -812,7 +814,9 @@ class DB_PgSQL implements DB_Base
 				}
 				else
 				{
-					$values[$field] = "'{$value}'";
+					$quoted_value = $this->quote_val("'", $value);
+
+					$values[$field] = "{$quoted_value}";
 				}
 			}
 			$insert_rows[] = "(".implode(",", $values).")";
@@ -862,7 +866,9 @@ class DB_PgSQL implements DB_Base
 			}
 			else
 			{
-				$query .= $comma.$field."={$quote}{$value}{$quote}";
+				$quoted_value = $this->quote_val($quote, $value);
+
+				$query .= $comma.$field."={$quoted_value}";
 			}
 			$comma = ', ';
 		}
@@ -874,6 +880,20 @@ class DB_PgSQL implements DB_Base
 			UPDATE {$this->table_prefix}$table
 			SET $query
 		");
+	}
+
+	private function quote_val($quote, $value)
+	{
+		if(is_int($value))
+		{
+			$quoted = $value;
+		}
+		else
+		{
+			$quoted = $quote . $value . $quote;
+		}
+
+		return $quoted;
 	}
 
 	/**

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -1085,7 +1085,7 @@ class DB_SQLite implements DB_Base
 			}
 			else
 			{
-				$values .= $comma."'".$value."'";
+				$values .= $comma.$this->quote_val("'", $value);
 			}
 
 			$comma = ',';

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -645,7 +645,9 @@ class DB_SQLite implements DB_Base
 			}
 			else
 			{
-				$array[$field] = "'{$value}'";
+				$quoted_value = $this->quote_val("'", $value);
+
+				$array[$field] = "{$quoted_value}";
 			}
 		}
 
@@ -695,7 +697,9 @@ class DB_SQLite implements DB_Base
 				}
 				else
 				{
-					$values[$field] = "'{$value}'";
+					$quoted_value = $this->quote_val("'", $value);
+
+					$values[$field] = "{$quoted_value}";
 				}
 			}
 			$insert_rows[] = "(".implode(",", $values).")";
@@ -751,7 +755,9 @@ class DB_SQLite implements DB_Base
 			}
 			else
 			{
-				$query .= $comma.$field."={$quote}".$value."{$quote}";
+				$quoted_value = $this->quote_val($quote, $value);
+
+				$query .= $comma.$field."={$quoted_value}";
 			}
 			$comma = ', ';
 		}
@@ -764,6 +770,20 @@ class DB_SQLite implements DB_Base
 		$query = $this->query("UPDATE {$this->table_prefix}$table SET $query");
 		$query->closeCursor();
 		return $query;
+	}
+
+	private function quote_val($quote, $value)
+	{
+		if(is_int($value))
+		{
+			$quoted = $value;
+		}
+		else
+		{
+			$quoted = $quote . $value . $quote;
+		}
+
+		return $quoted;
 	}
 
 	/**


### PR DESCRIPTION
#1993 - Removes is_numeric, adds a function `quote_val` to handle the quoting of values and only doesn't quote if the value is an integer type. This fixes the issue and also provides the benefit the original patch was meant to.