### PR TITLE
Fixes #154 Select All for Reports

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -1160,7 +1160,7 @@ if(!empty($threadcache) && is_array($threadcache))
 
 		if($ismod)
 		{
-			if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|{$thread['tid']}|"))
+			if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|{$thread['tid']}|") !== false)
 			{
 				$inlinecheck = "checked=\"checked\"";
 				++$inlinecount;

--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -536,7 +536,7 @@ function build_postbit($post, $post_type=0)
 		{
 			$forumpermissions = forum_permissions($fid);
 		}
-		
+
 		// Figure out if we need to show an "edited by" message
 		if($post['edituid'] != 0 && $post['edittime'] != 0 && $post['editusername'] != "" && (($mybb->settings['showeditedby'] != 0 && $usergroup['cancp'] == 0) || ($mybb->settings['showeditedbyadmin'] != 0 && $usergroup['cancp'] == 1)))
 		{
@@ -631,7 +631,7 @@ function build_postbit($post, $post_type=0)
 		// Inline moderation stuff
 		if($ismod)
 		{
-			if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|".$post['pid']."|"))
+			if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|".$post['pid']."|") !== false)
 			{
 				$inlinecheck = "checked=\"checked\"";
 				$inlinecount++;
@@ -895,7 +895,7 @@ function get_post_attachments($id, &$post)
 	{
 		$forumpermissions = forum_permissions($post['fid']);
 	}
-	
+
 	if(isset($attachcache[$id]) && is_array($attachcache[$id]))
 	{ // This post has 1 or more attachments
 		foreach($attachcache[$id] as $aid => $attachment)

--- a/inc/languages/english/modcp.lang.php
+++ b/inc/languages/english/modcp.lang.php
@@ -41,10 +41,11 @@ $l['report_time'] = "Reported";
 $l['mark_read'] = "Mark Selected as Read";
 $l['no_reports'] = "There are currently no unread reports.";
 $l['no_logs'] = "No moderator actions are currently logged.";
-$l['error_noselected_reports'] = "Sorry, but you did not select any reported posts to mark as read. Either that or the selected posts have already been marked read by another user.";
+$l['error_noselected_reports'] = "Sorry, but you did not select any reported content to mark as read.";
 $l['error_missing_ipaddress'] = "Sorry, but you did not enter in an IP Address to find.";
 $l['error_no_results'] = "Sorry, there were no results found with the criteria you selected.";
-$l['redirect_reportsmarked'] = "The selected reported posts have been marked as read.";
+$l['redirect_reportsmarked'] = "The selected reported content have been marked as read.";
+$l['redirect_allreportsmarked'] = "All reported content has been marked as read.";
 $l['redirect_modnotes'] = "The moderator notes have been updated.";
 
 $l['for'] = "For";
@@ -61,6 +62,11 @@ $l['report_info_profile'] = "Profile of {1}";
 $l['report_info_reputation'] = "<a href=\"{1}\">Reputation</a> from {2}";
 $l['report_info_rep_profile'] = "<br /><span class=\"smalltext\">On {1}'s profile</span>";
 $l['report_info_lastreporter'] = "{1}<br />by {2}";
+
+$l['page_selected'] = "All <strong>{1}</strong> unread reports on this page are selected.";
+$l['all_selected'] = "All <strong>{1}</strong> unread reports are selected.";
+$l['select_all'] = "Select all <strong>{1}</strong> unread reports.";
+$l['clear_selection'] = "Clear Selection.";
 
 $l['moderator_notes'] = "Moderator Notes";
 $l['notes_public_all'] = "These notes are public to all moderators.";

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -7722,10 +7722,11 @@ if(use_xmlhttprequest == "1")
 		<template name="modcp_no_announcements_global" version="1400"><![CDATA[					<tr>
 						<td class="trow1" colspan="3">{$lang->no_global_announcements}</td>
 					</tr>]]></template>
-		<template name="modcp_reports" version="1808"><![CDATA[<html>
+		<template name="modcp_reports" version="1813"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->report_center}</title>
 {$headerinclude}
+<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_reports.js?ver=1813"></script>
 </head>
 <body>
 {$header}
@@ -7745,8 +7746,9 @@ if(use_xmlhttprequest == "1")
 			<td class="tcat" align="left" width="25%"><span class="smalltext"><strong>{$lang->report_type}</strong></span></td>
 			<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->report_count}</strong></span></td>
 			<td class="tcat" align="right" width="20%"><span class="smalltext"><strong>{$lang->report_lastpost}</strong></span></td>
-			<td class="tcat" align="center" width="5%"><input type="checkbox" name="allbox" onclick="selectReportedPosts();" /></td>
+			<td class="tcat" align="center" width="5%"><input type="checkbox" name="allbox" onclick="inlineReports.checkAll(this);" /></td>
 		</tr>
+		{$selectall}
 		{$reports}
 		<tr>
 			<td class="tfoot" colspan="7" align="right"><span class="smalltext"><strong><a href="modcp.php?action=allreports">{$lang->view_all_reports}</a></strong></span></td>
@@ -7754,7 +7756,7 @@ if(use_xmlhttprequest == "1")
 		</table>
 		{$reportspages}
 		<br />
-		<div align="center"><input type="hidden" name="action" value="do_reports" /><input type="submit" class="button" name="reportsubmit" value="{$lang->mark_read}" /></div>
+		<div align="center"><input type="hidden" name="action" value="do_reports" /><input type="submit" id="inline_read" class="button" name="reportsubmit" value="{$lang->mark_read} ({$inlinecount})" /></div>
 	</td>
 </tr>
 </table>
@@ -7762,28 +7764,8 @@ if(use_xmlhttprequest == "1")
 {$footer}
 <script type="text/javascript">
 <!--
-	var checked = false;
-	function selectReportedPosts()
-	{
-		if(checked == false)
-		{
-			checked = true;
-			$('input:checkbox').prop('checked', true);
-		}
-		else
-		{
-			checked = false;
-			$('input:checkbox').prop('checked', false);
-		}
-	}
-
-	function checkReportedPost(e)
-	{
-		if($(e).prop('checked') == false)
-		{
-			$('input:checkbox[name="allbox"]').prop('checked', false);
-		}
-	}
+	var mark_read_text = "{$lang->mark_read}";
+	var all_text = "{$report_count}";
 // -->
 </script>
 </body>
@@ -7833,15 +7815,21 @@ if(use_xmlhttprequest == "1")
 		<template name="modcp_reports_noreports" version="1607"><![CDATA[<tr>
 <td class="trow1" align="center" colspan="7">{$lang->no_reports}</td>
 </tr>]]></template>
-		<template name="modcp_reports_report" version="1808"><![CDATA[<tr>
+		<template name="modcp_reports_report" version="1813"><![CDATA[<tr class="inline_row">
 	<td class="{$trow}">{$report_data['content']}</td>
 	<td class="{$trow}" align="left">{$report_data['comment']}</td>
 	<td class="{$trow}" align="center">{$report_data['reports']}</td>
 	<td class="{$trow} smalltext" align="right">{$report_data['lastreporter']}</td>
-	<td class="{$trow}" align="center"><input type="checkbox" class="checkbox" name="reports[]" id="reports_{$report['rid']}" value="{$report['rid']}" onclick="checkReportedPost(this);" /></td>
+	<td class="{$trow}" align="center"><input type="checkbox" class="checkbox" name="reports[]" id="reports_{$report['rid']}" value="{$report['rid']}"{$inlinecheck} /></td>
 </tr>]]></template>
 		<template name="modcp_reports_report_comment" version="1808"><![CDATA[{$reason}]]></template>
 		<template name="modcp_reports_report_comment_extra" version="1808"><![CDATA[{$reason}: {$comment}]]></template>
+		<template name="modcp_reports_selectall" version="1813"><![CDATA[<tr id="selectAllrow" class="hiddenrow">
+	<td colspan="8" class="selectall">{$lang->page_selected} <a href="javascript:void(0)" onclick='inlineReports.selectAll(); return false;'>{$lang->select_all}</a></td>
+</tr>
+<tr id="allSelectedrow" class="hiddenrow">
+	<td colspan="8" class="selectall">{$lang->all_selected} <a href="javascript:void(0)" onclick='inlineReports.clearChecked(); return false;'>{$lang->clear_selection}</a></td>
+</tr>]]></template>
 		<template name="modcp_nobanned" version="1613"><![CDATA[<tr>
 		<td class="trow1" align="center" colspan="4">{$lang->no_bans_ending}</td>
 </tr>]]></template>

--- a/jscripts/inline_reports.js
+++ b/jscripts/inline_reports.js
@@ -1,0 +1,361 @@
+var inlineReports = {
+	init: function()
+	{
+		inlineReports.cookieName = 'inlinereports';
+		var inputs = $('input');
+
+		if(!inputs.length)
+		{
+			return false;
+		}
+
+		var inlineIds = inlineReports.getCookie(inlineReports.cookieName);
+		var removedIds = inlineReports.getCookie(inlineReports.cookieName+'_removed');
+		var allChecked = true;
+
+		$(inputs).each(function() {
+			var element = $(this);
+			if((element.attr('name') != 'allbox') && (element.attr('type') == 'checkbox') && (element.attr('id')) && (element.attr('id').split('_')[0] == 'reports'))
+			{
+				$(element).click(inlineReports.checkItem);
+			}
+
+			if(element.attr('id'))
+			{
+				var inlineCheck = element.attr('id').split('_');
+				var id = inlineCheck[1];
+
+				if(inlineCheck[0] == 'reports')
+				{
+					if(inlineIds.indexOf(id) != -1 || (inlineIds.indexOf('ALL') != -1 && removedIds.indexOf(id) == -1))
+					{
+						element.prop('checked', true);
+						var report = element.parents('.inline_row');
+						if(report.length)
+						{
+							report.addClass('trow_selected');
+						}
+					}
+					else
+					{
+						element.prop('checked', false);
+						var report = element.parents('.inline_row');
+						if(report.length)
+						{
+							report.removeClass('trow_selected');
+						}
+					}
+					allChecked = false;
+				}
+			}
+		});
+
+		inlineReports.updateCookies(inlineIds, removedIds);
+
+		if(inlineIds.indexOf('ALL') != -1 && removedIds.length == 0)
+		{
+			var allSelectedRow = $('#allSelectedrow');
+			if(allSelectedRow)
+			{
+				allSelectedRow.show();
+			}
+		}
+		else if(inlineIds.indexOf('ALL') == -1 && allChecked == true)
+		{
+			var selectRow = $('#selectAllrow');
+			if(selectRow)
+			{
+				selectRow.show();
+			}
+		}
+		return true;
+	},
+
+	checkItem: function()
+	{
+		var element = $(this);
+
+		if(!element || !element.attr('id'))
+		{
+			return false;
+		}
+
+		var inlineCheck = element.attr('id').split('_');
+		var id = inlineCheck[1];
+
+		if(!id)
+		{
+			return false;
+		}
+
+		var inlineIds = inlineReports.getCookie(inlineReports.cookieName);
+		var removedIds = inlineReports.getCookie(inlineReports.cookieName+'_removed');
+
+		if(element.prop('checked') == true)
+		{
+			if(inlineIds.indexOf('ALL') == -1)
+			{
+				inlineIds = inlineReports.addId(inlineIds, id);
+			}
+			else
+			{
+				removedIds = inlineReports.removeId(removedIds, id);
+				if(removedIds.length == 0)
+				{
+					var allSelectedRow = $('#allSelectedrow');
+					if(allSelectedRow)
+					{
+						allSelectedRow.show();
+					}
+				}
+			}
+			var report = element.parents('.inline_row');
+			if(report.length)
+			{
+				report.addClass('trow_selected');
+			}
+		}
+		else
+		{
+			if(inlineIds.indexOf('ALL') == -1)
+			{
+				inlineIds = inlineReports.removeId(inlineIds, id);
+				var selectRow = $('#selectAllrow');
+				if(selectRow)
+				{
+					selectRow.hide();
+				}
+			}
+			else
+			{
+				removedIds = inlineReports.addId(removedIds, id);
+				var allSelectedRow = $('#allSelectedrow');
+				if(allSelectedRow)
+				{
+					allSelectedRow.hide();
+				}
+			}
+			var report = element.parents('.inline_row');
+			if(report.length)
+			{
+				report.removeClass('trow_selected');
+			}
+		}
+
+		inlineReports.updateCookies(inlineIds, removedIds);
+
+		return true;
+	},
+
+	clearChecked: function()
+	{
+		$('#selectAllrow').hide();
+		$('#allSelectedrow').hide();
+
+		var inputs = $('input');
+
+		if(!inputs.length)
+		{
+			return false;
+		}
+
+		$(inputs).each(function() {
+			var element = $(this);
+			if(!element.val()) return;
+			if(element.attr('type') == 'checkbox' && ((element.attr('id') && element.attr('id').split('_')[0] == 'reports') || element.attr('name') == 'allbox'))
+			{
+				element.prop('checked', false);
+			}
+		});
+
+		$('.trow_selected').each(function() {
+			$(this).removeClass('trow_selected');
+		});
+
+		$('#inline_read').val(mark_read_text+' (0)');
+		Cookie.unset(inlineReports.cookieName);
+		Cookie.unset(inlineReports.cookieName + '_removed');
+
+		return true;
+	},
+
+	checkAll: function(master)
+	{
+		inputs = $('input');
+		master = $(master);
+
+		if(!inputs.length)
+		{
+			return false;
+		}
+
+		var inlineIds = inlineReports.getCookie(inlineReports.cookieName);
+		var removedIds = inlineReports.getCookie(inlineReports.cookieName+'_removed');
+
+		var newIds = new Array();
+		$(inputs).each(function() {
+			var element = $(this);
+			if(!element.val() || !element.attr('id')) return;
+			inlineCheck = element.attr('id').split('_');
+			if((element.attr('name') != 'allbox') && (element.attr('type') == 'checkbox') && (inlineCheck[0] == 'reports'))
+			{
+				var id = inlineCheck[1];
+				var changed = (element.prop('checked') != master.prop('checked'));
+				element.prop('checked', master.prop('checked'));
+
+				var report = element.parents('.inline_row');
+				if(report.length)
+				{
+					if(master.prop('checked') == true)
+					{
+						report.addClass('trow_selected');
+					}
+					else
+					{
+						report.removeClass('trow_selected');
+					}
+				}
+
+				if(changed)
+				{
+					if(master.prop('checked') == true)
+					{
+						if(inlineIds.indexOf('ALL') == -1)
+						{
+							inlineIds = inlineReports.addId(inlineIds, id);
+						}
+						else
+						{
+							removedIds = inlineReports.removeId(removedIds, id);
+						}
+					}
+					else
+					{
+						if(inlineIds.indexOf('ALL') == -1)
+						{
+							inlineIds = inlineReports.removeId(inlineIds, id);
+						}
+						else
+						{
+							removedIds = inlineReports.addId(removedIds, id);
+						}
+					}
+				}
+			}
+		});
+
+		var count = inlineReports.updateCookies(inlineIds, removedIds);
+
+		if(count < all_text)
+		{
+			var selectRow = $('#selectAllrow');
+			if(selectRow.length)
+			{
+				if(master.prop('checked') == true)
+				{
+					selectRow.show();
+				}
+				else
+				{
+					selectRow.hide();
+				}
+			}
+		}
+
+		if(inlineIds.indexOf('ALL') == -1 || removedIds.length != 0)
+		{
+			$('#allSelectedrow').hide();
+		}
+		else if(inlineIds.indexOf('ALL') != -1 && removedIds.length == 0)
+		{
+			$('#allSelectedrow').show();
+		}
+	},
+
+	selectAll: function()
+	{
+		inlineReports.updateCookies(new Array('ALL'), new Array());
+
+		$('#selectAllrow').hide();
+		$('#allSelectedrow').show();
+	},
+
+	getCookie: function(name)
+	{
+		var inlineCookie = Cookie.get(name);
+
+		var ids = new Array();
+		if(inlineCookie)
+		{
+			var inlineIds = inlineCookie.split('|');
+			$.each(inlineIds, function(index, item) {
+				if(item != '' && item != null)
+				{
+					ids.push(item);
+				}
+			});
+		}
+		return ids;
+	},
+
+	setCookie: function(name, array)
+	{
+		if(array.length != 0)
+		{
+			var data = '|'+array.join('|')+'|';
+			Cookie.set(name, data, 60 * 60 * 1000);
+		}
+		else
+		{
+			Cookie.unset(name);
+		}
+	},
+
+	updateCookies: function(inlineIds, removedIds)
+	{
+		if(inlineIds.indexOf('ALL') != -1)
+		{
+			var count = all_text - removedIds.length;
+		}
+		else
+		{
+			var count = inlineIds.length;
+		}
+		if(count < 0)
+		{
+			count = 0;
+		}
+		$('#inline_read').val(mark_read_text+' ('+count+')');
+		if(count == 0)
+		{
+			inlineReports.clearChecked();
+		}
+		else
+		{
+			inlineReports.setCookie(inlineReports.cookieName, inlineIds);
+			inlineReports.setCookie(inlineReports.cookieName+'_removed', removedIds);
+		}
+		return count;
+	},
+
+	addId: function(array, id)
+	{
+		if(array.indexOf(id) == -1)
+		{
+			array.push(id);
+		}
+		return array;
+	},
+
+	removeId: function(array, id)
+	{
+		var position = array.indexOf(id);
+		if(position != -1)
+		{
+			array.splice(position, 1);
+		}
+		return array;
+	}
+};
+
+$(inlineReports.init);

--- a/modcp.php
+++ b/modcp.php
@@ -11,7 +11,7 @@
 define("IN_MYBB", 1);
 define('THIS_SCRIPT', 'modcp.php');
 
-$templatelist = "modcp_reports,modcp_reports_report,modcp_reports_multipage,modcp_reports_allreport,modcp_reports_allreports,modcp_modlogs_multipage,modcp_announcements_delete,modcp_announcements_edit,modcp_awaitingmoderation";
+$templatelist = "modcp_reports,modcp_reports_report,modcp_reports_selectall,modcp_reports_multipage,modcp_reports_allreport,modcp_reports_allreports,modcp_modlogs_multipage,modcp_announcements_delete,modcp_announcements_edit,modcp_awaitingmoderation";
 $templatelist .= ",modcp_reports_allnoreports,modcp_reports_noreports,modcp_banning,modcp_banning_ban,modcp_announcements_announcement_global,modcp_no_announcements_forum,modcp_modqueue_threads_thread,modcp_awaitingthreads,preview";
 $templatelist .= ",modcp_banning_nobanned,modcp_modqueue_threads_empty,modcp_modqueue_masscontrols,modcp_modqueue_threads,modcp_modqueue_posts_post,modcp_modqueue_posts_empty,modcp_awaitingposts,modcp_nav_editprofile,modcp_nav_banning";
 $templatelist .= ",modcp_nav,modcp_modlogs_noresults,modcp_modlogs_nologs,modcp,modcp_modqueue_posts,modcp_modqueue_attachments_attachment,modcp_modqueue_attachments_empty,modcp_modqueue_attachments,modcp_editprofile_suspensions_info";
@@ -285,13 +285,42 @@ if($mybb->input['action'] == "do_reports")
 	verify_post_check($mybb->get_input('my_post_key'));
 
 	$mybb->input['reports'] = $mybb->get_input('reports', MyBB::INPUT_ARRAY);
-	if(empty($mybb->input['reports']))
+	if(empty($mybb->input['reports']) && empty($mybb->cookies['inlinereports']))
 	{
 		error($lang->error_noselected_reports);
 	}
 
-	$sql = '1=1';
-	if(empty($mybb->input['allbox']))
+	$message = $lang->redirect_reportsmarked;
+
+	if(isset($mybb->cookies['inlinereports']))
+	{
+		if($mybb->cookies['inlinereports'] == '|ALL|') {
+			$message = $lang->redirect_allreportsmarked;
+			$sql = "1=1";
+			if(isset($mybb->cookies['inlinereports_removed']))
+			{
+				$inlinereportremovedlist = explode("|", $mybb->cookies['inlinereports_removed']);
+				$reports = array_map("intval", $inlinereportremovedlist);
+				$rids = implode("','", $reports);
+				$sql = "rid NOT IN ('0','{$rids}')";
+			}
+		}
+		else
+		{
+			$inlinereportlist = explode("|", $mybb->cookies['inlinereports']);
+			$reports = array_map("intval", $inlinereportlist);
+
+			if(!count($reports))
+			{
+				error($lang->error_noselected_reports);
+			}
+
+			$rids = implode("','", $reports);
+
+			$sql = "rid IN ('0','{$rids}')";
+		}
+	}
+	else
 	{
 		$mybb->input['reports'] = array_map("intval", $mybb->input['reports']);
 		$rids = implode("','", $mybb->input['reports']);
@@ -304,9 +333,12 @@ if($mybb->input['action'] == "do_reports")
 	$db->update_query("reportedcontent", array('reportstatus' => 1), "{$sql}{$flist_reports}");
 	$cache->update_reportedcontent();
 
+	my_unsetcookie('inlinereports');
+	my_unsetcookie('inlinereports_removed');
+
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 
-	redirect("modcp.php?action=reports&page={$page}", $lang->redirect_reportsmarked);
+	redirect("modcp.php?action=reports&page={$page}", $message);
 }
 
 if($mybb->input['action'] == "reports")
@@ -491,8 +523,14 @@ if($mybb->input['action'] == "reports")
 			}
 		}
 
+		$lang->page_selected = $lang->sprintf($lang->page_selected, count($reportcache));
+		$lang->select_all = $lang->sprintf($lang->select_all, (int)$report_count);
+		$lang->all_selected = $lang->sprintf($lang->all_selected, (int)$report_count);
+		eval("\$selectall = \"".$templates->get("modcp_reports_selectall")."\";");
+
 		$plugins->run_hooks('modcp_reports_intermediate');
 
+		$inlinecount = 0;
 		// Now that we have all of the information needed, display the reports
 		foreach($reportcache as $report)
 		{
@@ -572,6 +610,13 @@ if($mybb->input['action'] == "reports")
 
 				$lastreport_date = my_date('relative', $report['lastreport']);
 				$report_data['lastreporter'] = $lang->sprintf($lang->report_info_lastreporter, $lastreport_date, $lastreport_user);
+			}
+
+			$inlinecheck = '';
+			if(isset($mybb->cookies['inlinereports']) && my_strpos($mybb->cookies['inlinereports'], "|{$report['rid']}|") !== false)
+			{
+				$inlinecheck = " checked=\"checked\"";
+				++$inlinecount;
 			}
 
 			$plugins->run_hooks("modcp_reports_report");

--- a/search.php
+++ b/search.php
@@ -637,7 +637,7 @@ if($mybb->input['action'] == "results")
 			$inline_mod_checkbox = '';
 			if($is_supermod || is_moderator($thread['fid']))
 			{
-				if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|{$thread['tid']}|"))
+				if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|{$thread['tid']}|") !== false)
 				{
 					$inlinecheck = "checked=\"checked\"";
 					++$inlinecount;
@@ -1047,7 +1047,7 @@ if($mybb->input['action'] == "results")
 			$inline_mod_checkbox = '';
 			if($is_supermod || is_moderator($post['fid']))
 			{
-				if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|{$post['pid']}|"))
+				if(isset($mybb->cookies[$inlinecookie]) && my_strpos($mybb->cookies[$inlinecookie], "|{$post['pid']}|") !== false)
 				{
 					$inlinecheck = "checked=\"checked\"";
 					++$inlinecount;


### PR DESCRIPTION
Fixes #154

Implementation the same as inline moderation.

Additional changes:
- Use strict comparison for `my_strpos` as it ignores the first item in the list without it
- Change `error_noselected_reports` to be the correct description - never used when "the selected posts have already been marked read by another user"
- Change "posts" to "content" in other language strings

---

**This PR:**
- changes 1 language file
- changes 2 templates
- adds 1 new template
- adds 1 new `.js` file