### PR TITLE
Fix #2003 Deleting an event in 'editevent' without checking checkbox …

### DIFF
--- a/admin/inc/class_page.php
+++ b/admin/inc/class_page.php
@@ -108,7 +108,7 @@ class DefaultPage
 
 		echo "	<script type=\"text/javascript\" src=\"../jscripts/jquery.js\"></script>\n";
 		echo "	<script type=\"text/javascript\" src=\"../jscripts/jquery.plugins.min.js\"></script>\n";
-		echo "	<script type=\"text/javascript\" src=\"../jscripts/general.js\"></script>\n";
+		echo "	<script type=\"text/javascript\" src=\"../jscripts/general.js?ver=1806\"></script>\n";
 		echo "	<script type=\"text/javascript\" src=\"./jscripts/admincp.js\"></script>\n";
 		echo "	<script type=\"text/javascript\" src=\"./jscripts/tabs.js\"></script>\n";
 
@@ -386,7 +386,7 @@ lang.saved = \"{$lang->saved}\";
 <meta name="copyright" content="Copyright {$copy_year} MyBB Group." />
 <link rel="stylesheet" href="./styles/{$cp_style}/login.css" type="text/css" />
 <script type="text/javascript" src="../jscripts/jquery.js"></script>
-<script type="text/javascript" src="../jscripts/general.js"></script>
+<script type="text/javascript" src="../jscripts/general.js?ver=1806"></script>
 <script type="text/javascript" src="./jscripts/admincp.js"></script>
 <script type="text/javascript">
 //<![CDATA[
@@ -518,7 +518,7 @@ EOF;
 <meta name="copyright" content="Copyright {$copy_year} MyBB Group." />
 <link rel="stylesheet" href="./styles/{$cp_style}/login.css" type="text/css" />
 <script type="text/javascript" src="../jscripts/jquery.js"></script>
-<script type="text/javascript" src="../jscripts/general.js"></script>
+<script type="text/javascript" src="../jscripts/general.js?ver=1806"></script>
 <script type="text/javascript" src="./jscripts/admincp.js"></script>
 <script type="text/javascript">
 //<![CDATA[

--- a/calendar.php
+++ b/calendar.php
@@ -553,6 +553,58 @@ if($mybb->input['action'] == "addevent")
 	output_page($addevent);
 }
 
+// Delete an event
+if($mybb->input['action'] == "do_deleteevent" && $mybb->request_method == "post")
+{
+	$query = $db->simple_select("events", "*", "eid='{$mybb->input['eid']}'");
+	$event = $db->fetch_array($query);
+
+	if(!$event)
+	{
+		error($lang->error_invalidevent);
+	}
+
+	$query = $db->simple_select("calendars", "*", "cid='{$event['cid']}'");
+	$calendar = $db->fetch_array($query);
+
+	// Invalid calendar?
+	if(!$calendar)
+	{
+		error($lang->invalid_calendar);
+	}
+
+	// Do we have permission to view this calendar or post events?
+	$calendar_permissions = get_calendar_permissions($calendar['cid']);
+	if($calendar_permissions['canviewcalendar'] != 1 || $calendar_permissions['canaddevents'] != 1)
+	{
+		error_no_permission();
+	}
+
+	if(($event['uid'] != $mybb->user['uid'] || $mybb->user['uid'] == 0) && $calendar_permissions['canmoderateevents'] != 1)
+	{
+		error_no_permission();
+	}
+
+	// Verify incoming POST request
+	verify_post_check($mybb->get_input('my_post_key'));
+
+	$plugins->run_hooks("calendar_do_deleteevent_start");
+
+	// Is the checkbox set?
+	if($mybb->get_input('delete', MyBB::INPUT_INT) == 1)
+	{
+		$db->delete_query("events", "eid='{$event['eid']}'");
+		$plugins->run_hooks("calendar_do_deleteevent_end");
+
+		// Redirect back to the main calendar view.
+		redirect("calendar.php", $lang->redirect_eventdeleted);
+	}
+	else
+	{
+		error($lang->delete_no_checkbox);
+	}
+}
+
 // Edit an event
 if($mybb->input['action'] == "do_editevent" && $mybb->request_method == "post")
 {
@@ -587,15 +639,6 @@ if($mybb->input['action'] == "do_editevent" && $mybb->request_method == "post")
 
 	// Verify incoming POST request
 	verify_post_check($mybb->get_input('my_post_key'));
-
-	// Are we going to delete this event or just edit it?
-	if($mybb->get_input('delete', MyBB::INPUT_INT) == 1)
-	{
-		$db->delete_query("events", "eid='{$event['eid']}'");
-
-		// Redirect back to the main calendar view.
-		redirect("calendar.php", $lang->redirect_eventdeleted);
-	}
 
 	$plugins->run_hooks("calendar_do_editevent_start");
 

--- a/inc/languages/english/calendar.lang.php
+++ b/inc/languages/english/calendar.lang.php
@@ -90,6 +90,7 @@ $l['delete_q'] = "Delete?";
 $l['delete_1'] = "To delete this event, check the checkbox to the left and then click the button to the right.";
 $l['delete_2'] = "<b>Note:</b> This process cannot be undone.";
 $l['delete_now'] = "Delete Now";
+$l['delete_no_checkbox'] = "The event was not deleted because you didn't check the \"Delete\" checkbox.";
 $l['jump_to_calendar'] = "Jump to calendar:";
 $l['select_calendar'] = "Calendar:";
 $l['type_single'] = "Single day event";

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -2874,7 +2874,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <td class="trow1">{$lang->no_events}</td>
 </tr>
 </table>]]></template>
