### PR TITLE
Fixes #2371 Incorrect user activity when action is unset

### DIFF
--- a/inc/functions_online.php
+++ b/inc/functions_online.php
@@ -245,7 +245,7 @@ function fetch_wol_activity($location, $nopermission=false)
 		case "modcp":
 			if(!isset($parameters['action']))
 			{
-				$parameters['action'] = 0;
+				$parameters['action'] = '';
 			}
 
 			$accepted_parameters = array("modlogs", "announcements", "finduser", "warninglogs", "ipsearch");
@@ -442,7 +442,7 @@ function fetch_wol_activity($location, $nopermission=false)
 		case "showthread":
 			if(!isset($parameters['action']))
 			{
-				$parameters['action'] = 0;
+				$parameters['action'] = '';
 			}
 			if(!isset($parameters['pid']))
 			{


### PR DESCRIPTION
Fixes #2371 
The problem was initially setting the action to `0`. When checked by the first `in_array`, the loop was exited as the non-strict comparison evaluated to true.