### PR TITLE
Fix #2001 Calendar does not show errors when adding events

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -542,8 +542,6 @@ if($mybb->input['action'] == "addevent")
 		eval("\$calendar_select .= \"".$templates->get("calendar_addevent_calendarselect_hidden")."\";");
 	}
 
-	$event_errors = '';
-
 	$plugins->run_hooks("calendar_addevent_end");
 
 	eval("\$addevent = \"".$templates->get("calendar_addevent")."\";");

--- a/calendar.php
+++ b/calendar.php
@@ -542,6 +542,11 @@ if($mybb->input['action'] == "addevent")
 		eval("\$calendar_select .= \"".$templates->get("calendar_addevent_calendarselect_hidden")."\";");
 	}
 
+	if(!isset($event_errors))
+	{
+		$event_errors = '';
+	}
+
 	$plugins->run_hooks("calendar_addevent_end");
 
 	eval("\$addevent = \"".$templates->get("calendar_addevent")."\";");


### PR DESCRIPTION
The '$event_errors' variable was cleared for no reason right before outputting the template, therefore deleting the errors.

https://github.com/mybb/mybb/issues/2001