### PR TITLE
Better fix for #2057 - PM folders not translated

### DIFF
--- a/usercp.php
+++ b/usercp.php
@@ -42,6 +42,12 @@ if($mybb->user['uid'] == 0 || $mybb->usergroup['canusercp'] == 0)
 	error_no_permission();
 }
 
+if(!$mybb->user['pmfolders'])
+{
+	$mybb->user['pmfolders'] = '1**$%%$2**$%%$3**$%%$4**';
+	$db->update_query('users', array('pmfolders' => $mybb->user['pmfolders']), "uid = {$mybb->user['uid']}");
+}
+
 $errors = '';
 
 $mybb->input['action'] = $mybb->get_input('action');


### PR DESCRIPTION
Used the more proper `private.php` code instead of removing it completely, which may result in new users being confused about lack of folders in menu after visiting `usercp.php` directly.

https://github.com/mybb/mybb/issues/2057