### PR TITLE
Fixes #2299 - Missing setting descriptions in ACP

### DIFF
--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -1408,7 +1408,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="maxattachments">
 			<title>Maximum Attachments Per Post</title>
-			<description><![CDATA[The maximum number of attachments a user is allowed to upload per post. Set to 0 disable.]]></description>
+			<description><![CDATA[The maximum number of attachments a user is allowed to upload per post. Set to 0 to disable.]]></description>
 			<disporder>2</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -198,7 +198,7 @@ email=Sent via Email]]></optionscode>
 		</setting>
 		<setting name="showlanguageselect">
 			<title>Show Language Selector in Footer</title>
-			<description><![CDATA[Set to no if you do not want to show the language selection area in the footer of all pages in the board. If you only have one language installed this setting will be ignored.]]></description>
+			<description><![CDATA[Set to No if you do not want to show the language selection area in the footer of all pages in the board. If you only have one language installed this setting will be ignored.]]></description>
 			<disporder>8</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -206,7 +206,7 @@ email=Sent via Email]]></optionscode>
 		</setting>
 		<setting name="showthemeselect">
 			<title>Show Theme Selector in Footer</title>
-			<description><![CDATA[Set to no if you do not want to show the theme selection area in the footer of all pages in the board.]]></description>
+			<description><![CDATA[Set to No if you do not want to show the theme selection area in the footer of all pages in the board.]]></description>
 			<disporder>9</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -214,7 +214,7 @@ email=Sent via Email]]></optionscode>
 		</setting>
 		<setting name="maxmultipagelinks">
 			<title>Maximum Page Links in Pagination</title>
-			<description><![CDATA[Here you can set the number of next and previous page links to show in the pagination for threads or forums with more than one page of results.]]></description>
+			<description><![CDATA[Here you can set the number of next and previous page links to show in the pagination for threads or forums with more than one page of results. Set to 0 to disable the limitation.]]></description>
 			<disporder>10</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>
@@ -231,7 +231,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="no_plugins">
 			<title>Disable All Plugins</title>
-			<description><![CDATA[Setting this to yes will disable all plugins without deactivating or uninstalling them. This is equivalent of manually defining NO_PLUGINS at the top of ./inc/init.php.]]></description>
+			<description><![CDATA[Setting this to Yes will disable all plugins without deactivating or uninstalling them. This is equivalent of manually defining NO_PLUGINS at the top of ./inc/init.php.]]></description>
 			<disporder>12</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -393,7 +393,7 @@ none=Hide Errors and Warnings
 		</setting>
 		<setting name="ip_forwarded_check">
 			<title>Scrutinize User's IP address?</title>
-			<description><![CDATA[Do you want to check a user's IP address for HTTP_X_FORWARDED_FOR or HTTP_X_REAL_IP headers? If you're unsure, set this to no.]]></description>
+			<description><![CDATA[Do you want to check a user's IP address for HTTP_X_FORWARDED_FOR or HTTP_X_REAL_IP headers? If you're unsure, set this to No.]]></description>
 			<disporder>15</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -401,7 +401,7 @@ none=Hide Errors and Warnings
 		</setting>
 		<setting name="minifycss">
 			<title>Minify Stylesheets?</title>
-			<description><![CDATA[Do you want to minify stylesheets? Choosing yes can save bandwidth and overall provide faster page loads.]]></description>
+			<description><![CDATA[Do you want to minify stylesheets? Choosing Yes can save bandwidth and overall provide faster page loads.]]></description>
 			<disporder>16</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -616,7 +616,7 @@ min=0]]></optionscode>
 	<settinggroup name="forumdisplay" title="Forum Display Options" description="This section allows you to manage the various settings used on the forum display (forumdisplay.php) of your boards such as enabling and disabling different features." disporder="7" isdefault="1">
 		<setting name="threadsperpage">
 			<title>Threads Per Page</title>
