### PR TITLE
Fixes #2287 Prefix - Staff Only = Uneditable

### DIFF
--- a/editpost.php
+++ b/editpost.php
@@ -844,7 +844,7 @@ if(!$mybb->input['action'] || $mybb->input['action'] == "editpost")
 			$mybb->input['threadprefix'] = $thread['prefix'];
 		}
 
-		$prefixselect = build_prefix_select($forum['fid'], $mybb->get_input('threadprefix', MyBB::INPUT_INT));
+		$prefixselect = build_prefix_select($forum['fid'], $mybb->get_input('threadprefix', MyBB::INPUT_INT), 0, $thread['prefix']);
 	}
 	else
 	{

--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -626,6 +626,12 @@ class PostDataHandler extends DataHandler
 		}
 		else
 		{
+			if(!empty($this->data['tid']))
+			{
+				// Fetch the thread
+				$thread = get_thread($this->data['tid']);
+			}
+
 			$prefix_cache = build_prefixes($prefix);
 
 			if(empty($prefix_cache))
@@ -645,7 +651,7 @@ class PostDataHandler extends DataHandler
 					$user = get_user($this->data['uid']);
 				}
 
-				if(!is_member($prefix_cache['groups'], array('usergroup' => $user['usergroup'], 'additionalgroups' => $user['additionalgroups'])))
+				if(!is_member($prefix_cache['groups'], array('usergroup' => $user['usergroup'], 'additionalgroups' => $user['additionalgroups'])) && (empty($this->data['tid']) || $prefix != $thread['prefix']))
 				{
 					$this->set_error('invalid_prefix');
 					return false;
@@ -656,7 +662,7 @@ class PostDataHandler extends DataHandler
 				// Decide whether this prefix can be used in our forum
 				$forums = explode(",", $prefix_cache['forums']);
 
-				if(!in_array($this->data['fid'], $forums))
+				if(!in_array($this->data['fid'], $forums) && (empty($this->data['tid']) || $prefix != $thread['prefix']))
 				{
 					$this->set_error('invalid_prefix');
 					return false;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3507,9 +3507,10 @@ function build_prefixes($pid=0)
  *  @param int|string $fid The forum ID (integer ID or string all)
  *  @param int|string $selected_pid The selected prefix ID (integer ID or string any)
  *  @param int $multiple Allow multiple prefix selection
+ *  @param int $previous_pid The previously selected prefix ID
  *  @return string The thread prefix selection menu
  */
-function build_prefix_select($fid, $selected_pid=0, $multiple=0)
+function build_prefix_select($fid, $selected_pid=0, $multiple=0, $previous_pid=0)
 {
 	global $cache, $db, $lang, $mybb, $templates;
 
@@ -3544,14 +3545,14 @@ function build_prefix_select($fid, $selected_pid=0, $multiple=0)
 			// Decide whether this prefix can be used in our forum
 			$forums = explode(",", $prefix['forums']);
 
-			if(!in_array($fid, $forums))
+			if(!in_array($fid, $forums) && $prefix['pid'] != $previous_pid)
 			{
 				// This prefix is not in our forum list
 				continue;
 			}
 		}
 
-		if($prefix['groups'] != "-1")
+		if($prefix['groups'] != "-1" && $prefix['pid'] != $previous_pid)
 		{
 			$prefix_groups = explode(",", $prefix['groups']);
 


### PR DESCRIPTION
It makes the original prefix available regardless of permissions when editing a thread.

Fixes #2287