### PR TITLE
Fix #2232 URLs with & and () and without protocol not parsed

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -306,7 +306,7 @@ class postParser
 			$callback_mycode['url_complex']['regex'] = "#\[url=([a-z]+?://)([^\r\n\"<]+?)\](.+?)\[/url\]#si";
 			$callback_mycode['url_complex']['replacement'] = array($this, 'mycode_parse_url_callback1');
 
-			$callback_mycode['url_complex2']['regex'] = "#\[url=([^\r\n\"<&\(\)]+?)\](.+?)\[/url\]#si";
+			$callback_mycode['url_complex2']['regex'] = "#\[url=([^\r\n\"<]+?)\](.+?)\[/url\]#si";
 			$callback_mycode['url_complex2']['replacement'] = array($this, 'mycode_parse_url_callback2');
 
 			++$callback_count;


### PR DESCRIPTION
The mentioned characters were disallowed for no apparaent reason.

https://github.com/mybb/mybb/issues/2232