### PR TITLE
Fixes #2382 my_date - no time for non-relative $format

### DIFF
--- a/admin/modules/tools/mailerrors.php
+++ b/admin/modules/tools/mailerrors.php
@@ -71,7 +71,7 @@ if($mybb->input['action'] == "view")
 	$log['subject'] = htmlspecialchars_uni($log['subject']);
 	$log['error'] = htmlspecialchars_uni($log['error']);
 	$log['smtperror'] = htmlspecialchars_uni($log['smtpcode']);
-	$log['dateline'] = date($mybb->settings['dateformat'], $log['dateline']).", ".date($mybb->settings['timeformat'], $log['dateline']);
+	$log['dateline'] = my_date('relative', $log['dateline']);
 	$log['message'] = nl2br(htmlspecialchars_uni($log['message']));
 
 	?>
@@ -214,7 +214,7 @@ if(!$mybb->input['action'])
 		$log['subject'] = htmlspecialchars_uni($log['subject']);
 		$log['toemail'] = htmlspecialchars_uni($log['toemail']);
 		$log['error'] = htmlspecialchars_uni($log['error']);
-		$log['dateline'] = date($mybb->settings['dateformat'], $log['dateline']).", ".date($mybb->settings['timeformat'], $log['dateline']);
+		$log['dateline'] = my_date('relative', $log['dateline']);
 
 		$table->construct_cell($form->generate_check_box("log[{$log['eid']}]", $log['eid'], ''));
 		$table->construct_cell("<a href=\"javascript:MyBB.popupWindow('index.php?module=tools-mailerrors&amp;action=view&amp;eid={$log['eid']}', null, true);\">{$log['subject']}</a>");

--- a/admin/modules/tools/maillogs.php
+++ b/admin/modules/tools/maillogs.php
@@ -69,7 +69,7 @@ if($mybb->input['action'] == "view")
 	$log['toemail'] = htmlspecialchars_uni($log['toemail']);
 	$log['fromemail'] = htmlspecialchars_uni($log['fromemail']);
 	$log['subject'] = htmlspecialchars_uni($log['subject']);
