### PR TITLE
Fixes #2815

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -9651,12 +9651,11 @@ if(use_xmlhttprequest == "1")
 		{$deleted_message}
 	</div>
 </div>]]></template>
-		<template name="postbit_deleted_member" version="1809"><![CDATA[<a name="pid{$post['pid']}" id="pid{$post['pid']}"></a>
+		<template name="postbit_deleted_member" version="1813"><![CDATA[<a name="pid{$post['pid']}" id="pid{$post['pid']}"></a>
 <div class="post deleted_post_hidden" id="post_{$post['pid']}">
 	<div class="deleted_post_author"><strong><span class="largetext">{$post['profilelink']}</span></strong></div>
-		<div class="post_content">
-			<em>{$lang->postbit_post_deleted}</em>
-		</div>
+	<div class="post_content">
+		<em>{$lang->postbit_post_deleted}</em>
 	</div>
 </div>]]></template>
 		<template name="postbit_edit" version="1809"><![CDATA[<a href="editpost.php?pid={$post['pid']}" id="edit_post_{$post['pid']}" title="{$lang->postbit_edit}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>

--- a/showthread.php
+++ b/showthread.php
@@ -924,8 +924,8 @@ if($mybb->input['action'] == "thread")
 			}
 		}
 
-		// Recount replies if user is a moderator to take into account unapproved posts.
-		if($ismod)
+		// Recount replies if user is a moderator or can see the deletion notice to take into account unapproved/deleted posts.
+		if($ismod || $forumpermissions['canviewdeletionnotice'] != 0)
 		{
 			$query = $db->simple_select("posts p", "COUNT(*) AS replies", "p.tid='$tid' $visible");
 			$cached_replies = $thread['replies']+$thread['unapprovedposts']+$thread['deletedposts'];


### PR DESCRIPTION
#2815 

This PR also fixes a styling issue with the postbit_deleted_member template, which contained an extra `</div>` causing the `#posts` container to finish earlier in Mozilla browsers. Quick replies were then appended after deleted posts.