### PR TITLE
Fixes #2497 - Missing lang string for "time" in moderation

### DIFF
--- a/inc/languages/english/moderation.lang.php
+++ b/inc/languages/english/moderation.lang.php
@@ -81,6 +81,7 @@ $l['post_separator'] = "Post Separator";
 $l['new_line'] = "New Line";
 $l['horizontal_rule'] = "Horizontal Rule";
 $l['resolve_fail'] = "N/A (Unable to resolve)";
+$l['time'] = "Time:";
 
 $l['opened'] = "Opened";
 $l['closed'] = "Closed";


### PR DESCRIPTION
Fixes #2497 - Missing lang string for "time" in moderation