### PR TITLE
Fixes #2663 - Wrong link to announcements in ModCP announcement list

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -6292,15 +6292,15 @@ if(use_xmlhttprequest == "1")
 	{$footer}
 </body>
 </html>]]></template>
-		<template name="modcp_announcements_announcement" version="1400"><![CDATA[					<tr>
-						<td class="{$trow}"><div style="padding-left: {$padding}px;">{$icon}<a href="modcp.php?action=edit_announcement&amp;aid={$aid}">{$subject}</a></div></td>
+		<template name="modcp_announcements_announcement" version="1811"><![CDATA[					<tr>
+						<td class="{$trow}"><div style="padding-left: {$padding}px;">{$icon}<a href="announcements.php?aid={$aid}">{$subject}</a></div></td>
 						<td class="{$trow}" align="center"><a href="modcp.php?action=edit_announcement&amp;aid={$aid}">{$lang->edit}</a></td>
 						<td class="{$trow}" align="center"><a href="modcp.php?action=delete_announcement&amp;aid={$aid}">{$lang->delete}</a></td>
 					</tr>]]></template>
 		<template name="modcp_announcements_announcement_active" version="1800"><![CDATA[<div class="subforumicon subforum_minion" title="{$lang->active_announcement}"></div>]]></template>
 		<template name="modcp_announcements_announcement_expired" version="1800"><![CDATA[<div class="subforumicon subforum_minioff" title="{$lang->expired_announcement}"></div>]]></template>
-		<template name="modcp_announcements_announcement_global" version="1400"><![CDATA[					<tr>
-						<td class="{$trow}">{$icon}<a href="modcp.php?action=edit_announcement&amp;aid={$aid}">{$subject}</a></td>
+		<template name="modcp_announcements_announcement_global" version="1811"><![CDATA[					<tr>
+						<td class="{$trow}">{$icon}<a href="announcements.php?aid={$aid}">{$subject}</a></td>
 						<td class="{$trow}" align="center"><a href="modcp.php?action=edit_announcement&amp;aid={$aid}">{$lang->edit}</a></td>
 						<td class="{$trow}" align="center"><a href="modcp.php?action=delete_announcement&amp;aid={$aid}">{$lang->delete}</a></td>
 					</tr>]]></template>


### PR DESCRIPTION
#2663 Wrong link to announcements in ModCP announcement list

After fix:
![issue_modcp_announcement_links_fix](https://cloud.githubusercontent.com/assets/9826631/22863792/c2303ea4-f146-11e6-95d8-b8b20a802022.PNG)
