### PR TITLE
Let user select more than three users

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -10360,7 +10360,7 @@ if(use_xmlhttprequest == "1")
 	$("#to").select2({
 		placeholder: "{$lang->search_user}",
 		minimumInputLength: 3,
-		maximumSelectionSize: 3,
+		maximumSelectionSize: {$mybb->usergroup['maxpmrecipients']},
 		multiple: true,
 		ajax: { // instead of writing the function to execute the request we use Select2's convenient helper
 			url: "xmlhttp.php?action=get_users",
@@ -10398,7 +10398,7 @@ if(use_xmlhttprequest == "1")
   $("#bcc").select2({
 		placeholder: "{$lang->search_user}",
 		minimumInputLength: 3,
-		maximumSelectionSize: 3,
+		maximumSelectionSize: {$mybb->usergroup['maxpmrecipients']},
 		multiple: true,
 		ajax: { // instead of writing the function to execute the request we use Select2's convenient helper
 			url: "xmlhttp.php?action=get_users",


### PR DESCRIPTION
Currently, users are limited to selecting three recipients when sending a PM. This commit allows users to select up to the number defined for their usergroup.

I'm unsure if you would like this changed so that the max works across both the to and bcc fields, but right now this is a lot more convenient than what it is currently.