### PR TITLE
Fix #1995 URLs not shortened at all

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1051,7 +1051,7 @@ class postParser
 			$name = $url;
 		}
 
-		if($name == $url && !empty($this->options['shorten_urls']))
+		if($name == $url && (!isset($this->options['shorten_urls']) || !empty($this->options['shorten_urls'])))
 		{
 			$name = htmlspecialchars_decode($name);
 			if(my_strlen($name) > 55)


### PR DESCRIPTION
Reverts the check to a correct one so that URLs are shortened by
default.

Could be merged into 1.8.5 since it's very simple to check. @JN-Jones
@ATofighi

https://github.com/mybb/mybb/issues/1995