### PR TITLE
Fixes an issue where the quickedit throws an issue if the forum requi…

### DIFF
--- a/xmlhttp.php
+++ b/xmlhttp.php
@@ -528,6 +528,13 @@ else if($mybb->input['action'] == "edit_post")
 			"editreason" => $editreason,
 			"edit_uid" => $mybb->user['uid']
 		);
+
+		// If this is the first post set the prefix. If a forum requires a prefix the quick edit would throw an error otherwise
+		if($post['pid'] == $thread['firstpost'])
+		{
+			$updatepost['prefix'] = $thread['prefix'];
+		}
+
 		$posthandler->set_data($updatepost);
 
 		// Now let the post handler do all the hard work.


### PR DESCRIPTION
…res prefixes

Since 1.8.6 the posthandler checks the prefix for firstposts (to avoid that you're able to remove the prefix later again), however as the quickedit doesn't set the prefix the post handler throws an error. To avoid rewriting the post handler (which doesn't know whether or not it's a quickedit or a full edit request) I've simply added the current prefix for the post handler

Caused by: https://github.com/mybb/mybb/pull/1984 #2184 