-			<description><![CDATA[The number of threads to display per page on the forum display]]></description>
+			<description><![CDATA[The number of threads to display per page on the forum display.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>
@@ -684,7 +684,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="readparentforums">
 			<title>Attempt to Mark Parent Forums as Read</title>
-			<description><![CDATA[When set to yes, this setting will attempt to mark the parent forums of a sub-forum as read if there are no more unread posts. Please note that this setting can lead to a decrease in performance and multiple database queries and therefore must be treated as experimental. See the <a href="https://docs.mybb.com/versions/1.6.5/">MyBB Docs</a> for more information regarding this change.]]></description>
+			<description><![CDATA[When set to Yes, this setting will attempt to mark the parent forums of a sub-forum as read if there are no more unread posts. Please note that this setting can lead to a decrease in performance and multiple database queries and therefore must be treated as experimental. See the <a href="https://docs.mybb.com/versions/1.6.5/">MyBB Docs</a> for more information regarding this change.]]></description>
 			<disporder>9</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -738,7 +738,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="threadusenetstyle">
 			<title>Usenet Style Thread View</title>
-			<description><![CDATA[Selecting yes will cause posts to look similar to how posts look in USENET. No will cause posts to look the modern way.]]></description>
+			<description><![CDATA[Selecting Yes will cause posts to look similar to how posts look in USENET. No will cause posts to look the modern way.]]></description>
 			<disporder>6</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -843,7 +843,7 @@ both=Email Verification & Administrator Activation]]></optionscode>
 		</setting>
 		<setting name="forcelogin">
 			<title>Force Users to Login</title>
-			<description><![CDATA[Setting this to yes will force guests to login or register in order to access the board.]]></description>
+			<description><![CDATA[Setting this to Yes will force guests to login or register in order to access the board.]]></description>
 			<disporder>4</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -895,7 +895,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="betweenregstime">
 			<title>Time Between Registrations</title>
-			<description><![CDATA[The amount of time (in hours) to disallow registrations for users who have already registered an account under the same ip address. 0 to disable.]]></description>
+			<description><![CDATA[The amount of time (in hours) to disallow registrations for users who have already registered an account under the same IP address. Set to 0 to disable.]]></description>
 			<disporder>10</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -913,7 +913,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="allowmultipleemails">
 			<title><![CDATA[Allow emails to be registered multiple times?]]></title>
-			<description><![CDATA[Select yes if you wish to allow users to sign up with the same email more than once otherwise select no.]]></description>
+			<description><![CDATA[Select Yes if you wish to allow users to sign up with the same email more than once otherwise select No.]]></description>
 			<disporder>12</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -976,7 +976,7 @@ disabled=Disable this feature]]></optionscode>
 		</setting>
 		<setting name="failedcaptchalogincount">
 			<title>Number of failed logins before verification required</title>
-			<description><![CDATA[The number of times to allow someone to attempt to login before required to enter a CAPTCHA verification. 0 to disable]]></description>
+			<description><![CDATA[The number of times to allow someone to attempt to login before required to enter a CAPTCHA verification. Set to 0 to disable]]></description>
 			<disporder>19</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -985,7 +985,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="failedlogincount">
 			<title>Number of times to allow failed logins</title>
-			<description><![CDATA[The number of times to allow someone to attempt to login. 0 to disable.]]></description>
+			<description><![CDATA[The number of times to allow someone to attempt to login. Set to 0 to disable.]]></description>
 			<disporder>20</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -1079,7 +1079,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="siglength">
 			<title>Length limit in Signatures</title>
-			<description><![CDATA[The maximum number of characters a user can place in a signature.]]></description>
+			<description><![CDATA[The maximum number of characters a user can place in a signature. Set to 0 to disable the limitation.]]></description>
 			<disporder>7</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -1147,7 +1147,7 @@ x=X]]></optionscode>
 		</setting>
 		<setting name="avatarsize">
 			<title>Max Uploaded Avatar Size</title>
-			<description><![CDATA[Maximum file size (in kilobytes) of uploaded avatars.]]></description>
+			<description><![CDATA[Maximum file size (in kilobytes) of uploaded avatars. Set to 0 to disable the limitation.]]></description>
 			<disporder>14</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>
@@ -1175,7 +1175,7 @@ disabled=Disable this feature]]></optionscode>
 		</setting>
 		<setting name="customtitlemaxlength">
 			<title>Custom User Title Maximum Length</title>
