### PR TITLE
RNG rewrite

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -7773,24 +7773,24 @@ function secure_seed_rng()
 {
 	$bytes = PHP_INT_SIZE;
 
-	$output = secure_binary_seed_rng($bytes);
-
-	// convert binary data to a decimal number
-	if ($bytes == 4)
+	do
 	{
-		$elements = unpack('i', $output);
-		$output = abs($elements[1]);
-	}
-	else
-	{
-		$elements = unpack('N2', $output);
-		$output = abs($elements[1] << 32 | $elements[2]);
 
-		if($output > PHP_INT_MAX)
+		$output = secure_binary_seed_rng($bytes);
+
+		// convert binary data to a decimal number
+		if ($bytes == 4)
 		{
-			$output = 0;
+			$elements = unpack('i', $output);
+			$output = abs($elements[1]);
 		}
-	}
+		else
+		{
+			$elements = unpack('N2', $output);
+			$output = abs($elements[1] << 32 | $elements[2]);
+		}
+
+	} while($output > PHP_INT_MAX);
 
 	return $output;
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -7648,129 +7648,186 @@ function signed($int)
 }
 
 /**
- * Returns a securely generated seed for PHP's RNG (Random Number Generator)
+ * Returns a securely generated seed
  *
- * @param int $count Length of the seed bytes (8 is default. Provides good cryptographic variance)
- * @return int An integer equivalent of a secure hexadecimal seed
+ * @return string A secure binary seed
  */
-function secure_seed_rng($count=8)
+function secure_binary_seed_rng($bytes)
 {
-	$output = '';
-	// DIRECTORY_SEPARATOR checks if running windows
-	if(DIRECTORY_SEPARATOR != '\\')
+	$output = null;
+
+	if(version_compare(PHP_VERSION, '7.0', '>='))
 	{
-		// Unix/Linux
-		// Use OpenSSL when available
-		if(function_exists('openssl_random_pseudo_bytes'))
+		try
 		{
-			$output = openssl_random_pseudo_bytes($count);
+			$output = random_bytes($bytes);
+		} catch (Exception $e) {
 		}
-		// Try mcrypt
-		elseif(function_exists('mcrypt_create_iv'))
+	}
+
+	if(strlen($output) < $bytes)
+	{
+		if(@is_readable('/dev/urandom') && ($handle = @fopen('/dev/urandom', 'rb')))
 		{
-			$output = mcrypt_create_iv($count, MCRYPT_DEV_URANDOM);
-		}
-		// Try /dev/urandom
-		elseif(@is_readable('/dev/urandom') && ($handle = @fopen('/dev/urandom', 'rb')))
-		{
-			$output = @fread($handle, $count);
+			$output = @fread($handle, $bytes);
 			@fclose($handle);
 		}
 	}
 	else
 	{
-		// Windows
-		// Use OpenSSL when available
-		// PHP <5.3.4 had a bug which makes that function unusable on Windows
-		if(function_exists('openssl_random_pseudo_bytes') && version_compare(PHP_VERSION, '5.3.4', '>='))
+		return $output;
+	}
+
+	if(strlen($output) < $bytes)
+	{
+		if(function_exists('mcrypt_create_iv'))
 		{
-			$output = openssl_random_pseudo_bytes($count);
+			if (DIRECTORY_SEPARATOR == '/')
+			{
+				$source = MCRYPT_DEV_URANDOM;
+			}
+			else
+			{
+				$source = MCRYPT_RAND;
+			}
+
+			$output = mcrypt_create_iv($bytes, $source);
 		}
-		// Try mcrypt
-		elseif(function_exists('mcrypt_create_iv'))
+	}
+	else
+	{
+		return $output;
+	}
+
+	if(strlen($output) < $bytes)
+	{
+		if(function_exists('openssl_random_pseudo_bytes'))
 		{
-			$output = mcrypt_create_iv($count, MCRYPT_RAND);
+			// PHP <5.3.4 had a bug which makes that function unusable on Windows
+			if ((DIRECTORY_SEPARATOR == '/') || version_compare(PHP_VERSION, '5.3.4', '>='))
+			{
+				$output = openssl_random_pseudo_bytes($bytes, $crypto_strong);
+				if ($crypto_strong == false)
+				{
+					$output = null;
+				}
+			}
 		}
-		// Try Windows CAPICOM before using our own generator
-		elseif(class_exists('COM'))
+	}
+	else
+	{
+		return $output;
+	}
+
+	if(strlen($output) < $bytes)
+	{
+		if(class_exists('COM'))
 		{
 			try
 			{
 				$CAPI_Util = new COM('CAPICOM.Utilities.1');
 				if(is_callable(array($CAPI_Util, 'GetRandom')))
 				{
-					$output = $CAPI_Util->GetRandom($count, 0);
+					$output = $CAPI_Util->GetRandom($bytes, 0);
 				}
 			} catch (Exception $e) {
 			}
 		}
 	}
-
-	// Didn't work? Do we still not have enough bytes? Use our own (less secure) rng generator
-	if(strlen($output) < $count)
+	else
 	{
-		$output = '';
+		return $output;
+	}
 
+	if(strlen($output) < $bytes)
+	{
 		// Close to what PHP basically uses internally to seed, but not quite.
 		$unique_state = microtime().@getmypid();
 
-		for($i = 0; $i < $count; $i += 16)
+		$rounds = ceil($bytes / 16);
+
+		for($i = 0; $i < $rounds; $i++)
 		{
 			$unique_state = md5(microtime().$unique_state);
-			$output .= pack('H*', md5($unique_state));
+			$output .= md5($unique_state);
+		}
+
+		$output = substr($output, 0, ($bytes * 2));
+
+		$output = pack('H*', $output);
+
+		return $output;
+	}
+	else
+	{
+		return $output;
+	}
+}
+
+/**
+ * Returns a securely generated seed integer
+ *
+ * @return int An integer equivalent of a secure hexadecimal seed
+ */
+function secure_seed_rng()
+{
+	$bytes = PHP_INT_SIZE;
+
+	$output = secure_binary_seed_rng($bytes);
+
+	// convert binary data to a decimal number
+	if ($bytes == 4)
+	{
+		$elements = unpack('i', $output);
+		$output = abs($elements[1]);
+	}
+	else
+	{
+		$elements = unpack('N2', $output);
+		$output = abs($elements[1] << 32 | $elements[2]);
+
+		if($output > PHP_INT_MAX)
+		{
+			$output = 0;
 		}
 	}
-
-	// /dev/urandom and openssl will always be twice as long as $count. base64_encode will roughly take up 33% more space but crc32 will put it to 32 characters
-	$output = hexdec(substr(dechex(crc32(base64_encode($output))), 0, $count));
 
 	return $output;
 }
 
 /**
- * Wrapper function for mt_rand. Automatically seeds using a secure seed once.
+ * Generates a cryptographically secure random number.
  *
  * @param int $min Optional lowest value to be returned (default: 0)
- * @param int $max Optional highest value to be returned (default: mt_getrandmax())
- * @param boolean $force_seed True forces it to reseed the RNG first
- * @return int An integer equivalent of a secure hexadecimal seed
+ * @param int $max Optional highest value to be returned (default: PHP_INT_MAX)
  */
