### PR TITLE
Fixes #2237 Round corners in child tables inconsistent

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -2172,7 +2172,7 @@ ul.thread_tools li.poll {
 .thread_status.newlockfolder {
 	background-position: 0 -320px;
 }]]></stylesheet>
-	<stylesheet name="css3.css" version="1800" disporder="7"><![CDATA[tr td.trow1:first-child,
+	<stylesheet name="css3.css" version="1807" disporder="7"><![CDATA[tr td.trow1:first-child,
 tr td.trow2:first-child,
 tr td.trow_shaded:first-child {
 	border-left: 0;
@@ -2194,13 +2194,13 @@ tr td.trow_shaded:last-child {
 	border-bottom: 0;
 }
 
-.tborder tbody tr:last-child td:first-child {
+.tborder:first-child tbody tr:last-child td:first-child {
 	-moz-border-radius-bottomleft: 6px;
 	-webkit-border-bottom-left-radius: 6px;
 	border-bottom-left-radius: 6px;
 }
 
-.tborder tbody tr:last-child td:last-child {
+.tborder:first-child tbody tr:last-child td:last-child {
 	-moz-border-radius-bottomright: 6px;
 	-webkit-border-bottom-right-radius: 6px;
 	border-bottom-right-radius: 6px;

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -2190,17 +2190,17 @@ tr td.trow_shaded:last-child {
 	border-radius: 7px;
 }
 
-.tborder tbody tr:last-child td {
+.tborder tbody tr:last-child > td {
 	border-bottom: 0;
 }
 
-.tborder:first-child tbody tr:last-child td:first-child {
+.tborder tbody tr:last-child > td:first-child {
 	-moz-border-radius-bottomleft: 6px;
 	-webkit-border-bottom-left-radius: 6px;
 	border-bottom-left-radius: 6px;
 }
 
-.tborder:first-child tbody tr:last-child td:last-child {
+.tborder tbody tr:last-child > td:last-child {
 	-moz-border-radius-bottomright: 6px;
 	-webkit-border-bottom-right-radius: 6px;
 	border-bottom-right-radius: 6px;


### PR DESCRIPTION
* Defined the desired CSS rule only for first child of tborder class.
* Changed the version number of css3.css to 1807