### PR TITLE
Fixes #2288 Missing closing </td> in template report_error_nomodal

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -10511,9 +10511,9 @@ document.write('<br /><span class="smalltext"><a href="#" onclick="UserCP.openBu
 		<template name="report_error" version="1800"><![CDATA[<tr>
 	<td colspan="2" class="trow1">{$error}</td>
 </tr>]]></template>
-		<template name="report_error_nomodal" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+		<template name="report_error_nomodal" version="1807"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 <tr>
-	<td class="thead" colspan="2"><strong>{$report_title}</strong>
+	<td class="thead" colspan="2"><strong>{$report_title}</strong></td>
 </tr>
 <tr>
 	<td class="tcat" colspan="2">{$lang->report_to_mod}</td>


### PR DESCRIPTION
- Added missing ```</td>```
- Changed version to 1807