### PR TITLE
Fixes #1912 PM download umlaut problems

### DIFF
--- a/private.php
+++ b/private.php
@@ -2060,6 +2060,7 @@ if($mybb->input['action'] == "do_export" && $mybb->request_method == "post")
 	}
 	else
 	{
+		echo "\xEF\xBB\xBF"; // UTF-8 BOM
 		echo $archived;
 	}
 }


### PR DESCRIPTION
Fixes #1912

Tested with umlauts (ä, ë, ï, ö, ü, ÿ), acutes (á, é, í, ó, ú, ý), graves (à, è, ì, ò, ù, ỳ), French Ç, Spanish Ñ, Polish Ł, German ß, Icelandic/Old English Ð and Þ and the letters Æ and Œ. Other letters should work too.