### PR TITLE
(#2046) Force HTTPS Gravatar URLs + Consistent URLs

### DIFF
--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -645,7 +645,7 @@ if($mybb->input['action'] == "edit")
 					$maxheight = (int)$maxwidth;
 
 					$extra_user_updates = array(
-						"avatar" => "http://www.gravatar.com/avatar/{$email}{$s}",
+						"avatar" => "https://www.gravatar.com/avatar/{$email}{$s}",
 						"avatardimensions" => "{$maxheight}|{$maxheight}",
 						"avatartype" => "gravatar"
 					);

--- a/usercp.php
+++ b/usercp.php
@@ -2151,7 +2151,7 @@ if($mybb->input['action'] == "do_avatar" && $mybb->request_method == "post")
 			$s = "?s={$maxheight}&r={$rating}&d=mm";
 
 			$updated_avatar = array(
-				"avatar" => "http://www.gravatar.com/avatar/{$email}{$s}.jpg",
+				"avatar" => "https://www.gravatar.com/avatar/{$email}{$s}",
 				"avatardimensions" => "{$maxheight}|{$maxheight}",
 				"avatartype" => "gravatar"
 			);


### PR DESCRIPTION
Forces all Gravatars to HTTPS and changes usercp.php
to remove the .jpg extension from its Gravatar URL because
that was inconsistent with the admin/modules/user/users.php
version and wasted characters.

Signed-off-by: Josh Harmon <me@joshharmon.me>