### PR TITLE
Fixes #2142 Hide "Last Post" for password-protected forums by default

### DIFF
--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -184,8 +184,8 @@ function build_forumbits($pid=0, $depth=1)
 				);
 			}
 
-			// If the current forums lastpost is greater than other child forums of the current parent, overwrite it
-			if(!isset($parent_lastpost) || $lastpost_data['lastpost'] > $parent_lastpost['lastpost'])
+			// If the current forums lastpost is greater than other child forums of the current parent and forum info isn't hidden, overwrite it
+			if((!isset($parent_lastpost) || $lastpost_data['lastpost'] > $parent_lastpost['lastpost']) && $hideinfo != true)
 			{
 				$parent_lastpost = $lastpost_data;
 			}


### PR DESCRIPTION
Fixes #2142

Subforums which are password protected won't show up in the lastpost info of the parent forum unless you have filled out the password.