### PR TITLE
Fixes #2817

### DIFF
--- a/moderation.php
+++ b/moderation.php
@@ -1398,6 +1398,8 @@ switch($mybb->input['action'])
 			eval("\$posts .= \"".$templates->get("moderation_split_post")."\";");
 			$altbg = alt_trow();
 		}
+
+		clearinline($tid, 'thread');
 		$forumselect = build_forum_jump("", $fid, 1, '', 0, true, '', "moveto");
 
 		$plugins->run_hooks("moderation_split");


### PR DESCRIPTION
#2817 

I kept it extremely simple by clearing the cookies when browsing to the split thread tool page; a more complex approach would be:
- subtract the selected posts with the ones going to be split in the new thread;
- delete them from the previous thread's cookie;
- add them to the new thread's cookie, generating one.

While this may be more correct, it also adds something I feel unnecessary. The split thread tool is meant to work on its own, it does not preselects any already-selected posts; therefore, checking posts before using this tool might as well not be intentional but by mistake.