### PR TITLE
Fix #2022: Enable opening/closing threads again by replying

### DIFF
--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -894,16 +894,16 @@ class PostDataHandler extends DataHandler
 				$modoptions_update = array();
 
 				// Close the thread.
-				if($modoptions['closethread'] == 1 && $thread['closed'] != 1)
+				if($modoptions['closethread'] == 1 && $closed != 1)
 				{
-					$modoptions_update['closed'] = $closed = 0;
+					$modoptions_update['closed'] = $closed = 1;
 					log_moderator_action($modlogdata, $lang->thread_closed);
 				}
 
 				// Open the thread.
-				if($modoptions['closethread'] != 1 && $thread['closed'] == 1)
+				if($modoptions['closethread'] != 1 && $closed == 1)
 				{
-					$modoptions_update['closed'] = $closed = 1;
+					$modoptions_update['closed'] = $closed = 0;
 					log_moderator_action($modlogdata, $lang->thread_opened);
 				}
 


### PR DESCRIPTION
This bug was introduced by #1922, and is obvious on lines 876 and 883 of that PR.

Also switch $thread['closed'] with $closed in the conditionals because (a) it's been cached for a reason, and (b) the $closed variable is being modified within them. It reads better.