### PR TITLE
Fix #1964 ||~|~|| sequence shouldn't be used in poll options

### DIFF
--- a/inc/languages/english/polls.lang.php
+++ b/inc/languages/english/polls.lang.php
@@ -45,6 +45,7 @@ $l['redirect_unvoted'] = "Your vote(s) in this thread have been removed.<br />Yo
 $l['redirect_polldeleted'] = "Thank you, the poll has successfully been removed from the thread.<br />You will now be taken back to the thread.";
 
 $l['error_polloptiontoolong'] = "One or more poll options you entered are longer than the acceptable limit. Please go back and shorten them.";
+$l['error_polloptionsequence'] = "One or more poll options you entered contain a sequence which should not be used in them: <strong>||~|~||</strong>. Please go back and remove it.";
 $l['error_noquestionoptions'] = "You either did not enter a question for your poll or do not have enough options. The minimum number of options a poll can have is 2.<br />Please go back and correct this error.";
 $l['error_pollalready'] = "Thread already has poll!";
 $l['error_nopolloptions'] = "The specified poll option is invalid or does not exist.";

--- a/polls.php
+++ b/polls.php
@@ -255,21 +255,32 @@ if($mybb->input['action'] == "do_newpoll" && $mybb->request_method == "post")
 			$options[$i] = '';
 		}
 
-		if(trim($options[$i]) != "")
-		{
-			$optioncount++;
-		}
-
-		if(my_strlen($options[$i]) > $mybb->settings['polloptionlimit'] && $mybb->settings['polloptionlimit'] != 0)
+		if($mybb->settings['polloptionlimit'] != 0 && my_strlen($options[$i]) > $mybb->settings['polloptionlimit'])
 		{
 			$lengtherror = 1;
 			break;
+		}
+
+		if(strpos($options[$i], '||~|~||') !== false)
+		{
+			$sequenceerror = 1;
+			break;
+		}
+		
+		if(trim($options[$i]) != "")
+		{
+			$optioncount++;
 		}
 	}
 
 	if(isset($lengtherror))
 	{
 		error($lang->error_polloptiontoolong);
+	}
+	
+	if(isset($sequenceerror))
+	{
+		error($lang->error_polloptionsequence);
 	}
 	
 	$mybb->input['question'] = $mybb->get_input('question');
@@ -631,21 +642,33 @@ if($mybb->input['action'] == "do_editpoll" && $mybb->request_method == "post")
 		{
 			$options[$i] = '';
 		}
-		if(trim($options[$i]) != '')
-		{
-			$optioncount++;
-		}
 
-		if(my_strlen($options[$i]) > $mybb->settings['polloptionlimit'] && $mybb->settings['polloptionlimit'] != 0)
+		if($mybb->settings['polloptionlimit'] != 0 && my_strlen($options[$i]) > $mybb->settings['polloptionlimit'])
 		{
 			$lengtherror = 1;
 			break;
+		}
+
+		if(strpos($options[$i], '||~|~||') !== false)
+		{
+			$sequenceerror = 1;
+			break;
+		}
+		
+		if(trim($options[$i]) != "")
+		{
+			$optioncount++;
 		}
 	}
 
 	if(isset($lengtherror))
 	{
 		error($lang->error_polloptiontoolong);
+	}
+	
+	if(isset($sequenceerror))
+	{
+		error($lang->error_polloptionsequence);
 	}
 
 	$mybb->input['question'] = $mybb->get_input('question');


### PR DESCRIPTION
Throws an eror if someone tries to enter `||~|~||` in one of the poll
options.

https://github.com/mybb/mybb/issues/1964