### PR TITLE
Wrong MySQL version detected

### DIFF
--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -1057,13 +1057,9 @@ class DB_MySQL implements DB_Base
 			return $this->version;
 		}
 
-		$version = @mysql_get_server_info();
-		if(!$version)
-		{
-			$query = $this->query("SELECT VERSION() as version");
-			$ver = $this->fetch_array($query);
-			$version = $ver['version'];
-		}
+		$query = $this->query("SELECT VERSION() as version");
+		$ver = $this->fetch_array($query);
+		$version = $ver['version'];
 
 		if($version)
 		{

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -1050,13 +1050,9 @@ class DB_MySQLi implements DB_Base
 			return $this->version;
 		}
 
-		$version = @mysqli_get_server_info($this->read_link);
-		if(!$version)
-		{
-			$query = $this->query("SELECT VERSION() as version");
-			$ver = $this->fetch_array($query);
-			$version = $ver['version'];
-		}
+		$query = $this->query("SELECT VERSION() as version");
+		$ver = $this->fetch_array($query);
+		$version = $ver['version'];
 
 		if($version)
 		{


### PR DESCRIPTION
If you are using MariaDB 10.x.x the server version returned is always 5.5.5 with mysqli_get_server_info().
With this issue, you cannot use FULLTEXT search with MariaDB.
More info: http://php.net/manual/en/mysqli.get-server-info.php#118822