### PR TITLE
Update SFS registration link to get an API key

### DIFF
--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -2318,7 +2318,7 @@ delete=Delete]]></optionscode>
 		</setting>
 		<setting name="purgespammerapikey">
 			<title>Stop Forum Spam API Key</title>
-			<description><![CDATA[In order to be able to submit information on a spammer to the Stop Forum Spam database, you need an API key. You can get one of these <a href="http://stopforumspam.com/signup" target="_blank">here</a>. When you have your key, paste it into the box below.]]></description>
+			<description><![CDATA[In order to be able to submit information on a spammer to the Stop Forum Spam database, you need an API key. You can get one of these <a href="https://www.stopforumspam.com/forum/register.php" target="_blank">here</a>. When you have your key, paste it into the box below.]]></description>
 			<disporder>6</disporder>
 			<optionscode><![CDATA[text]]></optionscode>
 			<settingvalue><![CDATA[]]></settingvalue>


### PR DESCRIPTION
SFS registration link was changed since they stopped anonymous registrations and requires to register in their forum first to get an API key.