### PR TITLE
Fix #907: Set posthandler-action for proper "subject" validation in preview

### DIFF
--- a/newreply.php
+++ b/newreply.php
@@ -982,6 +982,7 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 		// Set up posthandler.
 		require_once MYBB_ROOT."inc/datahandlers/post.php";
 		$posthandler = new PostDataHandler("insert");
+		$posthandler->action = "post";
 
 		// Set the post data that came from the input to the $post array.
 		$post = array(


### PR DESCRIPTION
Fix for Issue #907 

The posthandler action is used to determine the mode of validation of post subjects. When saving a reply, it is set to "post". When previewing a reply, it is currently not set at all.

Simply setting the action to "post" fixes the validation of subjects for previews.
