### PR TITLE
Fix #2522 - Links executing JS functions should return false and point to javascript.void(0) instead of hashtags

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3922,7 +3922,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 {$forums}
 </table>
 <br />]]></template>
-		<template name="forumdisplay_thread" version="1801"><![CDATA[<tr class="inline_row">
+		<template name="forumdisplay_thread" version="1809"><![CDATA[<tr class="inline_row">
 	<td align="center" class="{$bgcolor}{$thread_type_class}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}{$thread_type_class}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}{$thread_type_class}">
@@ -4947,7 +4947,7 @@ if(use_xmlhttprequest == "1")
 </ul>
 </td>
 </tr>]]></template>
-		<template name="member_profile_modoptions_viewnotes" version="1801"><![CDATA[[<a href="javascript:void(0)" onclick="MyBB.viewNotes({$memprofile['uid']}); return false;">{$lang->view_all_notes}</a>]]]></template>
+		<template name="member_profile_modoptions_viewnotes" version="1809"><![CDATA[[<a href="javascript:void(0)" onclick="MyBB.viewNotes({$memprofile['uid']}); return false;">{$lang->view_all_notes}</a>]]]></template>
 		<template name="member_profile_offline" version="1400"><![CDATA[<span class="offline" style="font-weight: bold;">{$lang->postbit_status_offline}</span>]]></template>
 		<template name="member_profile_online" version="1400"><![CDATA[<a href="online.php"><span class="online" style="font-weight: bold;">{$lang->postbit_status_online}</span></a> ({$location} @ {$location_time})]]></template>
 		<template name="member_profile_pm" version="1800"><![CDATA[<tr>
@@ -4962,7 +4962,7 @@ if(use_xmlhttprequest == "1")
 	<td class="{$bg_color}"><strong>{$lang->reputation}</strong></td>
 	<td class="{$bg_color}">{$reputation} [<a href="reputation.php?uid={$memprofile['uid']}">{$lang->reputation_details}</a>] {$vote_link}</td>
 </tr>]]></template>
-		<template name="member_profile_reputation_vote" version="1801"><![CDATA[[<a href="javascript:void(0)" onclick="MyBB.reputation({$memprofile['uid']}); return false;">{$lang->reputation_vote}</a>]]]></template>
+		<template name="member_profile_reputation_vote" version="1809"><![CDATA[[<a href="javascript:void(0)" onclick="MyBB.reputation({$memprofile['uid']}); return false;">{$lang->reputation_vote}</a>]]]></template>
 		<template name="member_profile_signature" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder tfixed">
 <tr>
 <td class="thead"><strong>{$lang->users_signature}</strong></td>
@@ -8714,7 +8714,7 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>]]></template>
 		<template name="multipage_end" version="1600"><![CDATA[{$lang->multipage_link_end} <a href="{$page_url}" class="pagination_last">{$pages}</a>]]></template>
