### PR TITLE
Fixes #2276 Redundant </a> in template "misc_whoposted_poster"

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -6121,8 +6121,8 @@ if(use_xmlhttprequest == "1")
 </table>
 </div>
 </div>]]></template>
-		<template name="misc_whoposted_poster" version="120"><![CDATA[<tr>
-<td class="{$altbg}">{$profile_link}</a></td>
+		<template name="misc_whoposted_poster" version="1807"><![CDATA[<tr>
+<td class="{$altbg}">{$profile_link}</td>
 <td class="{$altbg}">{$poster['posts']}</td>
 </tr>]]></template>
 		<template name="modcp" version="1805"><![CDATA[<html>


### PR DESCRIPTION
* removed unnecessary ```</a>```
* changed version to 1807