### PR TITLE
Initialise $bcc_form_val to an empty string.

### DIFF
--- a/private.php
+++ b/private.php
@@ -1135,6 +1135,10 @@ if($mybb->input['action'] == "read")
 		$bcc_form_val = implode(',', $bcc_form_val);
 		eval("\$bcc = \"".$templates->get("private_read_bcc")."\";");
 	}
+	else
+	{
+		$bcc_form_val = '';
+	}
 
 	$replyall = false;
 	if(count($to_recipients) > 1)


### PR DESCRIPTION
If the `$bcc_recipients` array is empty, the `$bcc_form_val` should be an empty string.

Signed-off-by: Euan Torano <euantorano@gmail.com>