### PR TITLE
Fixes #2066 by altering the form class to allow "0" as selected value

### DIFF
--- a/admin/inc/class_form.php
+++ b/admin/inc/class_form.php
@@ -422,7 +422,7 @@ class DefaultForm
 		foreach($option_list as $value => $option)
 		{
 			$select_add = '';
-			if(!empty($selected) && ((string)$value == (string)$selected || (is_array($selected) && in_array((string)$value, $selected))))
+			if((!is_array($selected) || !empty($selected)) && ((string)$value == (string)$selected || (is_array($selected) && in_array((string)$value, $selected))))
 			{
 				$select_add = " selected=\"selected\"";
 			}

--- a/admin/modules/config/mod_tools.php
+++ b/admin/modules/config/mod_tools.php
@@ -731,7 +731,7 @@ if($mybb->input['action'] == "add_thread_tool")
 			$mybb->input['stickthread'] = '';
 		}
 
-		if(!$mybb->get_input('threadprefix', MyBB::INPUT_INT))
+		if(!isset($mybb->input['threadprefix']))
 		{
 			$mybb->input['threadprefix'] = '';
 		}


### PR DESCRIPTION
#2066 

This issue is not related to the mod tools itself but to the fact that we check `$selected` via `empty` where PHP interprets `0` as empty. This makes sure that `$selected` is really an empty array otherwise we check the proper value which allows to select rows with `$value == 0`.