-			<description><![CDATA[Maximum length a user can enter for the custom user title.]]></description>
+			<description><![CDATA[Maximum length a user can enter for the custom user title. Set to 0 to disable the limitation.]]></description>
 			<disporder>17</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -1347,7 +1347,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="polloptionlimit">
 			<title>Maximum Poll Option Length</title>
-			<description><![CDATA[The maximum length that each poll option can be. (Set to 0 to disable).]]></description>
+			<description><![CDATA[The maximum length that each poll option can be. Set to 0 to disable.]]></description>
 			<disporder>17</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -1356,7 +1356,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="maxpolloptions">
 			<title>Maximum Number of Poll Options</title>
-			<description><![CDATA[The maximum number of options for polls that users can post.]]></description>
+			<description><![CDATA[The maximum number of options for polls that users can post. Set to 0 to disable the limitation.]]></description>
 			<disporder>18</disporder>
 			<optionscode><![CDATA[numeric
 min=2]]></optionscode>
@@ -1400,7 +1400,7 @@ min=0]]></optionscode>
 	<settinggroup name="attachments" title="Attachments" description="Various options related to the attachment system can be managed and set here." disporder="12" isdefault="1">
 		<setting name="enableattachments">
 			<title>Enable Attachment Functionality</title>
-			<description><![CDATA[If you wish to disable attachments on your board, set this option to no.]]></description>
+			<description><![CDATA[If you wish to disable attachments on your board, set this option to No.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1408,7 +1408,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="maxattachments">
 			<title>Maximum Attachments Per Post</title>
-			<description><![CDATA[The maximum number of attachments a user is allowed to upload per post.]]></description>
+			<description><![CDATA[The maximum number of attachments a user is allowed to upload per post. Set to 0 disable.]]></description>
 			<disporder>2</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>
@@ -1448,7 +1448,7 @@ min=1]]></optionscode>
 	<settinggroup name="memberlist" title="Member List" description="This section allows you to control various aspects of the board member listing (memberlist.php), such as how many members to show per page, and which features to enable or disable." disporder="13" isdefault="1">
 		<setting name="enablememberlist">
 			<title>Enable Member List Functionality</title>
-			<description><![CDATA[If you wish to disable the member list on your board, set this option to no.]]></description>
+			<description><![CDATA[If you wish to disable the member list on your board, set this option to No.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1497,7 +1497,7 @@ descending=Descending]]></optionscode>
 	<settinggroup name="reputation" title="Reputation" description="The reputation system allows your users to rate others and leave a comment on the user. This section has settings to disable and change other aspects of the reputation page (reputation.php)." disporder="14" isdefault="1">
 		<setting name="enablereputation">
 			<title>Enable Reputation Functionality</title>
-			<description><![CDATA[If you wish to disable the reputation system on your board, set this option to no.]]></description>
+			<description><![CDATA[If you wish to disable the reputation system on your board, set this option to No.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1545,7 +1545,7 @@ descending=Descending]]></optionscode>
 		</setting>
 		<setting name="repsperpage">
 			<title>Reputation Comments Per Page</title>
-			<description><![CDATA[Here you can enter the number of reputation comments to show per page on the reputation system]]></description>
+			<description><![CDATA[Here you can enter the number of reputation comments to show per page on the reputation system.]]></description>
 			<disporder>7</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>
@@ -1574,7 +1574,7 @@ min=1]]></optionscode>
 	<settinggroup name="warning" title="Warning System Settings" description="The warning system allows forum staff to warn users for rule violations. Here you can manage the settings that control the warning system (warnings.php)." disporder="15" isdefault="1">
 		<setting name="enablewarningsystem">
 			<title>Enable Warning System?</title>
-			<description><![CDATA[Set to no to completely disable the warning system.]]></description>
+			<description><![CDATA[Set to No to completely disable the warning system.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1590,7 +1590,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="canviewownwarning">
 			<title>Can Users View Own Warnings?</title>
-			<description><![CDATA[Set to yes to allow users to view recent warnings in their User CP and show their warning level to them in their profile.]]></description>
+			<description><![CDATA[Set to Yes to allow users to view recent warnings in their User CP and show their warning level to them in their profile.]]></description>
 			<disporder>3</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1617,7 +1617,7 @@ min=1]]></optionscode>
 	<settinggroup name="privatemessaging" title="Private Messaging" description="Various options with relation to the MyBB Private Messaging system (private.php) can be managed and set here." disporder="16" isdefault="1">
 		<setting name="enablepms">
 			<title>Enable Private Messaging Functionality</title>
