### PR TITLE
Create hookable functions for password hashing

### DIFF
--- a/inc/datahandlers/login.php
+++ b/inc/datahandlers/login.php
@@ -164,8 +164,6 @@ class LoginDataHandler extends DataHandler
 
 		$user = &$this->data;
 
-		$password = md5($user['password']);
-
 		if(!$this->login_data['uid'] || $this->login_data['uid'] && !$this->login_data['salt'] && $strict == false)
 		{
 			$this->invalid_combination();
@@ -177,7 +175,7 @@ class LoginDataHandler extends DataHandler
 			{
 				// Generate a salt for this user and assume the password stored in db is a plain md5 password
 				$this->login_data['salt'] = generate_salt();
-				$this->login_data['password'] = salt_password($this->login_data['password'], $this->login_data['salt']);
+				$this->login_data['password'] = create_password_hash($this->login_data['password'], $this->login_data['salt']);
 
 				$sql_array = array(
 					"salt" => $this->login_data['salt'],
@@ -199,11 +197,9 @@ class LoginDataHandler extends DataHandler
 			}
 		}
 
-		$salted_password = md5(md5($this->login_data['salt']).$password);
-
 		$plugins->run_hooks('datahandler_login_verify_password_end', $args);
 
-		if($salted_password !== $this->login_data['password'])
+		if(!verify_user_password($this->login_data, $user['password']))
 		{
 			$this->invalid_combination(true);
 			return false;
@@ -256,7 +252,7 @@ class LoginDataHandler extends DataHandler
 		$user = &$this->data;
 
 		$options = array(
-			'fields' => array('uid', 'username', 'password', 'salt', 'loginkey', 'coppauser', 'usergroup', 'loginattempts'),
+			'fields' => '*',
 			'username_method' => (int)$settings['username_method']
 		);
 

--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -212,14 +212,11 @@ class UserDataHandler extends DataHandler
 			return false;
 		}
 
-		// MD5 the password
-		$user['md5password'] = md5($user['password']);
-
 		// Generate our salt
 		$user['salt'] = generate_salt();
 
 		// Combine the password and salt
-		$user['saltedpw'] = salt_password($user['md5password'], $user['salt']);
+		$user['saltedpw'] = create_password_hash($user['password'], $user['salt'], $user);
 
 		// Generate the user login key
 		$user['loginkey'] = generate_loginkey();

--- a/inc/functions_user.php
+++ b/inc/functions_user.php
@@ -191,16 +191,18 @@ function create_password_hash($password, $salt, $user = false)
 {
 	global $plugins;
 
-	$parameters = compact('password', 'salt', 'user');
+	$hash = null;
+
+	$parameters = compact('password', 'salt', 'user', 'hash');
 
 	if(!defined('IN_INSTALL') && !defined('IN_UPGRADE'))
 	{
 		$plugins->run_hooks('create_password_hash', $parameters);
 	}
 
-	if(is_string($parameters))
+	if(!is_null($parameters['hash']))
 	{
-		return $parameters;
+		return $parameters['hash'];
 	}
 	else
 	{
@@ -219,16 +221,18 @@ function verify_user_password($user, $password)
 {
 	global $plugins;
 
-	$parameters = compact('user', 'password');
+	$result = null;
+
+	$parameters = compact('user', 'password', 'result');
 
 	if(!defined('IN_INSTALL') && !defined('IN_UPGRADE'))
 	{
 		$plugins->run_hooks('verify_user_password', $parameters);
 	}
 
-	if(is_bool($parameters))
+	if(!is_null($parameters['result']))
 	{
-		return $parameters;
+		return $parameters['result'];
 	}
 	else
 	{


### PR DESCRIPTION
Fixes #2498

 - removed hardcoded `md5()` pre-hashing,
 - `salt_password()` marked as deprecated,
 - `create_password_hash()` and `verify_user_password()` added with new hooks, accepting the user row and raw password,
 - complete user row fetched on login attempt,
 - `my_hash_equals()` added, performing comparison using `hash_equals()` on PHP >= 5.6 or custom implementation

Session keys comparison should be also rewritten to use `my_hash_equals()` in the future.

Proof-of-concept plugin taking advantage of those changes available at: https://github.com/Devilshakerz/mybb-dvzHash