-		<template name="multipage_jump_page" version="1801"><![CDATA[<div class="popup_menu drop_go_page" style="display: none;">
+		<template name="multipage_jump_page" version="1809"><![CDATA[<div class="popup_menu drop_go_page" style="display: none;">
 	<form action="{$jump_url}" method="post">
 		<label for="page">{$lang->multipage_jump}:</label> <input type="text" class="textbox" name="page" value="{$page}" size="4" />
 		<input type="submit" class="button" value="{$lang->go}" />
@@ -8834,7 +8834,7 @@ if(use_xmlhttprequest == "1")
 <label><input type="checkbox" class="checkbox" name="modoptions[stickthread]" value="1"{$stickycheck} />&nbsp;{$lang->stick_thread}</label>
 </span></td>
 </tr>]]></template>
-		<template name="newreply_multiquote_external" version="1800"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newreply.php?tid={$tid}" onclick="return Post.loadMultiQuoted();">{$multiquote_quote}</a>, <a href="javascript:void(0)" onclick="Post.clearMultiQuoted(); return false;">{$multiquote_deselect}</a></span></div>]]></template>
+		<template name="newreply_multiquote_external" version="1809"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newreply.php?tid={$tid}" onclick="return Post.loadMultiQuoted();">{$multiquote_quote}</a>, <a href="javascript:void(0)" onclick="Post.clearMultiQuoted(); return false;">{$multiquote_deselect}</a></span></div>]]></template>
 		<template name="newreply_threadreview" version="1800"><![CDATA[<br />
 <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder tfixed">
 <tr>
@@ -8921,7 +8921,7 @@ if(use_xmlhttprequest == "1")
 <label><input type="checkbox" class="checkbox" name="postoptions[disablesmilies]" value="1" tabindex="9"{$postoptionschecked['disablesmilies']} /> {$lang->options_disablesmilies}</label>]]></template>
 		<template name="newthread_disablesmilies_hidden" version="1800"><![CDATA[<input type="hidden" name="postoptions[disablesmilies]" value="no" />]]></template>
 		<template name="newthread_draftinput" version="1808"><![CDATA[<input type="hidden" name="pid" value="{$pid}" />]]></template>
-		<template name="newthread_multiquote_external" version="1800"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newthread.php?fid={$fid}&amp;load_all_quotes=1" onclick="return Post.loadMultiQuotedAll();">{$multiquote_quote}</a>, <a href="javascript:void(0)" onclick="Post.clearMultiQuoted(); return false;">{$multiquote_deselect}</a></span></div>]]></template>
+		<template name="newthread_multiquote_external" version="1809"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newthread.php?fid={$fid}&amp;load_all_quotes=1" onclick="return Post.loadMultiQuotedAll();">{$multiquote_quote}</a>, <a href="javascript:void(0)" onclick="Post.clearMultiQuoted(); return false;">{$multiquote_deselect}</a></span></div>]]></template>
 		<template name="newthread_postpoll" version="120"><![CDATA[<tr>
 <td class="{$bgcolor2}" valign="top">
 <strong>{$lang->poll}</strong><br /><span class="smalltext">{$lang->poll_desc}</span>
@@ -9625,7 +9625,7 @@ if(use_xmlhttprequest == "1")
 		</div>
 	</div>
 </div>]]></template>
-		<template name="postbit_edit" version="1801"><![CDATA[<a href="editpost.php?pid={$post['pid']}" id="edit_post_{$post['pid']}" title="{$lang->postbit_edit}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>
+		<template name="postbit_edit" version="1809"><![CDATA[<a href="editpost.php?pid={$post['pid']}" id="edit_post_{$post['pid']}" title="{$lang->postbit_edit}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>
 <div id="edit_post_{$post['pid']}_popup" class="popup_menu" style="display: none;"><div class="popup_item_container"><a href="javascript:void(0)" class="popup_item quick_edit_button" id="quick_edit_post_{$post['pid']}">{$lang->postbit_quick_edit}</a></div><div class="popup_item_container"><a href="editpost.php?pid={$post['pid']}" class="popup_item">{$lang->postbit_full_edit}</a></div></div>
 <script type="text/javascript">
 // <!--
@@ -9659,7 +9659,7 @@ if(use_xmlhttprequest == "1")
 		<template name="postbit_inlinecheck" version="1800"><![CDATA[<input type="checkbox" class="checkbox" name="inlinemod_{$post['pid']}" id="inlinemod_{$post['pid']}" value="1" style="vertical-align: middle; margin: -2px 0 0 5px;" {$inlinecheck}  />]]></template>
 		<template name="postbit_iplogged_hiden" version="1800"><![CDATA[{$lang->postbit_ipaddress} <a href="moderation.php?action={$action}&amp;{$idtype}={$post[$idtype]}">{$lang->postbit_ipaddress_logged}</a>]]></template>
 		<template name="postbit_iplogged_show" version="1800"><![CDATA[{$lang->postbit_ipaddress} {$ipaddress}]]></template>
-		<template name="postbit_multiquote" version="1801"><![CDATA[<a href="javascript:void(0)" onclick="Thread.multiQuote({$post['pid']}); return false;" style="display: none;" id="multiquote_link_{$post['pid']}" title="{$lang->postbit_multiquote}" class="postbit_multiquote"><span id="multiquote_{$post['pid']}">{$lang->postbit_button_multiquote}</span></a>
+		<template name="postbit_multiquote" version="1809"><![CDATA[<a href="javascript:void(0)" onclick="Thread.multiQuote({$post['pid']}); return false;" style="display: none;" id="multiquote_link_{$post['pid']}" title="{$lang->postbit_multiquote}" class="postbit_multiquote"><span id="multiquote_{$post['pid']}">{$lang->postbit_button_multiquote}</span></a>
 <script type="text/javascript">
 //<!--
 	$('#multiquote_link_{$post['pid']}').css("display", "");
@@ -9690,10 +9690,10 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>]]></template>
 		<template name="postbit_quote" version="1800"><![CDATA[<a href="newreply.php?tid={$tid}&amp;replyto={$post['pid']}" title="{$lang->postbit_quote}" class="postbit_quote"><span>{$lang->postbit_button_quote}</span></a>]]></template>
-		<template name="postbit_rep_button" version="1801"><![CDATA[<a href="javascript:void(0)" onclick="MyBB.reputation({$post['uid']},{$post['pid']}); return false;" title="{$lang->postbit_reputation_add}" class="postbit_reputation_add"><span>{$lang->postbit_button_reputation_add}</span></a>]]></template>
+		<template name="postbit_rep_button" version="1809"><![CDATA[<a href="javascript:void(0)" onclick="MyBB.reputation({$post['uid']},{$post['pid']}); return false;" title="{$lang->postbit_reputation_add}" class="postbit_reputation_add"><span>{$lang->postbit_button_reputation_add}</span></a>]]></template>
 		<template name="postbit_reply_pm" version="1800"><![CDATA[<a href="private.php?action=send&amp;pmid={$id}&amp;do=reply" title="{$lang->reply_title}" class="postbit_reply_pm"><span>{$lang->postbit_button_reply_pm}</span></a>]]></template>
 		<template name="postbit_replyall_pm" version="1480"><![CDATA[<a href="private.php?action=send&amp;pmid={$id}&amp;do=replyall" title="{$lang->reply_to_all}" class="postbit_reply_all"><span>{$lang->postbit_button_reply_all}</span></a>]]></template>
-		<template name="postbit_report" version="1801"><![CDATA[<a href="javascript:void(0)" onclick="Report.reportPost({$post['pid']}); return false;" title="{$lang->postbit_report}" class="postbit_report"><span>{$lang->postbit_button_report}</span></a>]]></template>
+		<template name="postbit_report" version="1809"><![CDATA[<a href="javascript:void(0)" onclick="Report.reportPost({$post['pid']}); return false;" title="{$lang->postbit_report}" class="postbit_report"><span>{$lang->postbit_button_report}</span></a>]]></template>
 		<template name="postbit_reputation" version="1400"><![CDATA[<br />{$lang->postbit_reputation} {$post['userreputation']}]]></template>
 		<template name="postbit_reputation_formatted" version="1800"><![CDATA[<strong class="{$reputation_class}">{$reputation}</strong>]]></template>
 		<template name="postbit_reputation_formatted_link" version="1800"><![CDATA[<a href="reputation.php?uid={$uid}"><strong class="{$reputation_class}">{$reputation}</strong></a>]]></template>
@@ -10792,7 +10792,7 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 {$footer}
 </body>
 </html>]]></template>
-		<template name="reputation_add" version="1801"><![CDATA[<div class="modal">
+		<template name="reputation_add" version="1809"><![CDATA[<div class="modal">
 	<div style="overflow-y: auto; max-height: 400px;" class="modal_{$user['uid']}_{$mybb->input['pid']}">
       <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 	<tr>
@@ -10858,7 +10858,7 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 		</td>
 	</tr>
 </table>]]></template>
-		<template name="reputation_addlink" version="1801"><![CDATA[<div class="float_right" style="padding-bottom: 4px;"><a href="javascript:void(0)" onclick="MyBB.reputation({$user['uid']}); return false;" class="button rate_user_button"><span>{$lang->rate_user}</span></a></div>]]></template>
+		<template name="reputation_addlink" version="1809"><![CDATA[<div class="float_right" style="padding-bottom: 4px;"><a href="javascript:void(0)" onclick="MyBB.reputation({$user['uid']}); return false;" class="button rate_user_button"><span>{$lang->rate_user}</span></a></div>]]></template>
 		<template name="reputation_deleted" version="1800"><![CDATA[
 <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 	<tr>
@@ -10883,7 +10883,7 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 			<a href="reputation.php?action=delete&amp;uid={$reputation_vote['rated_uid']}&amp;rid={$reputation_vote['rid']}&amp;my_post_key={$mybb->post_code}" onclick="MyBB.deleteReputation({$reputation_vote['rated_uid']}, {$reputation_vote['rid']}); return false;" class="postbit_qdelete"><span>{$lang->delete_vote}</span></a>
 		</div>]]>
 		</template>
-		<template name="reputation_vote_report" version="1801"><![CDATA[		<div class="float_right postbit_buttons">
+		<template name="reputation_vote_report" version="1809"><![CDATA[		<div class="float_right postbit_buttons">
 			<a href="javascript:void(0)" onclick="Report.reportReputation({$reputation_vote['rid']}); return false;" class="postbit_report"><span>{$lang->report_vote}</span></a>
 		</div>]]>
 		</template>
@@ -11111,7 +11111,7 @@ if(use_xmlhttprequest == "1")
 		<template name="search_results_posts_inlinemoderation_custom" version="120"><![CDATA[<optgroup label="{$lang->custom_mod_tools}">{$customposttools}</optgroup>]]></template>
 		<template name="search_results_posts_inlinemoderation_custom_tool" version="120"><![CDATA[<option value="{$tool['tid']}">{$tool['name']}</option>]]></template>
 		<template name="search_results_posts_nocheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap">&nbsp;</td>]]></template>
-		<template name="search_results_posts_post" version="1808"><![CDATA[<tr class="inline_row">
+		<template name="search_results_posts_post" version="1809"><![CDATA[<tr class="inline_row">
 	<td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}">
@@ -11208,7 +11208,7 @@ if(use_xmlhttprequest == "1")
 		<template name="search_results_threads_inlinemoderation_custom" version="120"><![CDATA[<optgroup label="{$lang->custom_mod_tools}">{$customthreadtools}</optgroup>]]></template>
 		<template name="search_results_threads_inlinemoderation_custom_tool" version="120"><![CDATA[<option value="{$tool['tid']}">{$tool['name']}</option>]]></template>
 		<template name="search_results_threads_nocheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap">&nbsp;</td>]]></template>
-		<template name="search_results_threads_thread" version="1801"><![CDATA[<tr class="inline_row">
+		<template name="search_results_threads_thread" version="1809"><![CDATA[<tr class="inline_row">
 	<td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}">
@@ -11556,7 +11556,7 @@ if(use_xmlhttprequest == "1")
 </table>
 <br />]]></template>
 		<template name="showthread_poll_undovote" version="1800"><![CDATA[ [<a href="polls.php?action=do_undovote&amp;pid={$poll['pid']}&amp;my_post_key={$mybb->post_code}">{$lang->undo_vote}</a>]]]></template>
-		<template name="showthread_quickreply" version="1801"><![CDATA[
+		<template name="showthread_quickreply" version="1809"><![CDATA[
 <div id="quickreply_spinner" class="showthread_spinner" style="display: none"><img src="{$theme['imgdir']}/spinner.gif" /></div>
 <br />
 {$moderation_notice}
@@ -11651,7 +11651,7 @@ if(use_xmlhttprequest == "1")
 </tr>
 {$similarthreadbits}
 </table>]]></template>
-		<template name="showthread_similarthreads_bit" version="1801"><![CDATA[<tr>
+		<template name="showthread_similarthreads_bit" version="1809"><![CDATA[<tr>
 	<td align="center" class="{$trow}" width="2%">{$icon}</td>
 	<td class="{$trow}">{$similar_thread['threadprefix']}<a href="{$similar_thread['threadlink']}">{$similar_thread['subject']}</a></td>
 	<td align="center" class="{$trow}">{$similar_thread['profilelink']}</td>
@@ -11691,7 +11691,7 @@ if(use_xmlhttprequest == "1")
 </tbody>
 </table>
 <br />]]></template>
-		<template name="showthread_threadnotes_viewnotes" version="1801"><![CDATA[[<a href="javascript:void(0)" onclick="Thread.viewNotes({$thread['tid']}); return false;">{$lang->view_all_notes}</a>]]]></template>
+		<template name="showthread_threadnotes_viewnotes" version="1809"><![CDATA[[<a href="javascript:void(0)" onclick="Thread.viewNotes({$thread['tid']}); return false;">{$lang->view_all_notes}</a>]]]></template>
 		<template name="showthread_threadnoteslink" version="1800"><![CDATA[ | <a href="moderation.php?action=threadnotes&modtype=thread&tid={$thread['tid']}">{$lang->view_thread_notes}</a>]]></template>
 		<template name="showthread_usersbrowsing" version="1600"><![CDATA[<br />
 <span class="smalltext">{$lang->users_browsing_thread} {$onlinemembers}{$onlinesep}{$invisonline}{$onlinesep2}{$guestsonline}</span>
@@ -11713,7 +11713,7 @@ if(use_xmlhttprequest == "1")
 {$getmore}
 </table>
 </div>]]></template>
-		<template name="smilieinsert_getmore" version="1805"><![CDATA[<tr>
+		<template name="smilieinsert_getmore" version="1809"><![CDATA[<tr>
   <td class="trow2" align="center"><span class="smalltext"><strong>[<a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=smilies&popup=true&editor=MyBBEditor&modal=1'); return false;">{$lang->smilieinsert_getmore}</a>]</strong></span></td>
 </tr>]]></template>
 		<template name="smilieinsert_row" version="1808"><![CDATA[<tr>{$smilie_icons}</tr>]]></template>
@@ -12562,7 +12562,7 @@ if(use_xmlhttprequest == "1")
 </tr>
 {$latest_subscribed_threads}
 </table>]]></template>
-		<template name="usercp_latest_subscribed_threads" version="1801"><![CDATA[<tr>
+		<template name="usercp_latest_subscribed_threads" version="1809"><![CDATA[<tr>
 <td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 <td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 <td class="{$bgcolor}">{$gotounread}{$thread['displayprefix']}<a href="{$thread['threadlink']}" class="{$new_class}">{$thread['subject']}</a><br /><span class="smalltext">{$thread['author']}</span></td>
@@ -12585,7 +12585,7 @@ if(use_xmlhttprequest == "1")
 </tr>
 {$latest_threads_threads}
 </table>]]></template>
-		<template name="usercp_latest_threads_threads" version="1801"><![CDATA[<tr>
+		<template name="usercp_latest_threads_threads" version="1809"><![CDATA[<tr>
 <td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 <td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 <td class="{$bgcolor}">{$gotounread}{$thread['displayprefix']}<a href="{$thread['threadlink']}" class="{$new_class}">{$thread['subject']}</a><br /><span class="smalltext">{$thread['author']}</span></td>
@@ -13331,7 +13331,7 @@ if(use_xmlhttprequest == "1")
 	</div>
 	</td>
 </tr>]]></template>
-		<template name="usercp_subscriptions_thread" version="1801"><![CDATA[<tr>
+		<template name="usercp_subscriptions_thread" version="1809"><![CDATA[<tr>
 	<td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}">{$gotounread}{$thread['threadprefix']}<a href="{$thread['threadlink']}" class="{$new_class}">{$thread['subject']}</a><br /><span class="smalltext">{$lang->notification_method} {$notification_type}</span></td>

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3271,7 +3271,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 {$footer}
 </body>
 </html>]]></template>
-		<template name="calendar_event_editbutton" version="1801"><![CDATA[<div style="text-align: right; vertical-align: bottom;" class="postbit_buttons">
+		<template name="calendar_event_editbutton" version="1809"><![CDATA[<div style="text-align: right; vertical-align: bottom;" class="postbit_buttons">
 	<a href="calendar.php?action=editevent&amp;eid={$event['eid']}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>
 	<a href="javascript:void(0)" onclick="MyBB.deleteEvent({$event['eid']}); return false;" class="postbit_qdelete"><span>{$lang->postbit_button_qdelete}</span></a>
 </div>]]></template>

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -2524,7 +2524,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 				// -->
 				</script>
 				<dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType();" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
+					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType(); return false;" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
 					<dd style="margin-top: 4px;" id="single_selects">
 						<select name="single_day">
 							{$single_days}
@@ -2549,7 +2549,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 							{$single_years}
 						</select>
 					</dd>
-					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType();" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
+					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType(); return false;" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
 					<dd style="margin-top: 4px; width: 100%;" id="ranged_selects">
 						<table width="100%">
 							<tr>
@@ -2948,7 +2948,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 				// -->
 				</script>
 				<dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType();" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
+					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType(); return false;" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
 					<dd style="margin-top: 4px;" id="single_selects">
 						<select name="single_day">
 							{$single_days}
@@ -2973,7 +2973,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 							{$single_years}
 						</select>
 					</dd>
-					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType();" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
+					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType(); return false;" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
 					<dd style="margin-top: 4px; width: 100%;" id="ranged_selects">
 						<table width="100%">
 							<tr>
@@ -3799,7 +3799,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 	{$customthreadtools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->inline_go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" onclick="javascript:inlineModeration.clearChecked();" value="{$lang->clear}" class="button" />
+<input type="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" class="button" />
 </form>
 <script type="text/javascript">
 <!--
@@ -3812,7 +3812,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <br />]]></template>
 		<template name="forumdisplay_inlinemoderation_approveunapprove" version="1800"><![CDATA[<option value="multiapprovethreads">{$lang->approve_threads}</option>
 <option value="multiunapprovethreads">{$lang->unapprove_threads}</option>]]></template>
-		<template name="forumdisplay_inlinemoderation_col" version="1400"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this)" /></td>]]></template>
+		<template name="forumdisplay_inlinemoderation_col" version="1400"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this); return false;" /></td>]]></template>
 		<template name="forumdisplay_inlinemoderation_custom" version="120"><![CDATA[<optgroup label="{$lang->custom_mod_tools}">{$customthreadtools}</optgroup>]]></template>
 		<template name="forumdisplay_inlinemoderation_custom_tool" version="120"><![CDATA[<option value="{$tool['tid']}">{$tool['name']}</option>]]></template>
 		<template name="forumdisplay_inlinemoderation_delete" version="1800"><![CDATA[<option value="multideletethreads">{$lang->delete_threads}</option>]]></template>
@@ -3821,10 +3821,10 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <option value="multiopenthreads">{$lang->open_threads}</option>]]></template>
 		<template name="forumdisplay_inlinemoderation_restore" version="1800"><![CDATA[<option value="multirestorethreads">{$lang->restore_threads}</option>]]></template>
 		<template name="forumdisplay_inlinemoderation_selectall" version="1600"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
-	<td colspan="8" class="selectall">{$lang->page_selected} <a href="#" onclick='inlineModeration.selectAll();'>{$lang->select_all}</a></td>
+	<td colspan="8" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
-	<td colspan="8" class="selectall">{$lang->all_selected} <a href="#" onclick='inlineModeration.clearChecked();'>{$lang->clear_selection}</a></td>
+	<td colspan="8" class="selectall">{$lang->all_selected} <a href="javascript:void(0)" onclick='inlineModeration.clearChecked(); return false;'>{$lang->clear_selection}</a></td>
 </tr>]]></template>
 		<template name="forumdisplay_inlinemoderation_softdelete" version="1800"><![CDATA[<option value="multisoftdeletethreads">{$lang->soft_delete_threads}</option>]]></template>
 		<template name="forumdisplay_inlinemoderation_standard" version="1800"><![CDATA[<optgroup label="{$lang->standard_mod_tools}">
@@ -4162,7 +4162,7 @@ $(".forumjump").change(function() {
 </div>]]></template>
 		<template name="global_pending_joinrequests" version="1600"><![CDATA[<div class="red_alert"><a href="{$mybb->settings['bburl']}/usercp.php?action=usergroups">{$lang->pending_joinrequests}</a></div>]]></template>
 		<template name="global_pm_alert" version="1800"><![CDATA[<div class="pm_alert" id="pm_notice">
-	<div class="float_right"><a href="{$mybb->settings['bburl']}/private.php?action=dismiss_notice&amp;my_post_key={$mybb->post_code}" title="{$lang->dismiss_notice}" onclick="return MyBB.dismissPMNotice('{$mybb->settings['bburl']}/')"><img src="{$theme['imgdir']}/dismiss_notice.png" alt="{$lang->dismiss_notice}" title="{$lang->dismiss_notice}" /></a></div>
+	<div class="float_right"><a href="{$mybb->settings['bburl']}/private.php?action=dismiss_notice&amp;my_post_key={$mybb->post_code}" title="{$lang->dismiss_notice}" onclick="return MyBB.dismissPMNotice('{$mybb->settings['bburl']}/');"><img src="{$theme['imgdir']}/dismiss_notice.png" alt="{$lang->dismiss_notice}" title="{$lang->dismiss_notice}" /></a></div>
 	<div>{$privatemessage_text}</div>
 </div>]]></template>
 		<template name="global_unreadreports" version="1800"><![CDATA[<div class="red_alert"><a href="{$mybb->settings['bburl']}/modcp.php?action=reports">{$lang->unread_reports}</a></div>]]></template>
@@ -4267,7 +4267,7 @@ $(".forumjump").change(function() {
 			{$admincplink}
 		</ul>
 		<ul class="menu user_links">
-			<li><a href="#" onclick="MyBB.popupWindow('{$mybb->settings['bburl']}/misc.php?action=buddypopup&modal=1', null, true); return false;">{$lang->welcome_open_buddy_list}</a></li>
+			<li><a href="javascript:void(0)" onclick="MyBB.popupWindow('{$mybb->settings['bburl']}/misc.php?action=buddypopup&modal=1', null, true); return false;">{$lang->welcome_open_buddy_list}</a></li>
 			<li><a href="{$mybb->settings['bburl']}/search.php?action=getnew">{$lang->welcome_newposts}</a></li>
 			<li><a href="{$mybb->settings['bburl']}/search.php?action=getdaily">{$lang->welcome_todaysposts}</a></li>
 			<li><a href="{$mybb->settings['bburl']}/private.php">{$lang->welcome_pms}</a> {$lang->welcome_pms_usage}</li>
@@ -6905,7 +6905,7 @@ if(use_xmlhttprequest == "1")
 										<tr>
 											<td>
 <dl style="margin-top: 0; margin-bottom: 0;">
-<dt><label><input type="checkbox" name="moderateposting" value="1" {$modpost_checked} class="checkbox" onclick="toggleSuspend('modposts');" id="modpost" /> {$lang->moderate_posts}</label></dt>
+<dt><label><input type="checkbox" name="moderateposting" value="1" {$modpost_checked} class="checkbox" onclick="toggleSuspend('modposts'); return false;" id="modpost" /> {$lang->moderate_posts}</label></dt>
 <dd style="margin-top: 4px;" id="modposts_action">
 <table cellpadding="4">
 {$moderateposts_info}
@@ -6921,7 +6921,7 @@ if(use_xmlhttprequest == "1")
 										<tr>
 											<td>
 <dl style="margin-top: 0; margin-bottom: 0;">
-<dt><label><input type="checkbox" name="suspendposting" value="1" {$suspost_checked} class="checkbox" onclick="toggleSuspend('susposts');" id="suspost" /> {$lang->suspend_posts}</label></dt>
+<dt><label><input type="checkbox" name="suspendposting" value="1" {$suspost_checked} class="checkbox" onclick="toggleSuspend('susposts'); return false;" id="suspost" /> {$lang->suspend_posts}</label></dt>
 <dd style="margin-top: 4px;" id="susposts_action">
 <table cellpadding="4">
 {$suspendposting_info}
@@ -7102,7 +7102,7 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>
 <dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-<dt><label><input type="checkbox" name="suspendsignature" value="1" class="checkbox" {$checked_item} onclick="toggleAction();" /> {$lang->suspend_signature}</label></dt>
+<dt><label><input type="checkbox" name="suspendsignature" value="1" class="checkbox" {$checked_item} onclick="toggleAction(); return false;" /> {$lang->suspend_signature}</label></dt>
 <dd style="margin-top: 4px;" id="suspend_action">
 <table cellpadding="4">
 {$suspendsignature_info}
@@ -7532,9 +7532,9 @@ if(use_xmlhttprequest == "1")
 		<template name="modcp_modqueue_link_forum" version="1800"><![CDATA[<strong>{$lang->meta_forum} <a href="{$forum_link}">{$forum_name}</a></strong><br />]]></template>
 		<template name="modcp_modqueue_link_thread" version="1800"><![CDATA[<strong>{$lang->meta_thread} <a href="{$post['threadlink']}">{$post['threadsubject']}</a></strong>]]></template>
 		<template name="modcp_modqueue_masscontrols" version="1800"><![CDATA[<ul class="modqueue_mass">
-  <li><a href="#" class="mass_ignore" onclick="$('input.radio_ignore').each(function(){ $(this).prop('checked', true); }); return false">{$lang->mark_all_ignored}</a></li>
-	<li><a href="#" class="mass_delete" onclick="$('input.radio_delete').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_deletion}</a></li>
-	<li><a href="#" class="mass_approve" onclick="$('input.radio_approve').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_approved}</a></li>
+	<li><a href="javascript:void(0)" class="mass_ignore" onclick="$('input.radio_ignore').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_ignored}</a></li>
+	<li><a href="javascript:void(0)" class="mass_delete" onclick="$('input.radio_delete').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_deletion}</a></li>
+	<li><a href="javascript:void(0)" class="mass_approve" onclick="$('input.radio_approve').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_approved}</a></li>
 </ul>]]></template>
 		<template name="modcp_modqueue_posts" version="1800"><![CDATA[<html>
 <head>
@@ -7741,7 +7741,7 @@ if(use_xmlhttprequest == "1")
 			<td class="tcat" align="left" width="25%"><span class="smalltext"><strong>{$lang->report_type}</strong></span></td>
 			<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->report_count}</strong></span></td>
 			<td class="tcat" align="right" width="20%"><span class="smalltext"><strong>{$lang->report_lastpost}</strong></span></td>
-			<td class="tcat" align="center" width="5%"><input type="checkbox" name="allbox" onclick="selectReportedPosts();" /></td>
+			<td class="tcat" align="center" width="5%"><input type="checkbox" name="allbox" onclick="selectReportedPosts(); return false;" /></td>
 		</tr>
 		{$reports}
 		<tr>
@@ -7834,7 +7834,7 @@ if(use_xmlhttprequest == "1")
 	<td class="{$trow}" align="left">{$report_data['comment']}</td>
 	<td class="{$trow}" align="center">{$report_data['reports']}</td>
 	<td class="{$trow} smalltext" align="right">{$report_data['lastreporter']}</td>
-	<td class="{$trow}" align="center"><input type="checkbox" class="checkbox" name="reports[]" id="reports_{$report['rid']}" value="{$report['rid']}" onclick="checkReportedPost(this);" /></td>
+	<td class="{$trow}" align="center"><input type="checkbox" class="checkbox" name="reports[]" id="reports_{$report['rid']}" value="{$report['rid']}" onclick="checkReportedPost(this); return false;" /></td>
 </tr>]]></template>
 		<template name="modcp_reports_report_comment" version="1808"><![CDATA[{$reason}]]></template>
 		<template name="modcp_reports_report_comment_extra" version="1808"><![CDATA[{$reason}: {$comment}]]></template>
@@ -8078,20 +8078,20 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>
 <dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-	<dt><input type="radio" name="type" value="openclosethread" {$type_selected['openclosethread']} id="type_openclosethread" onclick="toggleType();" /> <label for="type_openclosethread"><strong>{$lang->open_close_thread}</strong></label></dt>
-	<dt><input type="radio" name="type" value="softdeleterestorethread" {$type_selected['softdeleterestorethread']} id="type_softdeleterestorethread" onclick="toggleType();" /> <label for="type_softdeleterestorethread"><strong>{$lang->softdelete_restore_thread}</strong></label></dt>
-	<dt><input type="radio" name="type" value="deletethread" {$type_selected['deletethread']} id="type_deletethread" onclick="toggleType();" /> <label for="type_deletethread"><strong>{$lang->delete_thread}</strong></label></dt>
-	<dt><input type="radio" name="type" value="move" {$type_selected['move']} id="type_movecopythread" onclick="toggleType();" /> <label for="type_movecopythread"><strong>{$lang->move_copy_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="openclosethread" {$type_selected['openclosethread']} id="type_openclosethread" onclick="toggleType(); return false;" /> <label for="type_openclosethread"><strong>{$lang->open_close_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="softdeleterestorethread" {$type_selected['softdeleterestorethread']} id="type_softdeleterestorethread" onclick="toggleType(); return false;" /> <label for="type_softdeleterestorethread"><strong>{$lang->softdelete_restore_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="deletethread" {$type_selected['deletethread']} id="type_deletethread" onclick="toggleType(); return false;" /> <label for="type_deletethread"><strong>{$lang->delete_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="move" {$type_selected['move']} id="type_movecopythread" onclick="toggleType(); return false;" /> <label for="type_movecopythread"><strong>{$lang->move_copy_thread}</strong></label></dt>
 	<dd style="margin-top: 4px;" id="type_movecopythread_expanded">
 	{$lang->new_forum}<br />
 	{$forumselect}
 	{$moderation_delayedmoderation_move}
 	</dd>
-	<dt><input type="radio" name="type" value="stick" {$type_selected['stick']} id="type_stick_unstick_thread" onclick="toggleType();" /> <label for="type_stick_unstick_thread"><strong>{$lang->stick_unstick_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="stick" {$type_selected['stick']} id="type_stick_unstick_thread" onclick="toggleType(); return false;" /> <label for="type_stick_unstick_thread"><strong>{$lang->stick_unstick_thread}</strong></label></dt>
 	{$moderation_delayedmoderation_merge}
-	<dt><input type="radio" name="type" value="removeredirects" {$type_selected['removeredirects']} id="type_removeredirects" onclick="toggleType();" /> <label for="type_removeredirects"><strong>{$lang->remove_redirects}</strong></label></dt>
-	<dt><input type="radio" name="type" value="removesubscriptions" {$type_selected['removesubscriptions']} id="type_removesubscriptions" onclick="toggleType();" /> <label for="type_removesubscriptions"><strong>{$lang->remove_subscriptions}</strong></label></dt>
-	<dt><input type="radio" name="type" value="approveunapprovethread" {$type_selected['approveunapprovethread']} id="type_approveunapprovethread" onclick="toggleType();" /> <label for="type_approveunapprovethread"><strong>{$lang->approve_unapprove_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="removeredirects" {$type_selected['removeredirects']} id="type_removeredirects" onclick="toggleType(); return false;" /> <label for="type_removeredirects"><strong>{$lang->remove_redirects}</strong></label></dt>
+	<dt><input type="radio" name="type" value="removesubscriptions" {$type_selected['removesubscriptions']} id="type_removesubscriptions" onclick="toggleType(); return false;" /> <label for="type_removesubscriptions"><strong>{$lang->remove_subscriptions}</strong></label></dt>
+	<dt><input type="radio" name="type" value="approveunapprovethread" {$type_selected['approveunapprovethread']} id="type_approveunapprovethread" onclick="toggleType(); return false;" /> <label for="type_approveunapprovethread"><strong>{$lang->approve_unapprove_thread}</strong></label></dt>
 	{$customthreadtools}
 </dl>
 <script type="text/javascript">
@@ -8121,8 +8121,8 @@ if(use_xmlhttprequest == "1")
 <option value="11" {$datemonth['11']}>{$lang->november}</option>
 <option value="12" {$datemonth['12']}>{$lang->december}</option>]]></template>
 		<template name="moderation_delayedmoderation_date_day" version="1809"><![CDATA[<option value="{$day}"{$selected}>{$day}</option>]]></template>
-		<template name="moderation_delayedmoderation_custommodtool" version="1600"><![CDATA[<dt><input type="radio" name="type" value="modtool_{$tool['tid']}" {$checked} id="type_modtool_{$tool['tid']}" onclick="toggleType();" /> <label for="type_modtool_{$tool['tid']}"><strong>{$tool['name']}</strong> <small>({$lang->custom})</small></label></dt>]]></template>
-		<template name="moderation_delayedmoderation_merge" version="1600"><![CDATA[<dt><input type="radio" name="type" value="merge" {$type_selected['merge']} id="type_merge" onclick="toggleType();" /> <label for="type_merge"><strong>{$lang->merge_threads}</strong></label></dt>
+		<template name="moderation_delayedmoderation_custommodtool" version="1600"><![CDATA[<dt><input type="radio" name="type" value="modtool_{$tool['tid']}" {$checked} id="type_modtool_{$tool['tid']}" onclick="toggleType(); return false;" /> <label for="type_modtool_{$tool['tid']}"><strong>{$tool['name']}</strong> <small>({$lang->custom})</small></label></dt>]]></template>
+		<template name="moderation_delayedmoderation_merge" version="1600"><![CDATA[<dt><input type="radio" name="type" value="merge" {$type_selected['merge']} id="type_merge" onclick="toggleType(); return false;" /> <label for="type_merge"><strong>{$lang->merge_threads}</strong></label></dt>
 <dd style="margin-top: 4px; width: 100%;" id="type_merge_expanded">
 	{$lang->new_subject}<br />
 	<input type="text" class="textbox" name="delayedmoderation[subject]" value="{$mybb->input['delayedmoderation']['subject']}" size="40" /><br />
@@ -9392,7 +9392,7 @@ if(use_xmlhttprequest == "1")
 </tr>]]></template>
 		<template name="post_attachments_attachment_mod_approve" version="120"><![CDATA[<input type="submit" class="button" name="approveattach" value="{$lang->approve_attachment}" onclick="return Post.attachmentAction({$attachment['aid']},'approve');" />]]></template>
 		<template name="post_attachments_attachment_mod_unapprove" version="120"><![CDATA[<input type="submit" class="button" name="unapproveattach" value="{$lang->unapprove_attachment}" onclick="return Post.attachmentAction({$attachment['aid']},'unapprove');" />]]></template>
-		<template name="post_attachments_attachment_postinsert" version="1800"><![CDATA[<input type="button" class="button" name="insert" value="{$lang->insert_attachment_post}" onclick="$('#message').sceditor('instance').insertText('[attachment={$attachment['aid']}]');" />]]></template>
+		<template name="post_attachments_attachment_postinsert" version="1800"><![CDATA[<input type="button" class="button" name="insert" value="{$lang->insert_attachment_post}" onclick="$('#message').sceditor('instance').insertText('[attachment={$attachment['aid']}]'); return false;" />]]></template>
 		<template name="post_attachments_attachment_remove" version="1604"><![CDATA[<input type="submit" class="button" name="rem" value="{$lang->remove_attachment}" onclick="return Post.removeAttachment({$attachment['aid']});" />]]></template>
 		<template name="post_attachments_attachment_unapproved" version="120"><![CDATA[<tr>
 <td class="trow_shaded" width="1" align="center">{$attachment['icon']}</td>
@@ -9608,7 +9608,7 @@ if(use_xmlhttprequest == "1")
 		<template name="postbit_deleted" version="1809"><![CDATA[<div class="deleted_post_collapsed" id="deleted_post_{$post['pid']}">
 	<div class="deleted_post_author"><strong><span class="largetext">{$post['profilelink']}</span></strong></div>
 	<div class="deleted_post_message">
-		<div class="show_deleted_post float_right" style="vertical-align: top;" id="show_deleted_link_{$post['pid']}"><a href="#" onclick="Thread.showDeletedPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
+		<div class="show_deleted_post float_right" style="vertical-align: top;" id="show_deleted_link_{$post['pid']}"><a href="javascript:void(0)" onclick="Thread.showDeletedPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
 <script type="text/javascript">
 <!--
 	$('#show_deleted_link_{$post['pid']}').show();
@@ -9647,7 +9647,7 @@ if(use_xmlhttprequest == "1")
 		<template name="postbit_ignored" version="1800"><![CDATA[<div class="ignored_post" id="ignored_post_{$post['pid']}">
 	<div class="ignored_post_author"><strong><span class="largetext">{$post['profilelink']}</span></strong></div>
 	<div class="ignored_post_message">
-		<div class="show_ignored_post float_right" style="vertical-align: top;" id="show_ignored_link_{$post['pid']}"><a href="#" onclick="Thread.showIgnoredPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
+		<div class="show_ignored_post float_right" style="vertical-align: top;" id="show_ignored_link_{$post['pid']}"><a href="javascript:void(0)" onclick="Thread.showIgnoredPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
 <script type="text/javascript">
 <!--
 	$('#show_ignored_link_{$post['pid']}').show();
@@ -10364,7 +10364,7 @@ if(use_xmlhttprequest == "1")
 <td class="trow1" valign="top" width="200"><strong>{$lang->compose_to}</strong>
 	<script type="text/javascript">
 	<!--
-		document.write('(<a href="#" onclick="showBcc(); return false;" title="{$lang->compose_bcc_show_title}">{$lang->compose_bcc_show}<\/a>)');
+		document.write('(<a href="javascript:void(0)" onclick="showBcc(); return false;" title="{$lang->compose_bcc_show_title}">{$lang->compose_bcc_show}<\/a>)');
 	// -->
 	</script>
 	<br /><span class="smalltext">{$lang->separate_names}{$buddy_select_to}</span></td>
@@ -10524,7 +10524,7 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>]]></template>
 		<template name="private_send_buddyselect" version="1800"><![CDATA[<script type="text/javascript"><!--
-document.write('<br /><span class="smalltext"><a href="#" onclick="UserCP.openBuddySelect(\'{$buddy_select}\');"><img src="{$theme['imgdir']}/buddies.png" alt="" style="vertical-align: middle;" alt="" title="{$lang->select_from_buddies}" /> {$lang->select_from_buddies}</a></span>');
+document.write('<br /><span class="smalltext"><a href="javascript:void(0)" onclick="UserCP.openBuddySelect(\'{$buddy_select}\'); return false;"><img src="{$theme['imgdir']}/buddies.png" alt="" style="vertical-align: middle;" alt="" title="{$lang->select_from_buddies}" /> {$lang->select_from_buddies}</a></span>');
 // --></script>]]></template>
 		<template name="private_send_tracking" version="1805"><![CDATA[<br /><label><input type="checkbox" class="checkbox" name="options[readreceipt]" value="1" tabindex="8" {$optionschecked['readreceipt']} /> {$lang->options_read_receipt}</label>]]></template>
 		<template name="private_tracking" version="1800"><![CDATA[<html>
@@ -10825,7 +10825,7 @@ document.write('<br /><span class="smalltext"><a href="#" onclick="UserCP.openBu
 </table>
   </div>
 </div>]]></template>
-		<template name="reputation_add_delete" version="1800"><![CDATA[<input type="button" class="button" name="delete" value="{$lang->delete_vote}" onclick="javascript: return MyBB.submitReputation({$user['uid']}, {$mybb->input['pid']}, 1);" />]]></template>
+		<template name="reputation_add_delete" version="1800"><![CDATA[<input type="button" class="button" name="delete" value="{$lang->delete_vote}" onclick="return MyBB.submitReputation({$user['uid']}, {$mybb->input['pid']}, 1);" />]]></template>
 		<template name="reputation_add_error" version="1800"><![CDATA[<div class="modal">
 	<div style="overflow-y: auto; max-height: 400px;">
       <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
@@ -10846,9 +10846,9 @@ document.write('<br /><span class="smalltext"><a href="#" onclick="UserCP.openBu
 		</td>
 	</tr>
 </table>]]></template>
-		<template name="reputation_add_negative" version="1800"><![CDATA[					<option value="{$neg_value}" class="reputation_negative" onclick="$('#reputation').attr('class', 'reputation_negative')"{$vote_check[$neg_value]}>{$negative_title}</option>]]></template>
-		<template name="reputation_add_neutral" version="1800"><![CDATA[					<option value="0" class="reputation_neutral" onclick="$('#reputation').attr('class', 'reputation_neutral')"{$vote_check[0]}>{$lang->power_neutral}</option>]]></template>
-		<template name="reputation_add_positive" version="1800"><![CDATA[					<option value="{$value}" class="reputation_positive" onclick="$('#reputation').attr('class', 'reputation_positive')"{$vote_check[$value]}>{$positive_title}</option>
+		<template name="reputation_add_negative" version="1800"><![CDATA[					<option value="{$neg_value}" class="reputation_negative" onclick="$('#reputation').attr('class', 'reputation_negative'); return false;"{$vote_check[$neg_value]}>{$negative_title}</option>]]></template>
+		<template name="reputation_add_neutral" version="1800"><![CDATA[					<option value="0" class="reputation_neutral" onclick="$('#reputation').attr('class', 'reputation_neutral'); return false;"{$vote_check[0]}>{$lang->power_neutral}</option>]]></template>
+		<template name="reputation_add_positive" version="1800"><![CDATA[					<option value="{$value}" class="reputation_positive" onclick="$('#reputation').attr('class', 'reputation_positive'); return false;"{$vote_check[$value]}>{$positive_title}</option>
 {$positive_power}]]></template>
 		<template name="reputation_added" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 	<tr>
@@ -11027,13 +11027,13 @@ if(use_xmlhttprequest == "1")
 </tr>]]></template>
 		<template name="search_orderarrow" version="120"><![CDATA[<span class="smalltext">[<a href="{$sorturl}&amp;sortby={$sortby}&amp;order={$oppsortnext}">{$oppsort}</a>]</span>]]></template>
 		<template name="search_posts_inlinemoderation_selectall" version="1600"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
-	<td colspan="9" class="selectall">{$lang->page_selected} <a href="#" onclick='inlineModeration.selectAll();'>{$lang->select_all}</a></td>
+	<td colspan="9" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
-	<td colspan="9" class="selectall">{$lang->all_selected} <a href="#" onclick='inlineModeration.clearChecked();'>{$lang->clear_selection}</a></td>
+	<td colspan="9" class="selectall">{$lang->all_selected} <a href="javascript:void(0)" onclick='inlineModeration.clearChecked(); return false;'>{$lang->clear_selection}</a></td>
 </tr>]]></template>
 		<template name="search_results_icon" version="1800"><![CDATA[<img src="{$posticon['path']}" alt="{$posticon['name']}" title="{$posticon['name']}" />]]></template>
-		<template name="search_results_inlinemodcol" version="1408"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this)" /></td>]]></template>
+		<template name="search_results_inlinemodcol" version="1408"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this); return false;" /></td>]]></template>
 		<template name="search_results_posts" version="1600"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->search_results}</title>
@@ -11096,7 +11096,7 @@ if(use_xmlhttprequest == "1")
 {$customposttools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" class="button" onclick="javascript:inlineModeration.clearChecked();" value="{$lang->clear}" />
+<input type="button" class="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" />
 <input type="hidden" name="url" value="{$return_url}" />
 <input type="hidden" name="inlinetype" value="search" />
 </form>
@@ -11192,7 +11192,7 @@ if(use_xmlhttprequest == "1")
 	{$customthreadtools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->inline_go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" onclick="javascript:inlineModeration.clearChecked();" value="{$lang->clear}" class="button" />
+<input type="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" class="button" />
 <input type="hidden" name="url" value="{$return_url}" />
 <input type="hidden" name="inlinetype" value="search" />
 </form>
@@ -11230,10 +11230,10 @@ if(use_xmlhttprequest == "1")
 	{$inline_mod_checkbox}
 </tr>]]></template>
 		<template name="search_threads_inlinemoderation_selectall" version="1600"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
-	<td colspan="8" class="selectall">{$lang->page_selected} <a href="#" onclick='inlineModeration.selectAll();'>{$lang->select_all}</a></td>
+	<td colspan="8" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
-	<td colspan="8" class="selectall">{$lang->all_selected} <a href="#" onclick='inlineModeration.clearChecked();'>{$lang->clear_selection}</a></td>
+	<td colspan="8" class="selectall">{$lang->all_selected} <a href="javascript:void(0)" onclick='inlineModeration.clearChecked(); return false;'>{$lang->clear_selection}</a></td>
 </tr>]]></template>
 		<template name="showteam" version="120"><![CDATA[<html>
 <head>
@@ -11409,7 +11409,7 @@ if(use_xmlhttprequest == "1")
 {$customposttools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" class="button" onclick="javascript:inlineModeration.clearChecked();" value="{$lang->clear}" />
+<input type="button" class="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" />
 </form>
 <script type="text/javascript">
 <!--
@@ -13732,7 +13732,7 @@ if(use_xmlhttprequest == "1")
 {$footer}
 </body>
 </html>]]></template>
-		<template name="warnings_warn_custom" version="1400"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="custom" {$type_checked['custom']} class="types_check" onclick="checkType();" style="vertical-align: middle;" /> <strong>{$lang->custom}</strong></label></dt>
+		<template name="warnings_warn_custom" version="1400"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="custom" {$type_checked['custom']} class="types_check" onclick="checkType(); return false;" style="vertical-align: middle;" /> <strong>{$lang->custom}</strong></label></dt>
 					<dd style="margin-top: 4px;" id="type_custom" class="types">
 						<table>
 						<tr>
@@ -13800,7 +13800,7 @@ if(use_xmlhttprequest == "1")
 					}
 				// -->
 				</script>
-				<label style="display: block;"><input type="checkbox" class="checkbox" value="1" name="send_pm" id="send_pm" onclick="togglePM();" style="vertical-align: middle;" {$send_pm_checked} /> {$lang->send_user_warning_pm}</label>
+				<label style="display: block;"><input type="checkbox" class="checkbox" value="1" name="send_pm" id="send_pm" onclick="togglePM(); return false;" style="vertical-align: middle;" {$send_pm_checked} /> {$lang->send_user_warning_pm}</label>
 				<table id="pm_input" cellpadding="{$theme['tablespace']}">
 					<tr>
 						<td><strong>{$lang->send_pm_subject}</strong></td>
@@ -13830,7 +13830,7 @@ if(use_xmlhttprequest == "1")
 			<td width="20%" class="trow2"><strong>{$lang->post}</strong></td>
 			<td class="trow2"><input type="hidden" name="pid" value="{$post['pid']}" /><a href="{$post_link}">{$post['subject']}</a></td>
 		</tr>]]></template>
-		<template name="warnings_warn_type" version="1800"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="{$type['tid']}" {$checked} class="types_check" onclick="checkType();" style="vertical-align: middle;" /> <strong>{$type['title']}</strong> {$points}</label></dt>
+		<template name="warnings_warn_type" version="1800"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="{$type['tid']}" {$checked} class="types_check" onclick="checkType(); return false;" style="vertical-align: middle;" /> <strong>{$type['title']}</strong> {$points}</label></dt>
 					<dd style="margin-top: 4px;" id="type_{$type['tid']}" class="types">
 						<div class="smalltext">{$lang->new_warning_level}</div>
 						<div class="tborder float_left" style="width: 150px; margin: 0; padding: 1px;">
@@ -13852,7 +13852,7 @@ if(use_xmlhttprequest == "1")
 	<thead>
 		<tr>
 			<td class="thead">
-				<div class="float_right" style="margin-top: 3px;"><span class="smalltext"><a href="#" onclick="UserCP.closeBuddySelect(true); return false;">{$lang->close}</a></span></div>
+				<div class="float_right" style="margin-top: 3px;"><span class="smalltext"><a href="javascript:void(0)" onclick="UserCP.closeBuddySelect(true); return false;">{$lang->close}</a></span></div>
 				<div><strong>{$lang->select_buddies}</strong></div>
 			</td>
 		</tr>
@@ -13875,16 +13875,16 @@ if(use_xmlhttprequest == "1")
 			<td class="trow1">
 				<div class="smalltext"><strong>{$lang->selected_recipients}</strong></div>
 				<div id="buddyselect_buddies" class="smalltext" style="padding-left: 10px; height: 50px; overflow: auto;"></div>
-				<div style="text-align: right;"><input type="button" class="button" value="{$lang->ok}" onclick="UserCP.closeBuddySelect();" /> <input type="button" class="button" value="{$lang->cancel}" onclick="UserCP.closeBuddySelect(true);" /></div>
+				<div style="text-align: right;"><input type="button" class="button" value="{$lang->ok}" onclick="UserCP.closeBuddySelect(); return false;" /> <input type="button" class="button" value="{$lang->cancel}" onclick="UserCP.closeBuddySelect(true); return false;" /></div>
 			</td>
 		</tr>
 	</tbody>
 </table>]]></template>
 		<template name="xmlhttp_buddyselect_offline" version="1800"><![CDATA[					<tr>
-						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}');" /> <img src="{$theme['imgdir']}/buddy_offline.png" alt="({$lang->offline})" title="{$lang->offline}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
+						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}'); return false;" /> <img src="{$theme['imgdir']}/buddy_offline.png" alt="({$lang->offline})" title="{$lang->offline}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
 					</tr>]]></template>
 		<template name="xmlhttp_buddyselect_online" version="1800"><![CDATA[					<tr>
-						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}');" /> <img src="{$theme['imgdir']}/buddy_online.png" alt="({$lang->online})" title="{$lang->online}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
+						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}'); return false;" /> <img src="{$theme['imgdir']}/buddy_online.png" alt="({$lang->online})" title="{$lang->online}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
 					</tr>]]></template>
 		<template name="attachment_icon" version="1800"><![CDATA[<img src="{$icon}" title="{$name}" border="0" alt=".{$ext}" />]]></template>		<template name="changeuserbox" version="1400"><![CDATA[<tr>
 <td class="trow1" width="20%"><strong>{$lang->username}</strong></td>

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -2524,7 +2524,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 				// -->
 				</script>
 				<dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType(); return false;" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
+					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType();" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
 					<dd style="margin-top: 4px;" id="single_selects">
 						<select name="single_day">
 							{$single_days}
@@ -2549,7 +2549,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 							{$single_years}
 						</select>
 					</dd>
-					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType(); return false;" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
+					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType();" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
 					<dd style="margin-top: 4px; width: 100%;" id="ranged_selects">
 						<table width="100%">
 							<tr>
@@ -2948,7 +2948,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 				// -->
 				</script>
 				<dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType(); return false;" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
+					<dt><input type="radio" name="type" value="single" {$type_single} id="type_single" onclick="toggleType();" /> <label for="type_single"><strong>{$lang->type_single}</strong></label></dt>
 					<dd style="margin-top: 4px;" id="single_selects">
 						<select name="single_day">
 							{$single_days}
@@ -2973,7 +2973,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 							{$single_years}
 						</select>
 					</dd>
-					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType(); return false;" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
+					<dt><input type="radio" name="type" value="ranged" {$type_ranged} id="type_ranged" onclick="toggleType();" /> <label for="type_ranged"><strong>{$lang->type_ranged}</strong></label></dt>
 					<dd style="margin-top: 4px; width: 100%;" id="ranged_selects">
 						<table width="100%">
 							<tr>
@@ -3799,7 +3799,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 	{$customthreadtools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->inline_go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" class="button" />
+<input type="button" onclick="javascript:inlineModeration.clearChecked();" value="{$lang->clear}" class="button" />
 </form>
 <script type="text/javascript">
 <!--
@@ -3812,7 +3812,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <br />]]></template>
 		<template name="forumdisplay_inlinemoderation_approveunapprove" version="1800"><![CDATA[<option value="multiapprovethreads">{$lang->approve_threads}</option>
 <option value="multiunapprovethreads">{$lang->unapprove_threads}</option>]]></template>
-		<template name="forumdisplay_inlinemoderation_col" version="1400"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this); return false;" /></td>]]></template>
+		<template name="forumdisplay_inlinemoderation_col" version="1400"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this)" /></td>]]></template>
 		<template name="forumdisplay_inlinemoderation_custom" version="120"><![CDATA[<optgroup label="{$lang->custom_mod_tools}">{$customthreadtools}</optgroup>]]></template>
 		<template name="forumdisplay_inlinemoderation_custom_tool" version="120"><![CDATA[<option value="{$tool['tid']}">{$tool['name']}</option>]]></template>
 		<template name="forumdisplay_inlinemoderation_delete" version="1800"><![CDATA[<option value="multideletethreads">{$lang->delete_threads}</option>]]></template>
@@ -3820,7 +3820,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 		<template name="forumdisplay_inlinemoderation_openclose" version="1800"><![CDATA[<option value="multiclosethreads">{$lang->close_threads}</option>
 <option value="multiopenthreads">{$lang->open_threads}</option>]]></template>
 		<template name="forumdisplay_inlinemoderation_restore" version="1800"><![CDATA[<option value="multirestorethreads">{$lang->restore_threads}</option>]]></template>
-		<template name="forumdisplay_inlinemoderation_selectall" version="1600"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
+		<template name="forumdisplay_inlinemoderation_selectall" version="1800"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
 	<td colspan="8" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
@@ -4162,7 +4162,7 @@ $(".forumjump").change(function() {
 </div>]]></template>
 		<template name="global_pending_joinrequests" version="1600"><![CDATA[<div class="red_alert"><a href="{$mybb->settings['bburl']}/usercp.php?action=usergroups">{$lang->pending_joinrequests}</a></div>]]></template>
 		<template name="global_pm_alert" version="1800"><![CDATA[<div class="pm_alert" id="pm_notice">
-	<div class="float_right"><a href="{$mybb->settings['bburl']}/private.php?action=dismiss_notice&amp;my_post_key={$mybb->post_code}" title="{$lang->dismiss_notice}" onclick="return MyBB.dismissPMNotice('{$mybb->settings['bburl']}/');"><img src="{$theme['imgdir']}/dismiss_notice.png" alt="{$lang->dismiss_notice}" title="{$lang->dismiss_notice}" /></a></div>
+	<div class="float_right"><a href="{$mybb->settings['bburl']}/private.php?action=dismiss_notice&amp;my_post_key={$mybb->post_code}" title="{$lang->dismiss_notice}" onclick="return MyBB.dismissPMNotice('{$mybb->settings['bburl']}/')"><img src="{$theme['imgdir']}/dismiss_notice.png" alt="{$lang->dismiss_notice}" title="{$lang->dismiss_notice}" /></a></div>
 	<div>{$privatemessage_text}</div>
 </div>]]></template>
 		<template name="global_unreadreports" version="1800"><![CDATA[<div class="red_alert"><a href="{$mybb->settings['bburl']}/modcp.php?action=reports">{$lang->unread_reports}</a></div>]]></template>
@@ -4255,7 +4255,7 @@ $(".forumjump").change(function() {
 				<script type="text/javascript">
 					$("#quick_login input[name='url']").val($(location).attr('href'));
 				</script>]]></template>
-		<template name="header_welcomeblock_member" version="1804"><![CDATA[<!-- Continuation of div(class="upper") as opened in the header template -->
+		<template name="header_welcomeblock_member" version="1805"><![CDATA[<!-- Continuation of div(class="upper") as opened in the header template -->
 	<span class="welcome">{$lang->welcome_back} <a href="{$mybb->settings['bburl']}/member.php?action=logout&amp;logoutkey={$mybb->user['logoutkey']}" class="logout">{$lang->welcome_logout}</a></span>
 	</div>
 </div>
@@ -4876,9 +4876,9 @@ if(use_xmlhttprequest == "1")
 	{$contact_fields['skype']}
 	{$contact_fields['google']}
 </table>]]></template>
-		<template name="member_profile_contact_fields_aim" version="1804"><![CDATA[<tr>
+		<template name="member_profile_contact_fields_aim" version="1805"><![CDATA[<tr>
 	<td class="{$bgcolors['aim']}"><strong>{$lang->aim_screenname}</strong></td>
-	<td class="{$bgcolors['aim']}"><a href="javascript:;" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=aim&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['aim']}</a></td>
+	<td class="{$bgcolors['aim']}"><a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=aim&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['aim']}</a></td>
 </tr>]]></template>
 		<template name="member_profile_contact_fields_google" version="1800"><![CDATA[<tr>
 	<td class="{$bgcolors['google']}"><strong>{$lang->google_id}</strong></td>
@@ -4888,13 +4888,13 @@ if(use_xmlhttprequest == "1")
 	<td class="{$bgcolors['icq']}"><strong>{$lang->icq_number}</strong></td>
 	<td class="{$bgcolors['icq']}">{$memprofile['icq']}</td>
 </tr>]]></template>
-		<template name="member_profile_contact_fields_skype" version="1804"><![CDATA[<tr>
+		<template name="member_profile_contact_fields_skype" version="1805"><![CDATA[<tr>
 	<td class="{$bgcolors['skype']}"><strong>{$lang->skype_id}</strong></td>
-	<td class="{$bgcolors['skype']}"><a href="javascript:;" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=skype&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['skype']}</a></td>
+	<td class="{$bgcolors['skype']}"><a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=skype&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['skype']}</a></td>
 </tr>]]></template>
-		<template name="member_profile_contact_fields_yahoo" version="1804"><![CDATA[<tr>
+		<template name="member_profile_contact_fields_yahoo" version="1805"><![CDATA[<tr>
 	<td class="{$bgcolors['yahoo']}"><strong>{$lang->yahoo_id}</strong></td>
-	<td class="{$bgcolors['yahoo']}"><a href="javascript:;" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=yahoo&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['yahoo']}</a></td>
+	<td class="{$bgcolors['yahoo']}"><a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=yahoo&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['yahoo']}</a></td>
 </tr>]]></template>
 		<template name="member_profile_customfields" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder tfixed">
 <colgroup>
@@ -6048,7 +6048,7 @@ if(use_xmlhttprequest == "1")
 </table>
 </div>
 </div>]]></template>
-		<template name="misc_imcenter_nav" version="1804"><![CDATA[{$navsep}<a href="javascript:;" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype={$imtype}&amp;uid={$uid}&amp;modal=1'); return false;">{$imtype_lang}</a>]]></template>
+		<template name="misc_imcenter_nav" version="1805"><![CDATA[{$navsep}<a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype={$imtype}&amp;uid={$uid}&amp;modal=1'); return false;">{$imtype_lang}</a>]]></template>
 		<template name="misc_imcenter_skype" version="1807"><![CDATA[<div class="modal">
 <div style="overflow-y: auto; max-height: 400px;">
 <table width="100%" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" border="0" align="center" class="tborder">
@@ -6905,7 +6905,7 @@ if(use_xmlhttprequest == "1")
 										<tr>
 											<td>
 <dl style="margin-top: 0; margin-bottom: 0;">
-<dt><label><input type="checkbox" name="moderateposting" value="1" {$modpost_checked} class="checkbox" onclick="toggleSuspend('modposts'); return false;" id="modpost" /> {$lang->moderate_posts}</label></dt>
+<dt><label><input type="checkbox" name="moderateposting" value="1" {$modpost_checked} class="checkbox" onclick="toggleSuspend('modposts');" id="modpost" /> {$lang->moderate_posts}</label></dt>
 <dd style="margin-top: 4px;" id="modposts_action">
 <table cellpadding="4">
 {$moderateposts_info}
@@ -6921,7 +6921,7 @@ if(use_xmlhttprequest == "1")
 										<tr>
 											<td>
 <dl style="margin-top: 0; margin-bottom: 0;">
-<dt><label><input type="checkbox" name="suspendposting" value="1" {$suspost_checked} class="checkbox" onclick="toggleSuspend('susposts'); return false;" id="suspost" /> {$lang->suspend_posts}</label></dt>
+<dt><label><input type="checkbox" name="suspendposting" value="1" {$suspost_checked} class="checkbox" onclick="toggleSuspend('susposts');" id="suspost" /> {$lang->suspend_posts}</label></dt>
 <dd style="margin-top: 4px;" id="susposts_action">
 <table cellpadding="4">
 {$suspendposting_info}
@@ -7102,7 +7102,7 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>
 <dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-<dt><label><input type="checkbox" name="suspendsignature" value="1" class="checkbox" {$checked_item} onclick="toggleAction(); return false;" /> {$lang->suspend_signature}</label></dt>
+<dt><label><input type="checkbox" name="suspendsignature" value="1" class="checkbox" {$checked_item} onclick="toggleAction();" /> {$lang->suspend_signature}</label></dt>
 <dd style="margin-top: 4px;" id="suspend_action">
 <table cellpadding="4">
 {$suspendsignature_info}
@@ -7531,7 +7531,7 @@ if(use_xmlhttprequest == "1")
 </html>]]></template>
 		<template name="modcp_modqueue_link_forum" version="1800"><![CDATA[<strong>{$lang->meta_forum} <a href="{$forum_link}">{$forum_name}</a></strong><br />]]></template>
 		<template name="modcp_modqueue_link_thread" version="1800"><![CDATA[<strong>{$lang->meta_thread} <a href="{$post['threadlink']}">{$post['threadsubject']}</a></strong>]]></template>
-		<template name="modcp_modqueue_masscontrols" version="1800"><![CDATA[<ul class="modqueue_mass">
+		<template name="modcp_modqueue_masscontrols" version="1801"><![CDATA[<ul class="modqueue_mass">
 	<li><a href="javascript:void(0)" class="mass_ignore" onclick="$('input.radio_ignore').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_ignored}</a></li>
 	<li><a href="javascript:void(0)" class="mass_delete" onclick="$('input.radio_delete').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_deletion}</a></li>
 	<li><a href="javascript:void(0)" class="mass_approve" onclick="$('input.radio_approve').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_approved}</a></li>
@@ -7741,7 +7741,7 @@ if(use_xmlhttprequest == "1")
 			<td class="tcat" align="left" width="25%"><span class="smalltext"><strong>{$lang->report_type}</strong></span></td>
 			<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->report_count}</strong></span></td>
 			<td class="tcat" align="right" width="20%"><span class="smalltext"><strong>{$lang->report_lastpost}</strong></span></td>
-			<td class="tcat" align="center" width="5%"><input type="checkbox" name="allbox" onclick="selectReportedPosts(); return false;" /></td>
+			<td class="tcat" align="center" width="5%"><input type="checkbox" name="allbox" onclick="selectReportedPosts();" /></td>
 		</tr>
 		{$reports}
 		<tr>
@@ -7834,7 +7834,7 @@ if(use_xmlhttprequest == "1")
 	<td class="{$trow}" align="left">{$report_data['comment']}</td>
 	<td class="{$trow}" align="center">{$report_data['reports']}</td>
 	<td class="{$trow} smalltext" align="right">{$report_data['lastreporter']}</td>
-	<td class="{$trow}" align="center"><input type="checkbox" class="checkbox" name="reports[]" id="reports_{$report['rid']}" value="{$report['rid']}" onclick="checkReportedPost(this); return false;" /></td>
+	<td class="{$trow}" align="center"><input type="checkbox" class="checkbox" name="reports[]" id="reports_{$report['rid']}" value="{$report['rid']}" onclick="checkReportedPost(this);" /></td>
 </tr>]]></template>
 		<template name="modcp_reports_report_comment" version="1808"><![CDATA[{$reason}]]></template>
 		<template name="modcp_reports_report_comment_extra" version="1808"><![CDATA[{$reason}: {$comment}]]></template>
@@ -8078,20 +8078,20 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>
 <dl style="margin-top: 0; margin-bottom: 0; width: 100%;">
-	<dt><input type="radio" name="type" value="openclosethread" {$type_selected['openclosethread']} id="type_openclosethread" onclick="toggleType(); return false;" /> <label for="type_openclosethread"><strong>{$lang->open_close_thread}</strong></label></dt>
-	<dt><input type="radio" name="type" value="softdeleterestorethread" {$type_selected['softdeleterestorethread']} id="type_softdeleterestorethread" onclick="toggleType(); return false;" /> <label for="type_softdeleterestorethread"><strong>{$lang->softdelete_restore_thread}</strong></label></dt>
-	<dt><input type="radio" name="type" value="deletethread" {$type_selected['deletethread']} id="type_deletethread" onclick="toggleType(); return false;" /> <label for="type_deletethread"><strong>{$lang->delete_thread}</strong></label></dt>
-	<dt><input type="radio" name="type" value="move" {$type_selected['move']} id="type_movecopythread" onclick="toggleType(); return false;" /> <label for="type_movecopythread"><strong>{$lang->move_copy_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="openclosethread" {$type_selected['openclosethread']} id="type_openclosethread" onclick="toggleType();" /> <label for="type_openclosethread"><strong>{$lang->open_close_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="softdeleterestorethread" {$type_selected['softdeleterestorethread']} id="type_softdeleterestorethread" onclick="toggleType();" /> <label for="type_softdeleterestorethread"><strong>{$lang->softdelete_restore_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="deletethread" {$type_selected['deletethread']} id="type_deletethread" onclick="toggleType();" /> <label for="type_deletethread"><strong>{$lang->delete_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="move" {$type_selected['move']} id="type_movecopythread" onclick="toggleType();" /> <label for="type_movecopythread"><strong>{$lang->move_copy_thread}</strong></label></dt>
 	<dd style="margin-top: 4px;" id="type_movecopythread_expanded">
 	{$lang->new_forum}<br />
 	{$forumselect}
 	{$moderation_delayedmoderation_move}
 	</dd>
-	<dt><input type="radio" name="type" value="stick" {$type_selected['stick']} id="type_stick_unstick_thread" onclick="toggleType(); return false;" /> <label for="type_stick_unstick_thread"><strong>{$lang->stick_unstick_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="stick" {$type_selected['stick']} id="type_stick_unstick_thread" onclick="toggleType();" /> <label for="type_stick_unstick_thread"><strong>{$lang->stick_unstick_thread}</strong></label></dt>
 	{$moderation_delayedmoderation_merge}
-	<dt><input type="radio" name="type" value="removeredirects" {$type_selected['removeredirects']} id="type_removeredirects" onclick="toggleType(); return false;" /> <label for="type_removeredirects"><strong>{$lang->remove_redirects}</strong></label></dt>
-	<dt><input type="radio" name="type" value="removesubscriptions" {$type_selected['removesubscriptions']} id="type_removesubscriptions" onclick="toggleType(); return false;" /> <label for="type_removesubscriptions"><strong>{$lang->remove_subscriptions}</strong></label></dt>
-	<dt><input type="radio" name="type" value="approveunapprovethread" {$type_selected['approveunapprovethread']} id="type_approveunapprovethread" onclick="toggleType(); return false;" /> <label for="type_approveunapprovethread"><strong>{$lang->approve_unapprove_thread}</strong></label></dt>
+	<dt><input type="radio" name="type" value="removeredirects" {$type_selected['removeredirects']} id="type_removeredirects" onclick="toggleType();" /> <label for="type_removeredirects"><strong>{$lang->remove_redirects}</strong></label></dt>
+	<dt><input type="radio" name="type" value="removesubscriptions" {$type_selected['removesubscriptions']} id="type_removesubscriptions" onclick="toggleType();" /> <label for="type_removesubscriptions"><strong>{$lang->remove_subscriptions}</strong></label></dt>
+	<dt><input type="radio" name="type" value="approveunapprovethread" {$type_selected['approveunapprovethread']} id="type_approveunapprovethread" onclick="toggleType();" /> <label for="type_approveunapprovethread"><strong>{$lang->approve_unapprove_thread}</strong></label></dt>
 	{$customthreadtools}
 </dl>
 <script type="text/javascript">
@@ -8121,8 +8121,8 @@ if(use_xmlhttprequest == "1")
 <option value="11" {$datemonth['11']}>{$lang->november}</option>
 <option value="12" {$datemonth['12']}>{$lang->december}</option>]]></template>
 		<template name="moderation_delayedmoderation_date_day" version="1809"><![CDATA[<option value="{$day}"{$selected}>{$day}</option>]]></template>
-		<template name="moderation_delayedmoderation_custommodtool" version="1600"><![CDATA[<dt><input type="radio" name="type" value="modtool_{$tool['tid']}" {$checked} id="type_modtool_{$tool['tid']}" onclick="toggleType(); return false;" /> <label for="type_modtool_{$tool['tid']}"><strong>{$tool['name']}</strong> <small>({$lang->custom})</small></label></dt>]]></template>
-		<template name="moderation_delayedmoderation_merge" version="1600"><![CDATA[<dt><input type="radio" name="type" value="merge" {$type_selected['merge']} id="type_merge" onclick="toggleType(); return false;" /> <label for="type_merge"><strong>{$lang->merge_threads}</strong></label></dt>
+		<template name="moderation_delayedmoderation_custommodtool" version="1600"><![CDATA[<dt><input type="radio" name="type" value="modtool_{$tool['tid']}" {$checked} id="type_modtool_{$tool['tid']}" onclick="toggleType();" /> <label for="type_modtool_{$tool['tid']}"><strong>{$tool['name']}</strong> <small>({$lang->custom})</small></label></dt>]]></template>
+		<template name="moderation_delayedmoderation_merge" version="1600"><![CDATA[<dt><input type="radio" name="type" value="merge" {$type_selected['merge']} id="type_merge" onclick="toggleType();" /> <label for="type_merge"><strong>{$lang->merge_threads}</strong></label></dt>
 <dd style="margin-top: 4px; width: 100%;" id="type_merge_expanded">
 	{$lang->new_subject}<br />
 	<input type="text" class="textbox" name="delayedmoderation[subject]" value="{$mybb->input['delayedmoderation']['subject']}" size="40" /><br />
@@ -9392,7 +9392,7 @@ if(use_xmlhttprequest == "1")
 </tr>]]></template>
 		<template name="post_attachments_attachment_mod_approve" version="120"><![CDATA[<input type="submit" class="button" name="approveattach" value="{$lang->approve_attachment}" onclick="return Post.attachmentAction({$attachment['aid']},'approve');" />]]></template>
 		<template name="post_attachments_attachment_mod_unapprove" version="120"><![CDATA[<input type="submit" class="button" name="unapproveattach" value="{$lang->unapprove_attachment}" onclick="return Post.attachmentAction({$attachment['aid']},'unapprove');" />]]></template>
-		<template name="post_attachments_attachment_postinsert" version="1800"><![CDATA[<input type="button" class="button" name="insert" value="{$lang->insert_attachment_post}" onclick="$('#message').sceditor('instance').insertText('[attachment={$attachment['aid']}]'); return false;" />]]></template>
+		<template name="post_attachments_attachment_postinsert" version="1801"><![CDATA[<input type="button" class="button" name="insert" value="{$lang->insert_attachment_post}" onclick="$('#message').sceditor('instance').insertText('[attachment={$attachment['aid']}]'); return false;" />]]></template>
 		<template name="post_attachments_attachment_remove" version="1604"><![CDATA[<input type="submit" class="button" name="rem" value="{$lang->remove_attachment}" onclick="return Post.removeAttachment({$attachment['aid']});" />]]></template>
 		<template name="post_attachments_attachment_unapproved" version="120"><![CDATA[<tr>
 <td class="trow_shaded" width="1" align="center">{$attachment['icon']}</td>
@@ -9605,7 +9605,7 @@ if(use_xmlhttprequest == "1")
 </div>
 </div>]]></template>
 		<template name="postbit_delete_pm" version="1800"><![CDATA[<a href="private.php?action=delete&amp;pmid={$id}&amp;my_post_key={$mybb->post_code}" title="{$lang->delete_title}" class="postbit_delete_pm"><span>{$lang->postbit_button_delete_pm}</span></a>]]></template>
-		<template name="postbit_deleted" version="1809"><![CDATA[<div class="deleted_post_collapsed" id="deleted_post_{$post['pid']}">
+		<template name="postbit_deleted" version="1810"><![CDATA[<div class="deleted_post_collapsed" id="deleted_post_{$post['pid']}">
 	<div class="deleted_post_author"><strong><span class="largetext">{$post['profilelink']}</span></strong></div>
 	<div class="deleted_post_message">
 		<div class="show_deleted_post float_right" style="vertical-align: top;" id="show_deleted_link_{$post['pid']}"><a href="javascript:void(0)" onclick="Thread.showDeletedPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
@@ -9644,7 +9644,7 @@ if(use_xmlhttprequest == "1")
 		<template name="postbit_gotopost" version="1804"><![CDATA[ <a href="{$url}" class="quick_jump"></a>]]></template>
 		<template name="postbit_groupimage" version="120"><![CDATA[<img src="{$usergroup['image']}" alt="{$usergroup['title']}" title="{$usergroup['title']}" />]]></template>
 		<template name="postbit_icon" version="1800"><![CDATA[<img src="{$icon['path']}" alt="{$icon['name']}" title="{$icon['name']}" style="vertical-align: middle;" />&nbsp;]]></template>
-		<template name="postbit_ignored" version="1800"><![CDATA[<div class="ignored_post" id="ignored_post_{$post['pid']}">
+		<template name="postbit_ignored" version="1801"><![CDATA[<div class="ignored_post" id="ignored_post_{$post['pid']}">
 	<div class="ignored_post_author"><strong><span class="largetext">{$post['profilelink']}</span></strong></div>
 	<div class="ignored_post_message">
 		<div class="show_ignored_post float_right" style="vertical-align: top;" id="show_ignored_link_{$post['pid']}"><a href="javascript:void(0)" onclick="Thread.showIgnoredPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
@@ -10340,7 +10340,7 @@ if(use_xmlhttprequest == "1")
 		<template name="private_search_results_nomessages" version="1600"><![CDATA[<tr>
 <td colspan="7" class="trow1">{$lang->nomessages}</td>
 </tr>]]></template>
-		<template name="private_send" version="1808"><![CDATA[<html>
+		<template name="private_send" version="1809"><![CDATA[<html>
 <head>
 <title>{$lang->compose_pm}</title>
 {$headerinclude}
@@ -10523,7 +10523,7 @@ if(use_xmlhttprequest == "1")
 }
 // -->
 </script>]]></template>
-		<template name="private_send_buddyselect" version="1800"><![CDATA[<script type="text/javascript"><!--
+		<template name="private_send_buddyselect" version="1801"><![CDATA[<script type="text/javascript"><!--
 document.write('<br /><span class="smalltext"><a href="javascript:void(0)" onclick="UserCP.openBuddySelect(\'{$buddy_select}\'); return false;"><img src="{$theme['imgdir']}/buddies.png" alt="" style="vertical-align: middle;" alt="" title="{$lang->select_from_buddies}" /> {$lang->select_from_buddies}</a></span>');
 // --></script>]]></template>
 		<template name="private_send_tracking" version="1805"><![CDATA[<br /><label><input type="checkbox" class="checkbox" name="options[readreceipt]" value="1" tabindex="8" {$optionschecked['readreceipt']} /> {$lang->options_read_receipt}</label>]]></template>
@@ -10846,9 +10846,9 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 		</td>
 	</tr>
 </table>]]></template>
-		<template name="reputation_add_negative" version="1800"><![CDATA[					<option value="{$neg_value}" class="reputation_negative" onclick="$('#reputation').attr('class', 'reputation_negative'); return false;"{$vote_check[$neg_value]}>{$negative_title}</option>]]></template>
-		<template name="reputation_add_neutral" version="1800"><![CDATA[					<option value="0" class="reputation_neutral" onclick="$('#reputation').attr('class', 'reputation_neutral'); return false;"{$vote_check[0]}>{$lang->power_neutral}</option>]]></template>
-		<template name="reputation_add_positive" version="1800"><![CDATA[					<option value="{$value}" class="reputation_positive" onclick="$('#reputation').attr('class', 'reputation_positive'); return false;"{$vote_check[$value]}>{$positive_title}</option>
+		<template name="reputation_add_negative" version="1801"><![CDATA[					<option value="{$neg_value}" class="reputation_negative" onclick="$('#reputation').attr('class', 'reputation_negative');"{$vote_check[$neg_value]}>{$negative_title}</option>]]></template>
+		<template name="reputation_add_neutral" version="1801"><![CDATA[					<option value="0" class="reputation_neutral" onclick="$('#reputation').attr('class', 'reputation_neutral');"{$vote_check[0]}>{$lang->power_neutral}</option>]]></template>
+		<template name="reputation_add_positive" version="1801"><![CDATA[					<option value="{$value}" class="reputation_positive" onclick="$('#reputation').attr('class', 'reputation_positive');"{$vote_check[$value]}>{$positive_title}</option>
 {$positive_power}]]></template>
 		<template name="reputation_added" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 	<tr>
@@ -11026,14 +11026,14 @@ if(use_xmlhttprequest == "1")
 </td>
 </tr>]]></template>
 		<template name="search_orderarrow" version="120"><![CDATA[<span class="smalltext">[<a href="{$sorturl}&amp;sortby={$sortby}&amp;order={$oppsortnext}">{$oppsort}</a>]</span>]]></template>
-		<template name="search_posts_inlinemoderation_selectall" version="1600"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
+		<template name="search_posts_inlinemoderation_selectall" version="1800"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
 	<td colspan="9" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
 	<td colspan="9" class="selectall">{$lang->all_selected} <a href="javascript:void(0)" onclick='inlineModeration.clearChecked(); return false;'>{$lang->clear_selection}</a></td>
 </tr>]]></template>
 		<template name="search_results_icon" version="1800"><![CDATA[<img src="{$posticon['path']}" alt="{$posticon['name']}" title="{$posticon['name']}" />]]></template>
-		<template name="search_results_inlinemodcol" version="1408"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this); return false;" /></td>]]></template>
+		<template name="search_results_inlinemodcol" version="1800"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this);" /></td>]]></template>
 		<template name="search_results_posts" version="1600"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->search_results}</title>
@@ -11075,7 +11075,7 @@ if(use_xmlhttprequest == "1")
 </html>]]></template>
 		<template name="search_results_posts_forumlink" version="1808"><![CDATA[<a href="{$post['forumlink_link']}">{$post['forumlink_name']}</a>]]></template>
 		<template name="search_results_posts_inlinecheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap"><input type="checkbox" class="checkbox" name="inlinemod_{$post['pid']}" id="inlinemod_{$post['pid']}" value="1" style="vertical-align: middle;" {$inlinecheck}  /></td>]]></template>
-		<template name="search_results_posts_inlinemoderation" version="1807"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
+		<template name="search_results_posts_inlinemoderation" version="1808"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
 <form action="moderation.php" method="post" style="margin-top: 0; margin-bottom: 0;">
 <input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 <input type="hidden" name="tid" value="0" />
@@ -11096,7 +11096,7 @@ if(use_xmlhttprequest == "1")
 {$customposttools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" class="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" />
+<input type="button" class="button" onclick="inlineModeration.clearChecked();" value="{$lang->clear}" />
 <input type="hidden" name="url" value="{$return_url}" />
 <input type="hidden" name="inlinetype" value="search" />
 </form>
@@ -11169,7 +11169,7 @@ if(use_xmlhttprequest == "1")
 		</html>]]></template>
 		<template name="search_results_threads_forumlink" version="1808"><![CDATA[<a href="{$thread['forumlink_link']}">{$thread['forumlink_name']}</a>]]></template>
 		<template name="search_results_threads_inlinecheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap"><input type="checkbox" class="checkbox" name="inlinemod_{$thread['tid']}" id="inlinemod_{$thread['tid']}" value="1" style="vertical-align: middle;" {$inlinecheck}  /></td>]]></template>
-		<template name="search_results_threads_inlinemoderation" version="1807"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
+		<template name="search_results_threads_inlinemoderation" version="1808"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
 		<form action="moderation.php" method="post">
 <input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 <input type="hidden" name="fid" value="0" />
@@ -11192,7 +11192,7 @@ if(use_xmlhttprequest == "1")
 	{$customthreadtools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->inline_go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" class="button" />
+<input type="button" onclick="inlineModeration.clearChecked();" value="{$lang->clear}" class="button" />
 <input type="hidden" name="url" value="{$return_url}" />
 <input type="hidden" name="inlinetype" value="search" />
 </form>
@@ -11229,7 +11229,7 @@ if(use_xmlhttprequest == "1")
 	</td>
 	{$inline_mod_checkbox}
 </tr>]]></template>
-		<template name="search_threads_inlinemoderation_selectall" version="1600"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
+		<template name="search_threads_inlinemoderation_selectall" version="1800"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
 	<td colspan="8" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
@@ -11398,7 +11398,7 @@ if(use_xmlhttprequest == "1")
 			<td class="tcat"><span class="smalltext"><strong>{$lang->message}</strong></span></td>
 		</tr>
 		]]></template>
-		<template name="showthread_inlinemoderation" version="1809"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
+		<template name="showthread_inlinemoderation" version="1810"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
 <form action="moderation.php" method="post" style="margin-top: 0; margin-bottom: 0;" id="inlinemoderation_options">
 <input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 <input type="hidden" name="tid" value="{$tid}" />
@@ -11409,7 +11409,7 @@ if(use_xmlhttprequest == "1")
 {$customposttools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" class="button" onclick="inlineModeration.clearChecked(); return false;" value="{$lang->clear}" />
+<input type="button" class="button" onclick="inlineModeration.clearChecked();" value="{$lang->clear}" />
 </form>
 <script type="text/javascript">
 <!--
@@ -13732,7 +13732,7 @@ if(use_xmlhttprequest == "1")
 {$footer}
 </body>
 </html>]]></template>
-		<template name="warnings_warn_custom" version="1400"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="custom" {$type_checked['custom']} class="types_check" onclick="checkType(); return false;" style="vertical-align: middle;" /> <strong>{$lang->custom}</strong></label></dt>
+		<template name="warnings_warn_custom" version="1400"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="custom" {$type_checked['custom']} class="types_check" onclick="checkType();" style="vertical-align: middle;" /> <strong>{$lang->custom}</strong></label></dt>
 					<dd style="margin-top: 4px;" id="type_custom" class="types">
 						<table>
 						<tr>
@@ -13800,7 +13800,7 @@ if(use_xmlhttprequest == "1")
 					}
 				// -->
 				</script>
-				<label style="display: block;"><input type="checkbox" class="checkbox" value="1" name="send_pm" id="send_pm" onclick="togglePM(); return false;" style="vertical-align: middle;" {$send_pm_checked} /> {$lang->send_user_warning_pm}</label>
+				<label style="display: block;"><input type="checkbox" class="checkbox" value="1" name="send_pm" id="send_pm" onclick="togglePM();" style="vertical-align: middle;" {$send_pm_checked} /> {$lang->send_user_warning_pm}</label>
 				<table id="pm_input" cellpadding="{$theme['tablespace']}">
 					<tr>
 						<td><strong>{$lang->send_pm_subject}</strong></td>
@@ -13830,7 +13830,7 @@ if(use_xmlhttprequest == "1")
 			<td width="20%" class="trow2"><strong>{$lang->post}</strong></td>
 			<td class="trow2"><input type="hidden" name="pid" value="{$post['pid']}" /><a href="{$post_link}">{$post['subject']}</a></td>
 		</tr>]]></template>
-		<template name="warnings_warn_type" version="1800"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="{$type['tid']}" {$checked} class="types_check" onclick="checkType(); return false;" style="vertical-align: middle;" /> <strong>{$type['title']}</strong> {$points}</label></dt>
+		<template name="warnings_warn_type" version="1800"><![CDATA[					<dt><label style="display: block;"><input type="radio" name="type" value="{$type['tid']}" {$checked} class="types_check" onclick="checkType();" style="vertical-align: middle;" /> <strong>{$type['title']}</strong> {$points}</label></dt>
 					<dd style="margin-top: 4px;" id="type_{$type['tid']}" class="types">
 						<div class="smalltext">{$lang->new_warning_level}</div>
 						<div class="tborder float_left" style="width: 150px; margin: 0; padding: 1px;">
@@ -13848,7 +13848,7 @@ if(use_xmlhttprequest == "1")
 				<td class="{$alt_bg}" style="text-align: center;">{$issuedby}</td>
 				<td class="{$alt_bg}" style="text-align: center;"><a href="warnings.php?action=view&amp;wid={$warning['wid']}">{$lang->view}</a></td>
 			</tr>]]></template>
-		<template name="xmlhttp_buddyselect" version="1405"><![CDATA[<table border="0" cellspacing="1" cellpadding="4" class="tborder" style="width: 300px;">
+		<template name="xmlhttp_buddyselect" version="1800"><![CDATA[<table border="0" cellspacing="1" cellpadding="4" class="tborder" style="width: 300px;">
 	<thead>
 		<tr>
 			<td class="thead">
@@ -13875,16 +13875,16 @@ if(use_xmlhttprequest == "1")
 			<td class="trow1">
 				<div class="smalltext"><strong>{$lang->selected_recipients}</strong></div>
 				<div id="buddyselect_buddies" class="smalltext" style="padding-left: 10px; height: 50px; overflow: auto;"></div>
-				<div style="text-align: right;"><input type="button" class="button" value="{$lang->ok}" onclick="UserCP.closeBuddySelect(); return false;" /> <input type="button" class="button" value="{$lang->cancel}" onclick="UserCP.closeBuddySelect(true); return false;" /></div>
+				<div style="text-align: right;"><input type="button" class="button" value="{$lang->ok}" onclick="UserCP.closeBuddySelect();" /> <input type="button" class="button" value="{$lang->cancel}" onclick="UserCP.closeBuddySelect(true);" /></div>
 			</td>
 		</tr>
 	</tbody>
 </table>]]></template>
 		<template name="xmlhttp_buddyselect_offline" version="1800"><![CDATA[					<tr>
-						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}'); return false;" /> <img src="{$theme['imgdir']}/buddy_offline.png" alt="({$lang->offline})" title="{$lang->offline}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
+						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}');" /> <img src="{$theme['imgdir']}/buddy_offline.png" alt="({$lang->offline})" title="{$lang->offline}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
 					</tr>]]></template>
 		<template name="xmlhttp_buddyselect_online" version="1800"><![CDATA[					<tr>
-						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}'); return false;" /> <img src="{$theme['imgdir']}/buddy_online.png" alt="({$lang->online})" title="{$lang->online}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
+						<td class="trow1" onmouseover="this.className='trow2';" onmouseout="this.className='trow1';"><label><input type="checkbox" style="vertical-align: middle;" id="checkbox_{$buddy['uid']}" onclick="UserCP.selectBuddy('{$buddy['uid']}', '{$buddy['username']}');" /> <img src="{$theme['imgdir']}/buddy_online.png" alt="({$lang->online})" title="{$lang->online}" style="vertical-align: middle;" /> {$buddy_name}</label></td>
 					</tr>]]></template>
 		<template name="attachment_icon" version="1800"><![CDATA[<img src="{$icon}" title="{$name}" border="0" alt=".{$ext}" />]]></template>		<template name="changeuserbox" version="1400"><![CDATA[<tr>
 <td class="trow1" width="20%"><strong>{$lang->username}</strong></td>

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3271,9 +3271,9 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 {$footer}
 </body>
 </html>]]></template>
-		<template name="calendar_event_editbutton" version="1800"><![CDATA[<div style="text-align: right; vertical-align: bottom;" class="postbit_buttons">
+		<template name="calendar_event_editbutton" version="1801"><![CDATA[<div style="text-align: right; vertical-align: bottom;" class="postbit_buttons">
 	<a href="calendar.php?action=editevent&amp;eid={$event['eid']}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>
-	<a href="javascript:MyBB.deleteEvent({$event['eid']});" class="postbit_qdelete"><span>{$lang->postbit_button_qdelete}</span></a>
+	<a href="javascript:void(0)" onclick="MyBB.deleteEvent({$event['eid']}); return false;" class="postbit_qdelete"><span>{$lang->postbit_button_qdelete}</span></a>
 </div>]]></template>
 		<template name="calendar_event_modoptions" version="1604"><![CDATA[				<form method="post" action="calendar.php">
 					<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
@@ -3799,7 +3799,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 	{$customthreadtools}
 </select>
 <input type="submit" class="button" name="go" value="{$lang->inline_go} ({$inlinecount})" id="inline_go" />&nbsp;
-<input type="button" onclick="javascript:inlineModeration.clearChecked();" value="{$lang->clear}" class="button" />
+<input type="button" onclick="inlineModeration.clearChecked();" value="{$lang->clear}" class="button" />
 </form>
 <script type="text/javascript">
 <!--
@@ -3820,7 +3820,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 		<template name="forumdisplay_inlinemoderation_openclose" version="1800"><![CDATA[<option value="multiclosethreads">{$lang->close_threads}</option>
 <option value="multiopenthreads">{$lang->open_threads}</option>]]></template>
 		<template name="forumdisplay_inlinemoderation_restore" version="1800"><![CDATA[<option value="multirestorethreads">{$lang->restore_threads}</option>]]></template>
-		<template name="forumdisplay_inlinemoderation_selectall" version="1800"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
+		<template name="forumdisplay_inlinemoderation_selectall" version="1809"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
 	<td colspan="8" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
@@ -3922,7 +3922,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 {$forums}
 </table>
 <br />]]></template>
-		<template name="forumdisplay_thread" version="1800"><![CDATA[<tr class="inline_row">
+		<template name="forumdisplay_thread" version="1801"><![CDATA[<tr class="inline_row">
 	<td align="center" class="{$bgcolor}{$thread_type_class}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}{$thread_type_class}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}{$thread_type_class}">
@@ -3932,7 +3932,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 			<div class="author smalltext">{$thread['profilelink']}</div>
 		</div>
 	</td>
-	<td align="center" class="{$bgcolor}{$thread_type_class}"><a href="javascript:MyBB.whoPosted({$thread['tid']});">{$thread['replies']}</a>{$unapproved_posts}</td>
+	<td align="center" class="{$bgcolor}{$thread_type_class}"><a href="javascript:void(0)" onclick="MyBB.whoPosted({$thread['tid']}); return false;">{$thread['replies']}</a>{$unapproved_posts}</td>
 	<td align="center" class="{$bgcolor}{$thread_type_class}">{$thread['views']}</td>
 	{$rating}
 	<td class="{$bgcolor}{$thread_type_class}" style="white-space: nowrap; text-align: right;">
@@ -4255,7 +4255,7 @@ $(".forumjump").change(function() {
 				<script type="text/javascript">
 					$("#quick_login input[name='url']").val($(location).attr('href'));
 				</script>]]></template>
-		<template name="header_welcomeblock_member" version="1805"><![CDATA[<!-- Continuation of div(class="upper") as opened in the header template -->
+		<template name="header_welcomeblock_member" version="1809"><![CDATA[<!-- Continuation of div(class="upper") as opened in the header template -->
 	<span class="welcome">{$lang->welcome_back} <a href="{$mybb->settings['bburl']}/member.php?action=logout&amp;logoutkey={$mybb->user['logoutkey']}" class="logout">{$lang->welcome_logout}</a></span>
 	</div>
 </div>
@@ -4876,7 +4876,7 @@ if(use_xmlhttprequest == "1")
 	{$contact_fields['skype']}
 	{$contact_fields['google']}
 </table>]]></template>
-		<template name="member_profile_contact_fields_aim" version="1805"><![CDATA[<tr>
+		<template name="member_profile_contact_fields_aim" version="1809"><![CDATA[<tr>
 	<td class="{$bgcolors['aim']}"><strong>{$lang->aim_screenname}</strong></td>
 	<td class="{$bgcolors['aim']}"><a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=aim&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['aim']}</a></td>
 </tr>]]></template>
@@ -4888,11 +4888,11 @@ if(use_xmlhttprequest == "1")
 	<td class="{$bgcolors['icq']}"><strong>{$lang->icq_number}</strong></td>
 	<td class="{$bgcolors['icq']}">{$memprofile['icq']}</td>
 </tr>]]></template>
-		<template name="member_profile_contact_fields_skype" version="1805"><![CDATA[<tr>
+		<template name="member_profile_contact_fields_skype" version="1809"><![CDATA[<tr>
 	<td class="{$bgcolors['skype']}"><strong>{$lang->skype_id}</strong></td>
 	<td class="{$bgcolors['skype']}"><a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=skype&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['skype']}</a></td>
 </tr>]]></template>
-		<template name="member_profile_contact_fields_yahoo" version="1805"><![CDATA[<tr>
+		<template name="member_profile_contact_fields_yahoo" version="1809"><![CDATA[<tr>
 	<td class="{$bgcolors['yahoo']}"><strong>{$lang->yahoo_id}</strong></td>
 	<td class="{$bgcolors['yahoo']}"><a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype=yahoo&amp;uid={$uid}&amp;modal=1'); return false;">{$memprofile['yahoo']}</a></td>
 </tr>]]></template>
@@ -4947,7 +4947,7 @@ if(use_xmlhttprequest == "1")
 </ul>
 </td>
 </tr>]]></template>
-		<template name="member_profile_modoptions_viewnotes" version="1800"><![CDATA[[<a href="javascript:MyBB.viewNotes({$memprofile['uid']});">{$lang->view_all_notes}</a>]]]></template>
+		<template name="member_profile_modoptions_viewnotes" version="1801"><![CDATA[[<a href="javascript:void(0)" onclick="MyBB.viewNotes({$memprofile['uid']}); return false;">{$lang->view_all_notes}</a>]]]></template>
 		<template name="member_profile_offline" version="1400"><![CDATA[<span class="offline" style="font-weight: bold;">{$lang->postbit_status_offline}</span>]]></template>
 		<template name="member_profile_online" version="1400"><![CDATA[<a href="online.php"><span class="online" style="font-weight: bold;">{$lang->postbit_status_online}</span></a> ({$location} @ {$location_time})]]></template>
 		<template name="member_profile_pm" version="1800"><![CDATA[<tr>
@@ -4962,7 +4962,7 @@ if(use_xmlhttprequest == "1")
 	<td class="{$bg_color}"><strong>{$lang->reputation}</strong></td>
 	<td class="{$bg_color}">{$reputation} [<a href="reputation.php?uid={$memprofile['uid']}">{$lang->reputation_details}</a>] {$vote_link}</td>
 </tr>]]></template>
-		<template name="member_profile_reputation_vote" version="1800"><![CDATA[[<a href="javascript:MyBB.reputation({$memprofile['uid']});">{$lang->reputation_vote}</a>]]]></template>
+		<template name="member_profile_reputation_vote" version="1801"><![CDATA[[<a href="javascript:void(0)" onclick="MyBB.reputation({$memprofile['uid']}); return false;">{$lang->reputation_vote}</a>]]]></template>
 		<template name="member_profile_signature" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder tfixed">
 <tr>
 <td class="thead"><strong>{$lang->users_signature}</strong></td>
@@ -6048,7 +6048,7 @@ if(use_xmlhttprequest == "1")
 </table>
 </div>
 </div>]]></template>
-		<template name="misc_imcenter_nav" version="1805"><![CDATA[{$navsep}<a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype={$imtype}&amp;uid={$uid}&amp;modal=1'); return false;">{$imtype_lang}</a>]]></template>
+		<template name="misc_imcenter_nav" version="1809"><![CDATA[{$navsep}<a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=imcenter&amp;imtype={$imtype}&amp;uid={$uid}&amp;modal=1'); return false;">{$imtype_lang}</a>]]></template>
 		<template name="misc_imcenter_skype" version="1807"><![CDATA[<div class="modal">
 <div style="overflow-y: auto; max-height: 400px;">
 <table width="100%" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" border="0" align="center" class="tborder">
@@ -7531,7 +7531,7 @@ if(use_xmlhttprequest == "1")
 </html>]]></template>
 		<template name="modcp_modqueue_link_forum" version="1800"><![CDATA[<strong>{$lang->meta_forum} <a href="{$forum_link}">{$forum_name}</a></strong><br />]]></template>
 		<template name="modcp_modqueue_link_thread" version="1800"><![CDATA[<strong>{$lang->meta_thread} <a href="{$post['threadlink']}">{$post['threadsubject']}</a></strong>]]></template>
-		<template name="modcp_modqueue_masscontrols" version="1801"><![CDATA[<ul class="modqueue_mass">
+		<template name="modcp_modqueue_masscontrols" version="1809"><![CDATA[<ul class="modqueue_mass">
 	<li><a href="javascript:void(0)" class="mass_ignore" onclick="$('input.radio_ignore').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_ignored}</a></li>
 	<li><a href="javascript:void(0)" class="mass_delete" onclick="$('input.radio_delete').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_deletion}</a></li>
 	<li><a href="javascript:void(0)" class="mass_approve" onclick="$('input.radio_approve').each(function(){ $(this).prop('checked', true); }); return false;">{$lang->mark_all_approved}</a></li>
@@ -8714,13 +8714,13 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>]]></template>
 		<template name="multipage_end" version="1600"><![CDATA[{$lang->multipage_link_end} <a href="{$page_url}" class="pagination_last">{$pages}</a>]]></template>
-		<template name="multipage_jump_page" version="1800"><![CDATA[<div class="popup_menu drop_go_page" style="display: none;">
+		<template name="multipage_jump_page" version="1801"><![CDATA[<div class="popup_menu drop_go_page" style="display: none;">
 	<form action="{$jump_url}" method="post">
 		<label for="page">{$lang->multipage_jump}:</label> <input type="text" class="textbox" name="page" value="{$page}" size="4" />
 		<input type="submit" class="button" value="{$lang->go}" />
 	</form>
 </div>
-<a href="javascript:;" class="go_page" title="{$lang->multipage_jump}"><img src="{$theme['imgdir']}/arrow_down.png" alt="{$lang->multipage_jump}" /></a>&nbsp;
+<a href="javascript:void(0)" class="go_page" title="{$lang->multipage_jump}"><img src="{$theme['imgdir']}/arrow_down.png" alt="{$lang->multipage_jump}" /></a>&nbsp;
 <script type="text/javascript">
 	var go_page = 'go_page_' + $(".go_page").length;
 	$(".go_page").last().attr('id', go_page);
@@ -8834,7 +8834,7 @@ if(use_xmlhttprequest == "1")
 <label><input type="checkbox" class="checkbox" name="modoptions[stickthread]" value="1"{$stickycheck} />&nbsp;{$lang->stick_thread}</label>
 </span></td>
 </tr>]]></template>
-		<template name="newreply_multiquote_external" version="1400"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newreply.php?tid={$tid}" onclick="return Post.loadMultiQuoted();">{$multiquote_quote}</a>, <a href="javascript:Post.clearMultiQuoted();">{$multiquote_deselect}</a></span></div>]]></template>
+		<template name="newreply_multiquote_external" version="1800"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newreply.php?tid={$tid}" onclick="return Post.loadMultiQuoted();">{$multiquote_quote}</a>, <a href="javascript:void(0)" onclick="Post.clearMultiQuoted(); return false;">{$multiquote_deselect}</a></span></div>]]></template>
 		<template name="newreply_threadreview" version="1800"><![CDATA[<br />
 <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder tfixed">
 <tr>
@@ -8921,7 +8921,7 @@ if(use_xmlhttprequest == "1")
 <label><input type="checkbox" class="checkbox" name="postoptions[disablesmilies]" value="1" tabindex="9"{$postoptionschecked['disablesmilies']} /> {$lang->options_disablesmilies}</label>]]></template>
 		<template name="newthread_disablesmilies_hidden" version="1800"><![CDATA[<input type="hidden" name="postoptions[disablesmilies]" value="no" />]]></template>
 		<template name="newthread_draftinput" version="1808"><![CDATA[<input type="hidden" name="pid" value="{$pid}" />]]></template>
-		<template name="newthread_multiquote_external" version="1400"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newthread.php?fid={$fid}&amp;load_all_quotes=1" onclick="return Post.loadMultiQuotedAll();">{$multiquote_quote}</a>, <a href="javascript:Post.clearMultiQuoted();">{$multiquote_deselect}</a></span></div>]]></template>
+		<template name="newthread_multiquote_external" version="1800"><![CDATA[<div id="multiquote_unloaded"><span class="smalltext">{$multiquote_text} <a href="./newthread.php?fid={$fid}&amp;load_all_quotes=1" onclick="return Post.loadMultiQuotedAll();">{$multiquote_quote}</a>, <a href="javascript:void(0)" onclick="Post.clearMultiQuoted(); return false;">{$multiquote_deselect}</a></span></div>]]></template>
 		<template name="newthread_postpoll" version="120"><![CDATA[<tr>
 <td class="{$bgcolor2}" valign="top">
 <strong>{$lang->poll}</strong><br /><span class="smalltext">{$lang->poll_desc}</span>
@@ -9392,7 +9392,7 @@ if(use_xmlhttprequest == "1")
 </tr>]]></template>
 		<template name="post_attachments_attachment_mod_approve" version="120"><![CDATA[<input type="submit" class="button" name="approveattach" value="{$lang->approve_attachment}" onclick="return Post.attachmentAction({$attachment['aid']},'approve');" />]]></template>
 		<template name="post_attachments_attachment_mod_unapprove" version="120"><![CDATA[<input type="submit" class="button" name="unapproveattach" value="{$lang->unapprove_attachment}" onclick="return Post.attachmentAction({$attachment['aid']},'unapprove');" />]]></template>
-		<template name="post_attachments_attachment_postinsert" version="1801"><![CDATA[<input type="button" class="button" name="insert" value="{$lang->insert_attachment_post}" onclick="$('#message').sceditor('instance').insertText('[attachment={$attachment['aid']}]'); return false;" />]]></template>
+		<template name="post_attachments_attachment_postinsert" version="1809"><![CDATA[<input type="button" class="button" name="insert" value="{$lang->insert_attachment_post}" onclick="$('#message').sceditor('instance').insertText('[attachment={$attachment['aid']}]'); return false;" />]]></template>
 		<template name="post_attachments_attachment_remove" version="1604"><![CDATA[<input type="submit" class="button" name="rem" value="{$lang->remove_attachment}" onclick="return Post.removeAttachment({$attachment['aid']});" />]]></template>
 		<template name="post_attachments_attachment_unapproved" version="120"><![CDATA[<tr>
 <td class="trow_shaded" width="1" align="center">{$attachment['icon']}</td>
@@ -9605,7 +9605,7 @@ if(use_xmlhttprequest == "1")
 </div>
 </div>]]></template>
 		<template name="postbit_delete_pm" version="1800"><![CDATA[<a href="private.php?action=delete&amp;pmid={$id}&amp;my_post_key={$mybb->post_code}" title="{$lang->delete_title}" class="postbit_delete_pm"><span>{$lang->postbit_button_delete_pm}</span></a>]]></template>
-		<template name="postbit_deleted" version="1810"><![CDATA[<div class="deleted_post_collapsed" id="deleted_post_{$post['pid']}">
+		<template name="postbit_deleted" version="1809"><![CDATA[<div class="deleted_post_collapsed" id="deleted_post_{$post['pid']}">
 	<div class="deleted_post_author"><strong><span class="largetext">{$post['profilelink']}</span></strong></div>
 	<div class="deleted_post_message">
 		<div class="show_deleted_post float_right" style="vertical-align: top;" id="show_deleted_link_{$post['pid']}"><a href="javascript:void(0)" onclick="Thread.showDeletedPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
@@ -9625,8 +9625,8 @@ if(use_xmlhttprequest == "1")
 		</div>
 	</div>
 </div>]]></template>
-		<template name="postbit_edit" version="1800"><![CDATA[<a href="editpost.php?pid={$post['pid']}" id="edit_post_{$post['pid']}" title="{$lang->postbit_edit}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>
-<div id="edit_post_{$post['pid']}_popup" class="popup_menu" style="display: none;"><div class="popup_item_container"><a href="javascript:;" class="popup_item quick_edit_button" id="quick_edit_post_{$post['pid']}">{$lang->postbit_quick_edit}</a></div><div class="popup_item_container"><a href="editpost.php?pid={$post['pid']}" class="popup_item">{$lang->postbit_full_edit}</a></div></div>
+		<template name="postbit_edit" version="1801"><![CDATA[<a href="editpost.php?pid={$post['pid']}" id="edit_post_{$post['pid']}" title="{$lang->postbit_edit}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>
+<div id="edit_post_{$post['pid']}_popup" class="popup_menu" style="display: none;"><div class="popup_item_container"><a href="javascript:void(0)" class="popup_item quick_edit_button" id="quick_edit_post_{$post['pid']}">{$lang->postbit_quick_edit}</a></div><div class="popup_item_container"><a href="editpost.php?pid={$post['pid']}" class="popup_item">{$lang->postbit_full_edit}</a></div></div>
 <script type="text/javascript">
 // <!--
 	if(use_xmlhttprequest == "1")
@@ -9644,7 +9644,7 @@ if(use_xmlhttprequest == "1")
 		<template name="postbit_gotopost" version="1804"><![CDATA[ <a href="{$url}" class="quick_jump"></a>]]></template>
 		<template name="postbit_groupimage" version="120"><![CDATA[<img src="{$usergroup['image']}" alt="{$usergroup['title']}" title="{$usergroup['title']}" />]]></template>
 		<template name="postbit_icon" version="1800"><![CDATA[<img src="{$icon['path']}" alt="{$icon['name']}" title="{$icon['name']}" style="vertical-align: middle;" />&nbsp;]]></template>
-		<template name="postbit_ignored" version="1801"><![CDATA[<div class="ignored_post" id="ignored_post_{$post['pid']}">
+		<template name="postbit_ignored" version="1809"><![CDATA[<div class="ignored_post" id="ignored_post_{$post['pid']}">
 	<div class="ignored_post_author"><strong><span class="largetext">{$post['profilelink']}</span></strong></div>
 	<div class="ignored_post_message">
 		<div class="show_ignored_post float_right" style="vertical-align: top;" id="show_ignored_link_{$post['pid']}"><a href="javascript:void(0)" onclick="Thread.showIgnoredPost({$post['pid']}); return false;" class="button small_button"><span>{$lang->postbit_show_ignored_post}</span></a></div>
@@ -9659,7 +9659,7 @@ if(use_xmlhttprequest == "1")
 		<template name="postbit_inlinecheck" version="1800"><![CDATA[<input type="checkbox" class="checkbox" name="inlinemod_{$post['pid']}" id="inlinemod_{$post['pid']}" value="1" style="vertical-align: middle; margin: -2px 0 0 5px;" {$inlinecheck}  />]]></template>
 		<template name="postbit_iplogged_hiden" version="1800"><![CDATA[{$lang->postbit_ipaddress} <a href="moderation.php?action={$action}&amp;{$idtype}={$post[$idtype]}">{$lang->postbit_ipaddress_logged}</a>]]></template>
 		<template name="postbit_iplogged_show" version="1800"><![CDATA[{$lang->postbit_ipaddress} {$ipaddress}]]></template>
-		<template name="postbit_multiquote" version="1800"><![CDATA[<a href="javascript:Thread.multiQuote({$post['pid']});" style="display: none;" id="multiquote_link_{$post['pid']}" title="{$lang->postbit_multiquote}" class="postbit_multiquote"><span id="multiquote_{$post['pid']}">{$lang->postbit_button_multiquote}</span></a>
+		<template name="postbit_multiquote" version="1801"><![CDATA[<a href="javascript:void(0)" onclick="Thread.multiQuote({$post['pid']}); return false;" style="display: none;" id="multiquote_link_{$post['pid']}" title="{$lang->postbit_multiquote}" class="postbit_multiquote"><span id="multiquote_{$post['pid']}">{$lang->postbit_button_multiquote}</span></a>
 <script type="text/javascript">
 //<!--
 	$('#multiquote_link_{$post['pid']}').css("display", "");
@@ -9690,10 +9690,10 @@ if(use_xmlhttprequest == "1")
 // -->
 </script>]]></template>
 		<template name="postbit_quote" version="1800"><![CDATA[<a href="newreply.php?tid={$tid}&amp;replyto={$post['pid']}" title="{$lang->postbit_quote}" class="postbit_quote"><span>{$lang->postbit_button_quote}</span></a>]]></template>
-		<template name="postbit_rep_button" version="1800"><![CDATA[<a href="javascript:MyBB.reputation({$post['uid']},{$post['pid']});" title="{$lang->postbit_reputation_add}" class="postbit_reputation_add"><span>{$lang->postbit_button_reputation_add}</span></a>]]></template>
+		<template name="postbit_rep_button" version="1801"><![CDATA[<a href="javascript:void(0)" onclick="MyBB.reputation({$post['uid']},{$post['pid']}); return false;" title="{$lang->postbit_reputation_add}" class="postbit_reputation_add"><span>{$lang->postbit_button_reputation_add}</span></a>]]></template>
 		<template name="postbit_reply_pm" version="1800"><![CDATA[<a href="private.php?action=send&amp;pmid={$id}&amp;do=reply" title="{$lang->reply_title}" class="postbit_reply_pm"><span>{$lang->postbit_button_reply_pm}</span></a>]]></template>
 		<template name="postbit_replyall_pm" version="1480"><![CDATA[<a href="private.php?action=send&amp;pmid={$id}&amp;do=replyall" title="{$lang->reply_to_all}" class="postbit_reply_all"><span>{$lang->postbit_button_reply_all}</span></a>]]></template>
-		<template name="postbit_report" version="1800"><![CDATA[<a href="javascript:Report.reportPost({$post['pid']});" title="{$lang->postbit_report}" class="postbit_report"><span>{$lang->postbit_button_report}</span></a>]]></template>
+		<template name="postbit_report" version="1801"><![CDATA[<a href="javascript:void(0)" onclick="Report.reportPost({$post['pid']}); return false;" title="{$lang->postbit_report}" class="postbit_report"><span>{$lang->postbit_button_report}</span></a>]]></template>
 		<template name="postbit_reputation" version="1400"><![CDATA[<br />{$lang->postbit_reputation} {$post['userreputation']}]]></template>
 		<template name="postbit_reputation_formatted" version="1800"><![CDATA[<strong class="{$reputation_class}">{$reputation}</strong>]]></template>
 		<template name="postbit_reputation_formatted_link" version="1800"><![CDATA[<a href="reputation.php?uid={$uid}"><strong class="{$reputation_class}">{$reputation}</strong></a>]]></template>
@@ -10523,7 +10523,7 @@ if(use_xmlhttprequest == "1")
 }
 // -->
 </script>]]></template>
-		<template name="private_send_buddyselect" version="1801"><![CDATA[<script type="text/javascript"><!--
+		<template name="private_send_buddyselect" version="1809"><![CDATA[<script type="text/javascript"><!--
 document.write('<br /><span class="smalltext"><a href="javascript:void(0)" onclick="UserCP.openBuddySelect(\'{$buddy_select}\'); return false;"><img src="{$theme['imgdir']}/buddies.png" alt="" style="vertical-align: middle;" alt="" title="{$lang->select_from_buddies}" /> {$lang->select_from_buddies}</a></span>');
 // --></script>]]></template>
 		<template name="private_send_tracking" version="1805"><![CDATA[<br /><label><input type="checkbox" class="checkbox" name="options[readreceipt]" value="1" tabindex="8" {$optionschecked['readreceipt']} /> {$lang->options_read_receipt}</label>]]></template>
@@ -10602,9 +10602,9 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 		<template name="private_tracking_unreadmessage_stop" version="1800"><![CDATA[<tr>
 <td class="tfoot" align="right" colspan="5"><strong><input type="submit" class="button" name="stoptrackingunread" value="{$lang->stop_tracking}" /> / <input type="submit" class="button" name="cancel" value="{$lang->delete}" /> {$lang->selected_messages}</strong></td>
 </tr>]]></template>
-		<template name="report" version="1808"><![CDATA[<div class="modal">
+		<template name="report" version="1809"><![CDATA[<div class="modal">
   <div style="overflow-y: auto; max-height: 400px;" class="modal_{$id}">
-  <form action="report.php" method="post" class="reportData_{$id}" onsubmit="javascript: return Report.submitReport({$id});">
+  <form action="report.php" method="post" class="reportData_{$id}" onsubmit="return Report.submitReport({$id});">
 <input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 <input type="hidden" name="action" value="do_report" />
 <input type="hidden" name="type" value="{$report_type}" />
@@ -10792,13 +10792,13 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 {$footer}
 </body>
 </html>]]></template>
-		<template name="reputation_add" version="1800"><![CDATA[<div class="modal">
+		<template name="reputation_add" version="1801"><![CDATA[<div class="modal">
 	<div style="overflow-y: auto; max-height: 400px;" class="modal_{$user['uid']}_{$mybb->input['pid']}">
       <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 	<tr>
 		<td class="trow1" style="padding: 20px">
 			<strong>{$vote_title}</strong><br />{$post_rep_info}<br />
-          <form action="reputation.php" method="post" class="reputation_{$user['uid']}_{$mybb->input['pid']}" onsubmit="javascript: return MyBB.submitReputation({$user['uid']}, {$mybb->input['pid']});">
+          <form action="reputation.php" method="post" class="reputation_{$user['uid']}_{$mybb->input['pid']}" onsubmit="return MyBB.submitReputation({$user['uid']}, {$mybb->input['pid']});">
 				<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 				<input type="hidden" name="action" value="do_add" />
 				<input type="hidden" name="uid" value="{$user['uid']}" />
@@ -10825,7 +10825,7 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 </table>
   </div>
 </div>]]></template>
-		<template name="reputation_add_delete" version="1800"><![CDATA[<input type="button" class="button" name="delete" value="{$lang->delete_vote}" onclick="return MyBB.submitReputation({$user['uid']}, {$mybb->input['pid']}, 1);" />]]></template>
+		<template name="reputation_add_delete" version="1809"><![CDATA[<input type="button" class="button" name="delete" value="{$lang->delete_vote}" onclick="return MyBB.submitReputation({$user['uid']}, {$mybb->input['pid']}, 1);" />]]></template>
 		<template name="reputation_add_error" version="1800"><![CDATA[<div class="modal">
 	<div style="overflow-y: auto; max-height: 400px;">
       <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
@@ -10846,9 +10846,9 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 		</td>
 	</tr>
 </table>]]></template>
-		<template name="reputation_add_negative" version="1801"><![CDATA[					<option value="{$neg_value}" class="reputation_negative" onclick="$('#reputation').attr('class', 'reputation_negative');"{$vote_check[$neg_value]}>{$negative_title}</option>]]></template>
-		<template name="reputation_add_neutral" version="1801"><![CDATA[					<option value="0" class="reputation_neutral" onclick="$('#reputation').attr('class', 'reputation_neutral');"{$vote_check[0]}>{$lang->power_neutral}</option>]]></template>
-		<template name="reputation_add_positive" version="1801"><![CDATA[					<option value="{$value}" class="reputation_positive" onclick="$('#reputation').attr('class', 'reputation_positive');"{$vote_check[$value]}>{$positive_title}</option>
+		<template name="reputation_add_negative" version="1809"><![CDATA[					<option value="{$neg_value}" class="reputation_negative" onclick="$('#reputation').attr('class', 'reputation_negative');"{$vote_check[$neg_value]}>{$negative_title}</option>]]></template>
+		<template name="reputation_add_neutral" version="1809"><![CDATA[					<option value="0" class="reputation_neutral" onclick="$('#reputation').attr('class', 'reputation_neutral');"{$vote_check[0]}>{$lang->power_neutral}</option>]]></template>
+		<template name="reputation_add_positive" version="1809"><![CDATA[					<option value="{$value}" class="reputation_positive" onclick="$('#reputation').attr('class', 'reputation_positive');"{$vote_check[$value]}>{$positive_title}</option>
 {$positive_power}]]></template>
 		<template name="reputation_added" version="1800"><![CDATA[<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 	<tr>
@@ -10858,7 +10858,7 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 		</td>
 	</tr>
 </table>]]></template>
-		<template name="reputation_addlink" version="1800"><![CDATA[<div class="float_right" style="padding-bottom: 4px;"><a href="javascript:MyBB.reputation({$user['uid']});" class="button rate_user_button"><span>{$lang->rate_user}</span></a></div>]]></template>
+		<template name="reputation_addlink" version="1801"><![CDATA[<div class="float_right" style="padding-bottom: 4px;"><a href="javascript:void(0)" onclick="MyBB.reputation({$user['uid']}); return false;" class="button rate_user_button"><span>{$lang->rate_user}</span></a></div>]]></template>
 		<template name="reputation_deleted" version="1800"><![CDATA[
 <table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 	<tr>
@@ -10883,8 +10883,8 @@ document.write('<br /><span class="smalltext"><a href="javascript:void(0)" oncli
 			<a href="reputation.php?action=delete&amp;uid={$reputation_vote['rated_uid']}&amp;rid={$reputation_vote['rid']}&amp;my_post_key={$mybb->post_code}" onclick="MyBB.deleteReputation({$reputation_vote['rated_uid']}, {$reputation_vote['rid']}); return false;" class="postbit_qdelete"><span>{$lang->delete_vote}</span></a>
 		</div>]]>
 		</template>
-		<template name="reputation_vote_report" version="1800"><![CDATA[		<div class="float_right postbit_buttons">
-			<a href="javascript:Report.reportReputation({$reputation_vote['rid']});" class="postbit_report"><span>{$lang->report_vote}</span></a>
+		<template name="reputation_vote_report" version="1801"><![CDATA[		<div class="float_right postbit_buttons">
+			<a href="javascript:void(0)" onclick="Report.reportReputation({$reputation_vote['rid']}); return false;" class="postbit_report"><span>{$lang->report_vote}</span></a>
 		</div>]]>
 		</template>
 		<template name="search" version="1807"><![CDATA[<html>
@@ -11026,14 +11026,14 @@ if(use_xmlhttprequest == "1")
 </td>
 </tr>]]></template>
 		<template name="search_orderarrow" version="120"><![CDATA[<span class="smalltext">[<a href="{$sorturl}&amp;sortby={$sortby}&amp;order={$oppsortnext}">{$oppsort}</a>]</span>]]></template>
-		<template name="search_posts_inlinemoderation_selectall" version="1800"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
+		<template name="search_posts_inlinemoderation_selectall" version="1809"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
 	<td colspan="9" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
 	<td colspan="9" class="selectall">{$lang->all_selected} <a href="javascript:void(0)" onclick='inlineModeration.clearChecked(); return false;'>{$lang->clear_selection}</a></td>
 </tr>]]></template>
 		<template name="search_results_icon" version="1800"><![CDATA[<img src="{$posticon['path']}" alt="{$posticon['name']}" title="{$posticon['name']}" />]]></template>
-		<template name="search_results_inlinemodcol" version="1800"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this);" /></td>]]></template>
+		<template name="search_results_inlinemodcol" version="1809"><![CDATA[<td class="tcat" align="center" width="1"><input type="checkbox" name="allbox" onclick="inlineModeration.checkAll(this);" /></td>]]></template>
 		<template name="search_results_posts" version="1600"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->search_results}</title>
@@ -11075,7 +11075,7 @@ if(use_xmlhttprequest == "1")
 </html>]]></template>
 		<template name="search_results_posts_forumlink" version="1808"><![CDATA[<a href="{$post['forumlink_link']}">{$post['forumlink_name']}</a>]]></template>
 		<template name="search_results_posts_inlinecheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap"><input type="checkbox" class="checkbox" name="inlinemod_{$post['pid']}" id="inlinemod_{$post['pid']}" value="1" style="vertical-align: middle;" {$inlinecheck}  /></td>]]></template>
-		<template name="search_results_posts_inlinemoderation" version="1808"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
+		<template name="search_results_posts_inlinemoderation" version="1809"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
 <form action="moderation.php" method="post" style="margin-top: 0; margin-bottom: 0;">
 <input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 <input type="hidden" name="tid" value="0" />
@@ -11111,7 +11111,7 @@ if(use_xmlhttprequest == "1")
 		<template name="search_results_posts_inlinemoderation_custom" version="120"><![CDATA[<optgroup label="{$lang->custom_mod_tools}">{$customposttools}</optgroup>]]></template>
 		<template name="search_results_posts_inlinemoderation_custom_tool" version="120"><![CDATA[<option value="{$tool['tid']}">{$tool['name']}</option>]]></template>
 		<template name="search_results_posts_nocheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap">&nbsp;</td>]]></template>
-		<template name="search_results_posts_post" version="1807"><![CDATA[<tr class="inline_row">
+		<template name="search_results_posts_post" version="1808"><![CDATA[<tr class="inline_row">
 	<td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}">
@@ -11123,7 +11123,7 @@ if(use_xmlhttprequest == "1")
 	</td>
 	<td align="center" class="{$bgcolor}">{$post['profilelink']}</td>
 	<td class="{$bgcolor}" >{$post['forumlink']}</td>
-	<td align="center" class="{$bgcolor}"><a href="javascript:MyBB.whoPosted({$post['tid']});">{$post['thread_replies']}</a></td>
+	<td align="center" class="{$bgcolor}"><a href="javascript:void(0)" onclick="MyBB.whoPosted({$post['tid']}); return false;">{$post['thread_replies']}</a></td>
 	<td align="center" class="{$bgcolor}">{$post['thread_views']}</td>
 	<td class="{$bgcolor}" style="white-space: nowrap; text-align: center;"><span class="smalltext">{$posted}</span></td>
 	{$inline_mod_checkbox}
@@ -11169,7 +11169,7 @@ if(use_xmlhttprequest == "1")
 		</html>]]></template>
 		<template name="search_results_threads_forumlink" version="1808"><![CDATA[<a href="{$thread['forumlink_link']}">{$thread['forumlink_name']}</a>]]></template>
 		<template name="search_results_threads_inlinecheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap"><input type="checkbox" class="checkbox" name="inlinemod_{$thread['tid']}" id="inlinemod_{$thread['tid']}" value="1" style="vertical-align: middle;" {$inlinecheck}  /></td>]]></template>
-		<template name="search_results_threads_inlinemoderation" version="1808"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
+		<template name="search_results_threads_inlinemoderation" version="1809"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
 		<form action="moderation.php" method="post">
 <input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 <input type="hidden" name="fid" value="0" />
@@ -11208,7 +11208,7 @@ if(use_xmlhttprequest == "1")
 		<template name="search_results_threads_inlinemoderation_custom" version="120"><![CDATA[<optgroup label="{$lang->custom_mod_tools}">{$customthreadtools}</optgroup>]]></template>
 		<template name="search_results_threads_inlinemoderation_custom_tool" version="120"><![CDATA[<option value="{$tool['tid']}">{$tool['name']}</option>]]></template>
 		<template name="search_results_threads_nocheck" version="120"><![CDATA[<td class="{$bgcolor}" align="center" style="white-space: nowrap">&nbsp;</td>]]></template>
-		<template name="search_results_threads_thread" version="1800"><![CDATA[<tr class="inline_row">
+		<template name="search_results_threads_thread" version="1801"><![CDATA[<tr class="inline_row">
 	<td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}">
@@ -11219,7 +11219,7 @@ if(use_xmlhttprequest == "1")
 		</div>
 	</td>
 	<td class="{$bgcolor}">{$thread['forumlink']}</td>
-	<td align="center" class="{$bgcolor}"><a href="javascript:MyBB.whoPosted({$thread['tid']});">{$thread['replies']}</a></td>
+	<td align="center" class="{$bgcolor}"><a href="javascript:void(0)" onclick="MyBB.whoPosted({$thread['tid']}); return false;">{$thread['replies']}</a></td>
 	<td align="center" class="{$bgcolor}">{$thread['views']}</td>
 	<td class="{$bgcolor}" style="white-space: nowrap">
 		<span class="smalltext">
@@ -11229,7 +11229,7 @@ if(use_xmlhttprequest == "1")
 	</td>
 	{$inline_mod_checkbox}
 </tr>]]></template>
-		<template name="search_threads_inlinemoderation_selectall" version="1800"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
+		<template name="search_threads_inlinemoderation_selectall" version="1809"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
 	<td colspan="8" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineModeration.selectAll(); return false;'>{$lang->select_all}</a></td>
 </tr>
 <tr id="allSelectedrow" class="hiddenrow">
@@ -11328,7 +11328,7 @@ if(use_xmlhttprequest == "1")
 		<tr>
 			<td class="thead">
 				<div class="float_right">
-					<span class="smalltext"><strong><a href="javascript:;" id="thread_modes">{$lang->thread_modes}</a>{$threadnoteslink}</strong></span>
+					<span class="smalltext"><strong><a href="javascript:void(0)" id="thread_modes">{$lang->thread_modes}</a>{$threadnoteslink}</strong></span>
 				</div>
 				<div>
 					<strong>{$thread['threadprefix']}{$thread['subject']}</strong>
@@ -11398,7 +11398,7 @@ if(use_xmlhttprequest == "1")
 			<td class="tcat"><span class="smalltext"><strong>{$lang->message}</strong></span></td>
 		</tr>
 		]]></template>
-		<template name="showthread_inlinemoderation" version="1810"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
+		<template name="showthread_inlinemoderation" version="1809"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1807"></script>
 <form action="moderation.php" method="post" style="margin-top: 0; margin-bottom: 0;" id="inlinemoderation_options">
 <input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 <input type="hidden" name="tid" value="{$tid}" />
@@ -11556,7 +11556,7 @@ if(use_xmlhttprequest == "1")
 </table>
 <br />]]></template>
 		<template name="showthread_poll_undovote" version="1800"><![CDATA[ [<a href="polls.php?action=do_undovote&amp;pid={$poll['pid']}&amp;my_post_key={$mybb->post_code}">{$lang->undo_vote}</a>]]]></template>
-		<template name="showthread_quickreply" version="1800"><![CDATA[
+		<template name="showthread_quickreply" version="1801"><![CDATA[
 <div id="quickreply_spinner" class="showthread_spinner" style="display: none"><img src="{$theme['imgdir']}/spinner.gif" /></div>
 <br />
 {$moderation_notice}
@@ -11594,7 +11594,7 @@ if(use_xmlhttprequest == "1")
 					</div>
 					<div class="editor_control_bar" style="width: 95%; padding: 4px; margin-top: 3px; display: none;" id="quickreply_multiquote">
 						<span class="smalltext">
-							{$lang->quickreply_multiquote_selected} <a href="./newreply.php?tid={$tid}&amp;load_all_quotes=1" onclick="return Thread.loadMultiQuoted();">{$lang->quickreply_multiquote_now}</a> {$lang->or} <a href="javascript:Thread.clearMultiQuoted();">{$lang->quickreply_multiquote_deselect}</a>.
+							{$lang->quickreply_multiquote_selected} <a href="./newreply.php?tid={$tid}&amp;load_all_quotes=1" onclick="return Thread.loadMultiQuoted();">{$lang->quickreply_multiquote_now}</a> {$lang->or} <a href="javascript:void(0)" onclick="Thread.clearMultiQuoted(); return false;">{$lang->quickreply_multiquote_deselect}</a>.
 						</span>
 					</div>
 				</td>
@@ -11651,11 +11651,11 @@ if(use_xmlhttprequest == "1")
 </tr>
 {$similarthreadbits}
 </table>]]></template>
-		<template name="showthread_similarthreads_bit" version="1800"><![CDATA[<tr>
+		<template name="showthread_similarthreads_bit" version="1801"><![CDATA[<tr>
 	<td align="center" class="{$trow}" width="2%">{$icon}</td>
 	<td class="{$trow}">{$similar_thread['threadprefix']}<a href="{$similar_thread['threadlink']}">{$similar_thread['subject']}</a></td>
 	<td align="center" class="{$trow}">{$similar_thread['profilelink']}</td>
-	<td align="center" class="{$trow}"><a href="javascript:MyBB.whoPosted({$similar_thread['tid']});">{$similar_thread['replies']}</a></td>
+	<td align="center" class="{$trow}"><a href="javascript:void(0)" onclick="MyBB.whoPosted({$similar_thread['tid']}); return false;">{$similar_thread['replies']}</a></td>
 	<td align="center" class="{$trow}">{$similar_thread['views']}</td>
 	<td class="{$trow}" style="white-space: nowrap">
 		<span class="smalltext">{$lastpostdate}<br />
@@ -11691,7 +11691,7 @@ if(use_xmlhttprequest == "1")
 </tbody>
 </table>
 <br />]]></template>
-		<template name="showthread_threadnotes_viewnotes" version="1800"><![CDATA[[<a href="javascript:Thread.viewNotes({$thread['tid']});">{$lang->view_all_notes}</a>]]]></template>
+		<template name="showthread_threadnotes_viewnotes" version="1801"><![CDATA[[<a href="javascript:void(0)" onclick="Thread.viewNotes({$thread['tid']}); return false;">{$lang->view_all_notes}</a>]]]></template>
 		<template name="showthread_threadnoteslink" version="1800"><![CDATA[ | <a href="moderation.php?action=threadnotes&modtype=thread&tid={$thread['tid']}">{$lang->view_thread_notes}</a>]]></template>
 		<template name="showthread_usersbrowsing" version="1600"><![CDATA[<br />
 <span class="smalltext">{$lang->users_browsing_thread} {$onlinemembers}{$onlinesep}{$invisonline}{$onlinesep2}{$guestsonline}</span>
@@ -11713,8 +11713,8 @@ if(use_xmlhttprequest == "1")
 {$getmore}
 </table>
 </div>]]></template>
-		<template name="smilieinsert_getmore" version="1804"><![CDATA[<tr>
-  <td class="trow2" align="center"><span class="smalltext"><strong>[<a href="javascript:MyBB.popupWindow('/misc.php?action=smilies&popup=true&editor=MyBBEditor&modal=1')">{$lang->smilieinsert_getmore}</a>]</strong></span></td>
+		<template name="smilieinsert_getmore" version="1805"><![CDATA[<tr>
+  <td class="trow2" align="center"><span class="smalltext"><strong>[<a href="javascript:void(0)" onclick="MyBB.popupWindow('/misc.php?action=smilies&popup=true&editor=MyBBEditor&modal=1'); return false;">{$lang->smilieinsert_getmore}</a>]</strong></span></td>
 </tr>]]></template>
 		<template name="smilieinsert_row" version="1808"><![CDATA[<tr>{$smilie_icons}</tr>]]></template>
 		<template name="smilieinsert_row_empty" version="1808"><![CDATA[<tr>{$smilie_icons}<td colspan="{$colspan}">&nbsp;</td></tr>]]></template>
@@ -12562,11 +12562,11 @@ if(use_xmlhttprequest == "1")
 </tr>
 {$latest_subscribed_threads}
 </table>]]></template>
-		<template name="usercp_latest_subscribed_threads" version="1800"><![CDATA[<tr>
+		<template name="usercp_latest_subscribed_threads" version="1801"><![CDATA[<tr>
 <td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 <td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 <td class="{$bgcolor}">{$gotounread}{$thread['displayprefix']}<a href="{$thread['threadlink']}" class="{$new_class}">{$thread['subject']}</a><br /><span class="smalltext">{$thread['author']}</span></td>
-<td align="center" class="{$bgcolor}"><a href="javascript:MyBB.whoPosted({$thread['tid']});">{$thread['replies']}</a></td>
+<td align="center" class="{$bgcolor}"><a href="javascript:void(0)" onclick="MyBB.whoPosted({$thread['tid']}); return false;">{$thread['replies']}</a></td>
 <td align="center" class="{$bgcolor}">{$thread['views']}</td>
 <td class="{$bgcolor}" style="white-space: nowrap"><span class="smalltext">{$lastpostdate}
 <br /><a href="{$thread['lastpostlink']}">{$lang->lastpost}</a>: {$lastposterlink}</span>
@@ -12585,11 +12585,11 @@ if(use_xmlhttprequest == "1")
 </tr>
 {$latest_threads_threads}
 </table>]]></template>
-		<template name="usercp_latest_threads_threads" version="1800"><![CDATA[<tr>
+		<template name="usercp_latest_threads_threads" version="1801"><![CDATA[<tr>
 <td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 <td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 <td class="{$bgcolor}">{$gotounread}{$thread['displayprefix']}<a href="{$thread['threadlink']}" class="{$new_class}">{$thread['subject']}</a><br /><span class="smalltext">{$thread['author']}</span></td>
-<td align="center" class="{$bgcolor}"><a href="javascript:MyBB.whoPosted({$thread['tid']});">{$thread['replies']}</a></td>
+<td align="center" class="{$bgcolor}"><a href="javascript:void(0)" onclick="MyBB.whoPosted({$thread['tid']}); return false;">{$thread['replies']}</a></td>
 <td align="center" class="{$bgcolor}">{$thread['views']}</td>
 <td class="{$bgcolor}" style="white-space: nowrap"><span class="smalltext">{$lastpostdate}
 <br /><a href="{$thread['lastpostlink']}">{$lang->lastpost}</a>: {$lastposterlink}</span>
@@ -13331,11 +13331,11 @@ if(use_xmlhttprequest == "1")
 	</div>
 	</td>
 </tr>]]></template>
-		<template name="usercp_subscriptions_thread" version="1800"><![CDATA[<tr>
+		<template name="usercp_subscriptions_thread" version="1801"><![CDATA[<tr>
 	<td align="center" class="{$bgcolor}" width="2%"><span class="thread_status {$folder}" title="{$folder_label}">&nbsp;</span></td>
 	<td align="center" class="{$bgcolor}" width="2%">{$icon}</td>
 	<td class="{$bgcolor}">{$gotounread}{$thread['threadprefix']}<a href="{$thread['threadlink']}" class="{$new_class}">{$thread['subject']}</a><br /><span class="smalltext">{$lang->notification_method} {$notification_type}</span></td>
-	<td align="center" class="{$bgcolor}"><a href="javascript:MyBB.whoPosted({$thread['tid']});">{$thread['replies']}</a></td>
+	<td align="center" class="{$bgcolor}"><a href="javascript:void(0)" onclick="MyBB.whoPosted({$thread['tid']}); return false;">{$thread['replies']}</a></td>
 	<td align="center" class="{$bgcolor}">{$thread['views']}</td>
 	<td class="{$bgcolor}" style="white-space: nowrap">
 		<span class="smalltext">{$lastpostdate}<br />
@@ -13848,7 +13848,7 @@ if(use_xmlhttprequest == "1")
 				<td class="{$alt_bg}" style="text-align: center;">{$issuedby}</td>
 				<td class="{$alt_bg}" style="text-align: center;"><a href="warnings.php?action=view&amp;wid={$warning['wid']}">{$lang->view}</a></td>
 			</tr>]]></template>
-		<template name="xmlhttp_buddyselect" version="1800"><![CDATA[<table border="0" cellspacing="1" cellpadding="4" class="tborder" style="width: 300px;">
+		<template name="xmlhttp_buddyselect" version="1809"><![CDATA[<table border="0" cellspacing="1" cellpadding="4" class="tborder" style="width: 300px;">
 	<thead>
 		<tr>
 			<td class="thead">


### PR DESCRIPTION
#2522 

I've also standardized onclick calls (some are called with an old-fashioned javascript: prefix, the majority don't so I've deleted the javascript: prefix where present).

Despite fixing the issue, I do believe onclick should be avoided and added to inline scripts where possible.