-			<description><![CDATA[If you wish to disable the private messaging system on your board, set this option to no.]]></description>
+			<description><![CDATA[If you wish to disable the private messaging system on your board, set this option to No.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1633,7 +1633,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="pmsallowhtml">
 			<title>Allow HTML</title>
-			<description><![CDATA[Selecting yes will allow HTML to be used in private messages.]]></description>
+			<description><![CDATA[Selecting Yes will allow HTML to be used in private messages.]]></description>
 			<disporder>3</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -1641,7 +1641,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="pmsallowmycode">
 			<title>Allow MyCode</title>
-			<description><![CDATA[Selecting yes will allow MyCode to be used in private messages.]]></description>
+			<description><![CDATA[Selecting Yes will allow MyCode to be used in private messages.]]></description>
 			<disporder>4</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1649,7 +1649,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="pmsallowsmilies">
 			<title>Allow Smilies</title>
-			<description><![CDATA[Selecting yes will allow Smilies to be used in private messages.]]></description>
+			<description><![CDATA[Selecting Yes will allow Smilies to be used in private messages.]]></description>
 			<disporder>5</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1657,7 +1657,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="pmsallowimgcode">
 			<title>Allow [img] Code</title>
-			<description><![CDATA[Selecting yes will allow [img] Code to be used in private messages.]]></description>
+			<description><![CDATA[Selecting Yes will allow [img] Code to be used in private messages.]]></description>
 			<disporder>6</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1665,7 +1665,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="pmsallowvideocode">
 			<title>Allow [video] Code</title>
-			<description><![CDATA[Selecting yes will allow [video] Code to be used in private messages.]]></description>
+			<description><![CDATA[Selecting Yes will allow [video] Code to be used in private messages.]]></description>
 			<disporder>7</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1673,7 +1673,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="pmfloodsecs">
 			<title>Private Message Flood Time</title>
-			<description><![CDATA[Set the time (in seconds) users have to wait between sending messages, to be in effect; set to 0 to disable.]]></description>
+			<description><![CDATA[Set the time (in seconds) users have to wait between sending messages, to be in effect. Set to 0 to disable.]]></description>
 			<disporder>8</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -1682,7 +1682,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="showpmip">
 			<title>Show Private Message IP Addresses</title>
-			<description><![CDATA[Do you wish to show ip addresses of users who send private messages, and who you want to show ip addresses to?]]></description>
+			<description><![CDATA[Do you wish to show IP addresses of users who send private messages, and who you want to show IP addresses to?]]></description>
 			<disporder>9</disporder>
 			<optionscode><![CDATA[radio
 no=Do not show IP
@@ -1704,7 +1704,7 @@ min=0]]></optionscode>
 	<settinggroup name="calendar" title="Calendar" description="The board calendar allows the public and private listing of events and members' birthdays. This section allows you to control and manage the settings for the Calendar (calendar.php)." disporder="17" isdefault="1">
 		<setting name="enablecalendar">
 			<title>Enable Calendar Functionality</title>
-			<description><![CDATA[If you wish to disable the calendar on your board, set this option to no.]]></description>
+			<description><![CDATA[If you wish to disable the calendar on your board, set this option to No.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1769,7 +1769,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="prunepostcountall">
 			<title>Count all posts?</title>
-			<description><![CDATA[If set to yes, posts from forums which don't increase users' post count will also be considered while pruning.]]></description>
+			<description><![CDATA[If set to Yes, posts from forums which don't increase users' post count will also be considered while pruning.]]></description>
 			<disporder>4</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -1813,7 +1813,7 @@ min=0]]></optionscode>
 	<settinggroup name="portal" title="Portal Settings" description="The portal page compiles several different pieces of information about your forum, including latest posts, who's online, forum stats, announcements, and more. This section has settings to control the aspects of the portal page (portal.php)." disporder="20" isdefault="1">
 		<setting name="portal">
 			<title>Enable Portal</title>
-			<description><![CDATA[If you wish to disable the portal on your board, set this option to no.]]></description>
+			<description><![CDATA[If you wish to disable the portal on your board, set this option to No.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -1932,7 +1932,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="searchhardlimit">
 			<title>Hard Limit for Maximum Search Results</title>
-			<description><![CDATA[Enter the maximum amount of results to be processed. Set to 0 to disable. On larger boards (more than 1 million posts) this should be set to no more than 1000.]]></description>
+			<description><![CDATA[Enter the maximum amount of results to be processed. Set to 0 to disable. On larger boards (more than 1 million posts) this should be set to No more than 1000.]]></description>
 			<disporder>4</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -1959,7 +1959,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="partialmode">
 			<title>Clickable MyCode Editor in Partial Mode</title>
-			<description><![CDATA[Editor will be in partial mode if this option is set to 'yes'. Several MyCodes, such as [quote] and [img], will be inserted into it as plain text tags.]]></description>
+			<description><![CDATA[Editor will be in partial mode if this option is set to Yes. Several MyCodes, such as [quote] and [img], will be inserted into it as plain text tags.]]></description>
 			<disporder>2</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -1993,7 +1993,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowbasicmycode">
 			<title>Allow Basic MyCodes</title>
-			<description><![CDATA[Setting this to yes allows users to use the basic MyCodes, such as Bold, Italic, Underline, Strike-through and HR.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the basic MyCodes, such as Bold, Italic, Underline, Strike-through and HR.]]></description>
 			<disporder>6</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2001,7 +2001,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowcolormycode">
 			<title>Allow Color MyCode</title>
-			<description><![CDATA[Setting this to yes allows users to use the Color MyCode.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the Color MyCode.]]></description>
 			<disporder>7</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2009,7 +2009,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowsizemycode">
 			<title>Allow Size MyCode</title>
-			<description><![CDATA[Setting this to yes allows users to use the Size MyCode]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the Size MyCode]]></description>
 			<disporder>8</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2017,7 +2017,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowfontmycode">
 			<title>Allow Font MyCode</title>
-			<description><![CDATA[Setting this to yes allows users to use the Font MyCode.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the Font MyCode.]]></description>
 			<disporder>9</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2025,7 +2025,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowlinkmycode">
 			<title>Allow Link MyCode</title>
-			<description><![CDATA[Setting this to yes allows users to use the URL MyCode.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the URL MyCode.]]></description>
 			<disporder>10</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2033,7 +2033,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowemailmycode">
 			<title>Allow Email MyCode</title>
-			<description><![CDATA[Setting this to yes allows users to use the Email MyCode.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the Email MyCode.]]></description>
 			<disporder>11</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2041,7 +2041,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowalignmycode">
 			<title>Allow Alignment MyCode</title>
-			<description><![CDATA[Setting this to yes allows users to use the Align MyCode.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the Align MyCode.]]></description>
 			<disporder>12</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2049,7 +2049,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowlistmycode">
 			<title>Allow List MyCode</title>
-			<description><![CDATA[Setting this to yes allows users to use the List MyCode.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the List MyCode.]]></description>
 			<disporder>13</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2057,7 +2057,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowcodemycode">
 			<title>Allow Code MyCodes</title>
-			<description><![CDATA[Setting this to yes allows users to use the Code and PHP MyCodes.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the Code and PHP MyCodes.]]></description>
 			<disporder>14</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2065,7 +2065,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowsymbolmycode">
 			<title>Allow Symbol MyCodes</title>
-			<description><![CDATA[Setting this to yes allows users to use the (tm), (c) and (r) MyCodes.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the (tm), (c) and (r) MyCodes.]]></description>
 			<disporder>15</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2073,7 +2073,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="allowmemycode">
 			<title>Allow Me MyCodes</title>
-			<description><![CDATA[Setting this to yes allows users to use the /me and /slap MyCodes.]]></description>
+			<description><![CDATA[Setting this to Yes allows users to use the /me and /slap MyCodes.]]></description>
 			<disporder>16</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2081,7 +2081,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="guestimages">
 			<title>Parse [img] MyCode To Guests</title>
-			<description><![CDATA[Setting this to yes will parse posted images to guests. If no, a link will be shown instead.]]></description>
+			<description><![CDATA[Setting this to Yes will parse posted images to guests. If No, a link will be shown instead.]]></description>
 			<disporder>17</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2089,7 +2089,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="guestvideos">
 			<title>Parse [video] MyCode To Guests</title>
-			<description><![CDATA[Setting this to yes will parse posted videos to guests. If no, a link will be shown instead.]]></description>
+			<description><![CDATA[Setting this to Yes will parse posted videos to guests. If No, a link will be shown instead.]]></description>
 			<disporder>18</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2124,7 +2124,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="loginattemptstimeout">
 			<title>Login Attempts Timeout</title>
-			<description><![CDATA[If the person trying to login reaches the max number of attempts, how long should they have to wait before being able to login again? (Set in minutes)]]></description>
+			<description><![CDATA[If the person trying to login reaches the max number of attempts, how long should they have to wait before being able to login again (in minutes)? Set to 0 to disable.]]></description>
 			<disporder>4</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>
@@ -2217,7 +2217,7 @@ smtp=SMTP mail]]></optionscode>
 	<settinggroup name="contactsettings" title="Contact Settings" description="The various options to change the behaviour of the contact page (contact.php)." disporder="25" isdefault="1">
 		<setting name="contact">
 			<title>Enable Contact Page</title>
-			<description><![CDATA[Setting this to yes will allow access to the contact page.]]></description>
+			<description><![CDATA[Setting this to Yes will allow access to the contact page.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2225,7 +2225,7 @@ smtp=SMTP mail]]></optionscode>
 		</setting>
 		<setting name="contact_guests">
 			<title>Disable Contact Page to Guests</title>
-			<description><![CDATA[Setting this to yes will disallow access to the contact page for guests.]]></description>
+			<description><![CDATA[Setting this to Yes will disallow access to the contact page for guests.]]></description>
 			<disporder>2</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
@@ -2233,7 +2233,7 @@ smtp=SMTP mail]]></optionscode>
 		</setting>
 		<setting name="contact_badwords">
 			<title>Enable Word Filter on Contact Page</title>