-	$log['dateline'] = date($mybb->settings['dateformat'], $log['dateline']).", ".date($mybb->settings['timeformat'], $log['dateline']);
+	$log['dateline'] = my_date('relative', $log['dateline']);
 	if($mybb->settings['mail_logging'] == 1)
 	{
 		$log['message'] = $lang->na;
@@ -289,7 +289,7 @@ if(!$mybb->input['action'])
 	{
 		$table->construct_cell($form->generate_check_box("log[{$log['mid']}]", $log['mid'], ''), array("width" => 1));
 		$log['subject'] = htmlspecialchars_uni($log['subject']);
-		$log['dateline'] = date($mybb->settings['dateformat'], $log['dateline']).", ".date($mybb->settings['timeformat'], $log['dateline']);
+		$log['dateline'] = my_date('relative', $log['dateline']);
 
 		if($log['type'] == 2)
 		{

--- a/admin/modules/tools/system_health.php
+++ b/admin/modules/tools/system_health.php
@@ -757,7 +757,7 @@ if(!$mybb->input['action'])
 	while($task = $db->fetch_array($query))
 	{
 		$task['title'] = htmlspecialchars_uni($task['title']);
-		$next_run = date($mybb->settings['dateformat'], $task['nextrun']).", ".date($mybb->settings['timeformat'], $task['nextrun']);
+		$next_run = my_date('normal', $task['nextrun'], "", 2);
 		$table->construct_cell("<strong>{$task['title']}</strong>");
 		$table->construct_cell($next_run, array("class" => "align_center"));
 

--- a/admin/modules/tools/tasks.php
+++ b/admin/modules/tools/tasks.php
@@ -730,7 +730,7 @@ if(!$mybb->input['action'])
 	{
 		$task['title'] = htmlspecialchars_uni($task['title']);
 		$task['description'] = htmlspecialchars_uni($task['description']);
-		$next_run = date($mybb->settings['dateformat'], $task['nextrun']).", ".date($mybb->settings['timeformat'], $task['nextrun']);
+		$next_run = my_date('normal', $task['nextrun'], "", 2);
 		if($task['enabled'] == 1)
 		{
 			$icon = "<img src=\"styles/{$page->style}/images/icons/bullet_on.png\" alt=\"({$lang->alt_enabled})\" title=\"{$lang->alt_enabled}\"  style=\"vertical-align: middle;\" /> ";

--- a/admin/modules/user/group_promotions.php
+++ b/admin/modules/user/group_promotions.php
@@ -689,7 +689,7 @@ if($mybb->input['action'] == "logs")
 			$log['type'] = $lang->primary;
 		}
 
-		$log['dateline'] = date($mybb->settings['dateformat'], $log['dateline']).", ".date($mybb->settings['timeformat'], $log['dateline']);
+		$log['dateline'] = my_date('relative', $log['dateline']);
 		$table->construct_cell($log['username']);
 		$table->construct_cell($log['type'], array('style' => 'text-align: center;'));
 		$table->construct_cell($log['oldusergroup'], array('style' => 'text-align: center;'));

--- a/global.php
+++ b/global.php
@@ -715,7 +715,7 @@ if($mybb->usergroup['isbannedgroup'] == 1)
 
 		if($ban['lifted'] > 0)
 		{
-			$banlift = my_date($mybb->settings['dateformat'], $ban['lifted']) . $lang->comma . my_date($mybb->settings['timeformat'], $ban['lifted']);
+			$banlift = my_date('normal', $ban['lifted']);
 		}
 	}
 

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -821,7 +821,14 @@ class postParser
 		{
 			if($match[1] < TIME_NOW)
 			{
-				$postdate = my_date('relative', (int)$match[1]);
+				if($text_only)
+				{
+					$postdate = my_date('normal', (int)$match[1]);
+				}
+				else
+				{
+					$postdate = my_date('relative', (int)$match[1]);
+				}
 				$date = " ({$postdate})";
 			}
 			$username = preg_replace("#(?:&quot;|\"|')? dateline=(?:&quot;|\"|')?[0-9]+(?:&quot;|\"|')?#i", '', $username);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -322,7 +322,7 @@ function parse_page($contents)
 /**
  * Turn a unix timestamp in to a "friendly" date/time format for the user.
  *
- * @param string $format A date format according to PHP's date structure.
+ * @param string $format A date format (either relative, normal or PHP's date() structure).
  * @param int $stamp The unix timestamp the date should be generated for.
  * @param int|string $offset The offset in hours that should be applied to times. (timezones) Or an empty string to determine that automatically
  * @param int $ty Whether or not to use today/yesterday formatting.
@@ -380,7 +380,7 @@ function my_date($format, $stamp=0, $offset="", $ty=1, $adodb=false)
 	}
 
 	$todaysdate = $yesterdaysdate = '';
-	if($ty && ($format == $mybb->settings['dateformat'] || $format == 'relative'))
+	if($ty && ($format == $mybb->settings['dateformat'] || $format == 'relative' || $format == 'normal'))
 	{
 		$_stamp = TIME_NOW;
 		if($adodb == true)
@@ -470,11 +470,11 @@ function my_date($format, $stamp=0, $offset="", $ty=1, $adodb=false)
 			{
 				if($todaysdate == $date)
 				{
-					$date = $lang->sprintf($lang->today, $real_date);
+					$date = $lang->sprintf($lang->today_rel, $real_date);
 				}
 				else if($yesterdaysdate == $date)
 				{
-					$date = $lang->sprintf($lang->yesterday, $real_date);
+					$date = $lang->sprintf($lang->yesterday_rel, $real_date);
 				}
 			}
 
@@ -489,17 +489,42 @@ function my_date($format, $stamp=0, $offset="", $ty=1, $adodb=false)
 			}
 		}
 	}
+	elseif($format == 'normal')
+	{
+		// Normal format both date and time
+		if($ty != 2)
+		{
+			if($todaysdate == $date)
+			{
+				$date = $lang->today;
+			}
+			else if($yesterdaysdate == $date)
+			{
+				$date = $lang->yesterday;
+			}
+		}
+
+		$date .= $mybb->settings['datetimesep'];
+		if($adodb == true)
+		{
+			$date .= adodb_date($mybb->settings['timeformat'], $stamp + ($offset * 3600));
+		}
+		else
+		{
+			$date .= gmdate($mybb->settings['timeformat'], $stamp + ($offset * 3600));
+		}
+	}
 	else
 	{
 		if($ty && $format == $mybb->settings['dateformat'])
 		{
 			if($todaysdate == $date)
 			{
-				$date = $lang->sprintf($lang->today, $real_date);
+				$date = $lang->today;
 			}
 			else if($yesterdaysdate == $date)
 			{
-				$date = $lang->sprintf($lang->yesterday, $real_date);
+				$date = $lang->yesterday;
 			}
 		}
 		else

--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -920,7 +920,7 @@ function get_post_attachments($id, &$post)
 				{
 					$attachment['dateuploaded'] = $attachment['dateline'];
 				}
-				$attachdate = my_date('relative', $attachment['dateuploaded']);
+				$attachdate = my_date('normal', $attachment['dateuploaded']);
 				// Support for [attachment=id] code
 				if(stripos($post['message'], "[attachment=".$attachment['aid']."]") !== false)
 				{

--- a/inc/languages/english/admin/global.lang.php
+++ b/inc/languages/english/admin/global.lang.php
@@ -5,8 +5,10 @@
  *
  */
 
-$l['today'] = "<span title=\"{1}\">Today</span>";
-$l['yesterday'] = "<span title=\"{1}\">Yesterday</span>";
+$l['today_rel'] = "<span title=\"{1}\">Today</span>";
+$l['yesterday_rel'] = "<span title=\"{1}\">Yesterday</span>";
+$l['today'] = "Today";
+$l['yesterday'] = "Yesterday";
 
 $l['size_yb'] = "YB";
 $l['size_zb'] = "ZB";

--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -132,8 +132,10 @@ $l['no_subscribe_notification'] = "Subscribe without receiving any notification 
 $l['instant_email_subscribe'] = "Subscribe and receive email notification of new replies";
 $l['instant_pm_subscribe'] = "Subscribe and receive PM notification of new replies";
 
-$l['today'] = "<span title=\"{1}\">Today</span>";
-$l['yesterday'] = "<span title=\"{1}\">Yesterday</span>";
+$l['today_rel'] = "<span title=\"{1}\">Today</span>";
+$l['yesterday_rel'] = "<span title=\"{1}\">Yesterday</span>";
+$l['today'] = "Today";
+$l['yesterday'] = "Yesterday";
 $l['error'] = "Board Message";
 
 $l['multipage_pages'] = "Pages ({1}):";

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<theme name="MyBB Master Style" version="1811">
+<theme name="MyBB Master Style" version="1813">
 	<properties>
 		<templateset><![CDATA[1]]></templateset>
 		<imgdir><![CDATA[images]]></imgdir>
@@ -9,7 +9,7 @@
 		<editortheme><![CDATA[mybb.css]]></editortheme>
 	</properties>
 	<stylesheets>
-		<stylesheet name="global.css" version="1811" disporder="1"><![CDATA[body {
+		<stylesheet name="global.css" version="1813" disporder="1"><![CDATA[body {
 	background: #fff;
 	color: #333;
 	text-align: center;
@@ -791,7 +791,7 @@ blockquote cite {
 	margin: 0 0 10px 0;
 }
 
-blockquote cite span {
+blockquote cite > span {
 	float: right;
 	font-weight: normal;
 	font-size: 12px;

--- a/modcp.php
+++ b/modcp.php
@@ -3527,7 +3527,7 @@ if($mybb->input['action'] == "warninglogs")
 		$row['mod_username'] = htmlspecialchars_uni($row['mod_username']);
 		$mod_username = format_name($row['mod_username'], $row['mod_usergroup'], $row['mod_displaygroup']);
 		$mod_username_link = build_profile_link($mod_username, $row['mod_uid']);
-		$issued_date = my_date($mybb->settings['dateformat'], $row['dateline']).' '.my_date($mybb->settings['timeformat'], $row['dateline']);
+		$issued_date = my_date('normal', $row['dateline']);
 		$revoked_text = '';
 		if($row['daterevoked'] > 0)
 		{

--- a/usercp.php
+++ b/usercp.php
@@ -2867,7 +2867,7 @@ if($mybb->input['action'] == "editlists")
 				{
 					$bgcolor = alt_trow();
 					$request['username'] = build_profile_link(htmlspecialchars_uni($request['username']), (int)$request['touid']);
-					$request['date'] = my_date($mybb->settings['dateformat'], $request['date'])." ".my_date($mybb->settings['timeformat'], $request['date']);
+					$request['date'] = my_date('relative', $request['date']);
 					eval("\$sent_rows .= \"".$templates->get("usercp_editlists_sent_request", 1, 0)."\";");
 				}
 
@@ -2901,7 +2901,7 @@ if($mybb->input['action'] == "editlists")
 	{
 		$bgcolor = alt_trow();
 		$request['username'] = build_profile_link(htmlspecialchars_uni($request['username']), (int)$request['uid']);
-		$request['date'] = my_date($mybb->settings['dateformat'], $request['date'])." ".my_date($mybb->settings['timeformat'], $request['date']);
+		$request['date'] = my_date('relative', $request['date']);
 		eval("\$received_rows .= \"".$templates->get("usercp_editlists_received_request")."\";");
 	}
 
@@ -2923,7 +2923,7 @@ if($mybb->input['action'] == "editlists")
 	{
 		$bgcolor = alt_trow();
 		$request['username'] = build_profile_link(htmlspecialchars_uni($request['username']), (int)$request['touid']);
-		$request['date'] = my_date($mybb->settings['dateformat'], $request['date'])." ".my_date($mybb->settings['timeformat'], $request['date']);
+		$request['date'] = my_date('relative', $request['date']);
 		eval("\$sent_rows .= \"".$templates->get("usercp_editlists_sent_request")."\";");
 	}
 

--- a/warnings.php
+++ b/warnings.php
@@ -274,7 +274,7 @@ if($mybb->input['action'] == "warn")
 				}
 				else
 				{
-					$expires = my_date($mybb->settings['dateformat'], $warning['expires']) . ", " . my_date($mybb->settings['timeformat'], $warning['expires']);
+					$expires = my_date('normal', $warning['expires']);
 				}
 			}
 			else
@@ -654,7 +654,7 @@ if($mybb->input['action'] == "view")
 		}
 		else
 		{
-			$expires = my_date($mybb->settings['dateformat'], $warning['expires']) . ", " . my_date($mybb->settings['timeformat'], $warning['expires']);
+			$expires = my_date('normal', $warning['expires']);
 		}
 		$status = $lang->warning_active;
 	}
@@ -666,7 +666,7 @@ if($mybb->input['action'] == "view")
 		}
 		else if($warning['expires'])
 		{
-			$revoked_date = '('.my_date($mybb->settings['dateformat'], $warning['expires']).', '.my_date($mybb->settings['timeformat'], $warning['expires']).')';
+			$revoked_date = '('.my_date('normal', $warning['expires']).')';
 			$expires = $status = $lang->already_expired;
 		}
 	}
@@ -840,7 +840,7 @@ if(!$mybb->input['action'])
 			}
 			else
 			{
-				$expires = my_date($mybb->settings['dateformat'], $warning['expires']) . ", " . my_date($mybb->settings['timeformat'], $warning['expires']);
+				$expires = my_date('normal', $warning['expires']);
 			}
 		}
 		else


### PR DESCRIPTION
Fixes #2382 

- Added a 'normal' format to the my_date function. This will fully format the date and time without using relative dating.
- Changed a few instances of date() to my_date().
- Changed attachment hover from relative to normal (fixes #2751).
- Changed a few dates from older 1.6 style to 1.8 style.
- Fixed issue with relative time in quoted post (fix from [here](https://community.mybb.com/thread-210659-post-1274718.html#pid1274718)).
- Changed PM subscription excerpt to use normal date format (fixes #2802).