### PR TITLE
Implementation for fallbacks for empty email-address fields.

### DIFF
--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -118,9 +118,11 @@ class MailHandler
 		{
 			$email = $mybb->settings['returnemail'];
 		}
-		else
+		else if(trim($mybb->settings['adminemail']))
 		{
 			$email = $mybb->settings['adminemail'];
+		}else{
+			$email = @ini_get('sendmail_from');
 		}
 		
 		return $email;

--- a/inc/mailhandlers/php.php
+++ b/inc/mailhandlers/php.php
@@ -46,7 +46,7 @@ class PhpMail extends MailHandler
 
 		// Some mail providers ignore email's with incorrect return-to path's so try and fix that here
 		$this->sendmail_from = @ini_get('sendmail_from');
-		if($this->sendmail_from != $mybb->settings['adminemail'])
+		if($this->sendmail_from != $mybb->settings['adminemail'] && !empty(trim($mybb->settings['adminemail'])))
 		{
 			@ini_set("sendmail_from", $mybb->settings['adminemail']);
 		}


### PR DESCRIPTION
Prevents phpmail error due to empty adminmail and falls back to sendmail_from value if adminmail and return mail are missing.