### PR TITLE
Change protocol-relative embeds to HTTPS-default

### DIFF
--- a/jscripts/bbcodes_sceditor.js
+++ b/jscripts/bbcodes_sceditor.js
@@ -459,7 +459,7 @@ $(document).ready(function($) {
 				{
 					case 'dailymotion':
 						matches = content.match(/dailymotion\.com\/video\/([^_]+)/);
-						url     = matches ? 'http://www.dailymotion.com/embed/video/' + matches[1] : false;
+						url     = matches ? 'https://www.dailymotion.com/embed/video/' + matches[1] : false;
 						break;
 					case 'facebook':
 						matches = content.match(/facebook\.com\/(?:photo.php\?v=|video\/video.php\?v=|video\/embed\?video_id=|v\/?)(\d+)/);
@@ -475,15 +475,15 @@ $(document).ready(function($) {
 						break;
 					case 'veoh':
 						matches = content.match(/veoh\.com\/watch\/([^\/]+)/);
-						url     = matches ? '//www.veoh.com/swf/webplayer/WebPlayer.swf?videoAutoPlay=0&permalinkId=' + matches[1] : false;
+						url     = matches ? 'https://www.veoh.com/swf/webplayer/WebPlayer.swf?videoAutoPlay=0&permalinkId=' + matches[1] : false;
 						break;
 					case 'vimeo':
 						matches = content.match(/vimeo.com\/(\d+)($|\/)/);
-						url     = matches ? '//player.vimeo.com/video/' + matches[1] : false;
+						url     = matches ? 'https://player.vimeo.com/video/' + matches[1] : false;
 						break;
 					case 'youtube':
 						matches = content.match(/(?:v=|v\/|embed\/|youtu\.be\/)(.{11})/);
-						url     = matches ? '//www.youtube.com/embed/' + matches[1] : false;
+						url     = matches ? 'https://www.youtube.com/embed/' + matches[1] : false;
 						break;
 				}
 


### PR DESCRIPTION
Changes jscripts/bbcodes_sceditor.js to use https URLs instead of
protocol-relative URLs. There is no technical reason to not use
secure versions of resources, as unless one is in the middle of a
man-in-the-middle attack, their request is sent much more securely.

If the user is in a MITM scenario, they're already out of luck with
the protocol-relative URLs. That's not the point of this change.
They're out of luck even with this change -- I get that.

Most users are not under active MITM attacks, and most forums are not
running a TLS configuration. As a result, users' resource requests
effectively get downgraded to HTTP for no reason, exposing request
metadata that may pose privacy risks.

Signed-off-by: Josh Harmon <me@joshharmon.me>

EDIT: I don't know if there's an issue existing for this, and was unable to turn anything up in searches. I know we've talked about this before though.