-		<template name="calendar_editevent" version="1800"><![CDATA[<html>
+		<template name="calendar_editevent" version="1806"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->calendar} - {$lang->edit_event}</title>
 {$headerinclude}
@@ -2894,7 +2894,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 			<td class="trow1"><input type="submit" class="button" name="submit" value="{$lang->delete_now}" tabindex="10" /></td>
 		</tr>
 	</table>
-	<input type="hidden" name="action" value="do_editevent" />
+	<input type="hidden" name="action" value="do_deleteevent" />
 	<input type="hidden" name="eid" value="{$event['eid']}" />
 </form>
 <br />
@@ -13865,13 +13865,13 @@ $(function() {
 </html>]]></template>
 		<template name="debug_summary" version="1800"><![CDATA[<div id="debug">{$generated_in} {$debug_weight} <br />{$sql_queries} / {$server_load} / {$memory_usage}<br />[<a href="{$debuglink}" target="_blank">{$lang->debug_advanced_details}</a>]<br /></div>]]></template>
 		<template name="gobutton" version="120"><![CDATA[<input type="submit" class="button" value="{$lang->go}" />]]></template>
-		<template name="headerinclude" version="1804"><![CDATA[<link rel="alternate" type="application/rss+xml" title="{$lang->latest_threads} (RSS 2.0)" href="{$mybb->settings['bburl']}/syndication.php" />
+		<template name="headerinclude" version="1806"><![CDATA[<link rel="alternate" type="application/rss+xml" title="{$lang->latest_threads} (RSS 2.0)" href="{$mybb->settings['bburl']}/syndication.php" />
 <link rel="alternate" type="application/atom+xml" title="{$lang->latest_threads} (Atom 1.0)" href="{$mybb->settings['bburl']}/syndication.php?type=atom1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset={$charset}" />
 <meta http-equiv="Content-Script-Type" content="text/javascript" />
 <script type="text/javascript" src="{$mybb->asset_url}/jscripts/jquery.js?ver=1804"></script>
 <script type="text/javascript" src="{$mybb->asset_url}/jscripts/jquery.plugins.min.js?ver=1804"></script>
-<script type="text/javascript" src="{$mybb->asset_url}/jscripts/general.js?ver=1804"></script>
+<script type="text/javascript" src="{$mybb->asset_url}/jscripts/general.js?ver=1806"></script>
 
 {$stylesheets}
 <script type="text/javascript">

--- a/install/resources/output.php
+++ b/install/resources/output.php
@@ -40,7 +40,7 @@ class installerOutput {
 	<title>{$this->title} &gt; {$title}</title>
 	<link rel="stylesheet" href="stylesheet.css" type="text/css" />
 	<script type="text/javascript" src="../jscripts/jquery.js"></script>
-	<script type="text/javascript" src="../jscripts/general.js"></script>
+	<script type="text/javascript" src="../jscripts/general.js?ver=1806"></script>
 	{$dbconfig_add}
 </head>
 <body>

--- a/jscripts/general.js
+++ b/jscripts/general.js
@@ -104,7 +104,7 @@ var MyBB = {
 						{
 							name: "action",
 							type: "hidden",
-							value: "do_editevent"
+							value: "do_deleteevent"
 						})
 					);
 


### PR DESCRIPTION
…throws errors

Adds a new action `do_deleteevent` for deleting events and displays a proper error message (with a new language string) when the checkbox is not checked. The JavaScript function `MyBB.deleteEvent(eid)` is also using this action now. The action `do_editevent` is not capable of deleting events anymore.

https://github.com/mybb/mybb/issues/2003