-function my_rand($min=null, $max=null, $force_seed=false)
+function my_rand($min=0, $max=PHP_INT_MAX)
 {
-	static $seeded = false;
-	static $obfuscator = 0;
-
-	if($seeded == false || $force_seed == true)
+	// backward compatibility
+	if($min === null || $max === null || $max < $min)
 	{
-		mt_srand(secure_seed_rng());
-		$seeded = true;
+		$min = 0;
+		$max = PHP_INT_MAX;
+	}
 
-		$obfuscator = abs((int) secure_seed_rng());
-
-		// Ensure that $obfuscator is <= mt_getrandmax() for 64 bit systems.
-		if($obfuscator > mt_getrandmax())
+	if(version_compare(PHP_VERSION, '7.0', '>='))
+	{
+		try
 		{
-			$obfuscator -= mt_getrandmax();
+			$result = random_int($min, $max);
+		} catch (Exception $e) {
+		}
+
+		if(isset($result))
+		{
+			return $result;
 		}
 	}
 
-	if($min !== null && $max !== null)
-	{
-		$distance = $max - $min;
-		if($distance > 0)
-		{
-			return $min + (int)((float)($distance + 1) * (float)(mt_rand() ^ $obfuscator) / (mt_getrandmax() + 1));
-		}
-		else
-		{
-			return mt_rand($min, $max);
-		}
-	}
-	else
-	{
-		$val = mt_rand() ^ $obfuscator;
-		return $val;
-	}
+	$seed = secure_seed_rng();
+
+	$distance = $max - $min;
+	return $min + floor($distance * ($seed / PHP_INT_MAX) );
 }
 
 /**


### PR DESCRIPTION
 - added PHP7's CSPRNGs
 - checking the `$crypto_strong` parameter of `openssl_random_pseudo_bytes()`
 - `secure_seed_rng()` returns numbers in the widest possible scope (previously maximum set for 32-bit systems, now dependent on the system)
 - sources reordered, according to https://github.com/paragonie/random_compat/blob/master/ERRATA.md

`secure_seed_rng()` can be relatively slower due to restructuring (~0.8-1.2x) and `my_rand()` 6-9x slower on PHP7 and 6-14x slower on older versions.

Related: #1815, #2292