### PR TITLE
Fix #2051 wrong is_member() negation

### DIFF
--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -699,14 +699,7 @@ class PostDataHandler extends DataHandler
 						}
 					}
 
-					if($required['groups'] != "-1")
-					{
-						if(!is_member($required['groups'], array('usergroup' => $user['usergroup'], 'additionalgroups' => $user['additionalgroups'])))
-						{
-							$num_prefixes = true;
-						}
-					}
-					else
+					if(is_member($required['groups'], array('usergroup' => $user['usergroup'], 'additionalgroups' => $user['additionalgroups'])))
 					{
 						$num_prefixes = true;
 					}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3502,7 +3502,7 @@ function build_prefixes($pid=0)
 }
 
 /**
- * Build the thread prefix selection menu
+ * Build the thread prefix selection menu for the current user
  *
  *  @param int|string $fid The forum ID (integer ID or string all)
  *  @param int|string $selected_pid The selected prefix ID (integer ID or string any)
@@ -3521,18 +3521,8 @@ function build_prefix_select($fid, $selected_pid=0, $multiple=0)
 	$prefix_cache = build_prefixes(0);
 	if(empty($prefix_cache))
 	{
-		return false; // We've got no prefixes to show
-	}
-
-	$groups = array($mybb->user['usergroup']);
-	if($mybb->user['additionalgroups'])
-	{
-		$exp = explode(",", $mybb->user['additionalgroups']);
-
-		foreach($exp as $group)
-		{
-			$groups[] = $group;
-		}
+		// We've got no prefixes to show
+		return '';
 	}
 
 	// Go through each of our prefixes and decide which ones we can use
@@ -3551,29 +3541,16 @@ function build_prefix_select($fid, $selected_pid=0, $multiple=0)
 			}
 		}
 
-		if($prefix['groups'] != "-1")
+		if(is_member($prefix['groups']))
 		{
-			$prefix_groups = explode(",", $prefix['groups']);
-
-			foreach($groups as $group)
-			{
-				if(in_array($group, $prefix_groups) && !isset($prefixes[$prefix['pid']]))
-				{
-					// Our group can use this prefix!
-					$prefixes[$prefix['pid']] = $prefix;
-				}
-			}
-		}
-		else
-		{
-			// This prefix is for anybody to use...
+			// The current user can use this prefix
 			$prefixes[$prefix['pid']] = $prefix;
 		}
 	}
 
 	if(empty($prefixes))
 	{
-		return false;
+		return '';
 	}
 
 	$prefixselect = $prefixselect_prefix = '';
@@ -3618,10 +3595,11 @@ function build_prefix_select($fid, $selected_pid=0, $multiple=0)
 }
 
 /**
- * Build the thread prefix selection menu for a forum
+ * Build the thread prefix selection menu for a forum without group permission checks
  *
  *  @param int $fid The forum ID (integer ID)
  *  @param int $selected_pid The selected prefix ID (integer ID)
+ *	@return string The thread prefix selection menu
  */
 function build_forum_prefix_select($fid, $selected_pid=0)
 {
@@ -3632,7 +3610,7 @@ function build_forum_prefix_select($fid, $selected_pid=0)
 	$prefix_cache = build_prefixes(0);
 	if(empty($prefix_cache))
 	{
-		return false; // We've got no prefixes to show
+		return ''; // We've got no prefixes to show
 	}
 
 	// Go through each of our prefixes and decide which ones we can use
@@ -3659,7 +3637,7 @@ function build_forum_prefix_select($fid, $selected_pid=0)
 
 	if(empty($prefixes))
 	{
-		return false;
+		return '';
 	}
 
 	$default_selected = array();
@@ -4834,14 +4812,7 @@ function leave_usergroup($uid, $leavegroup)
 {
 	global $db, $mybb, $cache;
 
-	if($uid == $mybb->user['uid'])
-	{
-		$user = $mybb->user;
-	}
-	else
-	{
-		$user = get_user($uid);
-	}
+	$user = get_user($uid);
 
 	$groupslist = $comma = '';
 	$usergroups = $user['additionalgroups'].",";

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -7718,7 +7718,7 @@ function my_rand($min=null, $max=null, $force_seed=false)
 		mt_srand(secure_seed_rng());
 		$seeded = true;
 
-		$obfuscator = abs((int) secure_seed_rng());
+		$obfuscator = abs((int)secure_seed_rng());
 
 		// Ensure that $obfuscator is <= mt_getrandmax() for 64 bit systems.
 		if($obfuscator > mt_getrandmax())

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3599,7 +3599,7 @@ function build_prefix_select($fid, $selected_pid=0, $multiple=0)
  *
  *  @param int $fid The forum ID (integer ID)
  *  @param int $selected_pid The selected prefix ID (integer ID)
- *	@return string The thread prefix selection menu
+ *  @return string The thread prefix selection menu
  */
 function build_forum_prefix_select($fid, $selected_pid=0)
 {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3610,7 +3610,8 @@ function build_forum_prefix_select($fid, $selected_pid=0)
 	$prefix_cache = build_prefixes(0);
 	if(empty($prefix_cache))
 	{
-		return ''; // We've got no prefixes to show
+		// We've got no prefixes to show
+		return '';
 	}
 
 	// Go through each of our prefixes and decide which ones we can use


### PR DESCRIPTION
Fixes one invalid `is_member()` negation, returns empty strings instead
of `false` for HTML code, shortens redundant code (`-1` returns always
`true` for `is_member()` and `get_user()` the current user - `$mybb->user` - if the UID
matches).

https://github.com/mybb/mybb/issues/2051