-			<description><![CDATA[Setting this to yes will will send the subject and message fields through the word filter before sending.]]></description>
+			<description><![CDATA[Setting this to Yes will will send the subject and message fields through the word filter before sending.]]></description>
 			<disporder>3</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2468,7 +2468,7 @@ delete=Delete]]></optionscode>
 	<settinggroup name="statspage" title="Statistics Page" description="This section allows you to change the settings of the statistics page." disporder="28" isdefault="1">
 		<setting name="statsenabled">
 			<title>Enable Statistics Pages</title>
-			<description><![CDATA[If you wish to disable the statistics page on your board, set this option to no.]]></description>
+			<description><![CDATA[If you wish to disable the statistics page on your board, set this option to No.]]></description>
 			<disporder>1</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
@@ -2477,7 +2477,7 @@ delete=Delete]]></optionscode>
 		</setting>
 		<setting name="statscachetime">
 			<title>Statistics Cache Time</title>
-			<description><![CDATA[Insert the interval of time to refresh the statistics page cache (in hours). 0 to disable caching.]]></description>
+			<description><![CDATA[Insert the interval of time to refresh the statistics page cache (in hours). Set to 0 to disable caching.]]></description>
 			<disporder>2</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>
@@ -2487,7 +2487,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="statslimit">
 			<title>Stats Limit</title>
-			<description><![CDATA[The number of threads to show on the stats page for most replies and most views.]]></description>
+			<description><![CDATA[The number of threads to show on the stats page for most replies and most views. Set to 0 to disable.]]></description>
 			<disporder>3</disporder>
 			<optionscode><![CDATA[numeric
 min=0]]></optionscode>


### PR DESCRIPTION
Fixes #2299 - Missing setting desctriptions in ACP

@JN-Jones @PaulBender @Destroy666x @dequeues 

I am not sure about these: setting in L around n. 217 and 1411

Please review it carefully, I will try my best to find them all and fix the missing descriptions.
