### PR TITLE
(Fix #2168) Add start-of-string caret to RE: regex in newreply

### DIFF
--- a/newreply.php
+++ b/newreply.php
@@ -788,7 +788,7 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 					// If this post was the post for which a quote button was clicked, set the subject
 					if($replyto == $quoted_post['pid'])
 					{
-						$subject = preg_replace('#RE:\s?#i', '', $quoted_post['subject']);
+						$subject = preg_replace('#^RE:\s?#i', '', $quoted_post['subject']);
 						// Subject too long? Shorten it to avoid error message
 						if(my_strlen($subject) > 85)
 						{


### PR DESCRIPTION
Previously, the beginning-of-string caret was not added to the start
of the regex, which caused other occurrences of "re" in the subject to
be stripped erroneously
(i.e. Sierra Madre: test will result in invalid RE: Sierra Madtest).

This commit adds the ^ character to the beginning of the regex, which
anchors the search to beginning-of-string.

Test successful with regexr. http://regexr.com/3bnsm