### PR TITLE
Fixes #2092

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -4375,40 +4375,42 @@ $(".forumjump").change(function() {
 <td class="trow1"><span class="smalltext">{$lang->online_note}<br />{$onlinemembers}</span></td>
 </tr>]]></template>
 		<template name="index_whosonline_memberbit" version="1400"><![CDATA[{$comma}{$user['profilelink']}{$invisiblemark}]]></template>
-		<template name="managegroup" version="1807"><![CDATA[<html>
+		<template name="managegroup" version="1813"><![CDATA[<html>
 <head>
-<title>{$mybb->settings['bbname']} - {$lang->members_of}</title>
-{$headerinclude}
+	<title>{$mybb->settings['bbname']} - {$lang->members_of}</title>
+	{$headerinclude}
 </head>
 <body>
-{$header}
-{$joinrequests}
-<p>{$usergrouptype}</p>
-{$group_leaders}
-<form method="post" action="managegroup.php">
-<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
-<input type="hidden" name="action" value="do_manageusers" />
-<input type="hidden" name="gid" value="{$gid}" />
-<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
-<tr>
-<td class="thead" colspan="6"><strong>{$lang->members_of}</strong></td>
-</tr>
-<tr>
-<td class="tcat" width="40%"><span class="smalltext"><strong>{$lang->user_name}</strong></span></td>
-<td class="tcat" colspan="2" align="center"><span class="smalltext"><strong>{$lang->contact}</strong></span></td>
-<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->reg_date}</strong></span></td>
-<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->post_count}</strong></span></td>
-<td class="tcat" width="1">&nbsp;</td>
-</tr>
-{$users}
-</table>
-{$multipage}
-<br />
-<div align="center">{$remove_users}</div>
-</form>
-{$add_user}
-{$invite_user}
-{$footer}
+	{$header}
+	{$joinrequests}
+	<p>{$usergrouptype}</p>
+	{$group_leaders}
+	{$multipage}
+	<form method="post" action="managegroup.php">
+		<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
+		<input type="hidden" name="action" value="do_manageusers" />
+		<input type="hidden" name="gid" value="{$gid}" />
+		<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+			<tr>
+				<td class="thead" colspan="6"><strong>{$lang->members_of}</strong></td>
+			</tr>
+			<tr>
+				<td class="tcat" width="40%"><span class="smalltext"><strong>{$lang->user_name}</strong></span></td>
+				<td class="tcat" colspan="2" align="center"><span class="smalltext"><strong>{$lang->contact}</strong></span></td>
+				<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->reg_date}</strong></span></td>
+				<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->post_count}</strong></span></td>
+				<td class="tcat" width="1">&nbsp;</td>
+			</tr>
+			{$users}
+		</table>
+		<br />
+		<div align="center">
+			{$remove_users}
+		</div>
+	</form>
+	{$add_user}
+	{$invite_user}
+	{$footer}
 </body>
 </html>]]></template>
 		<template name="managegroup_adduser" version="1807"><![CDATA[<br />
@@ -7151,33 +7153,33 @@ if(use_xmlhttprequest == "1")
 		<template name="modcp_editprofile_suspensions_info" version="1600"><![CDATA[<tr>
 	<td colspan="2" class="smalltext"><em>{$suspension_info}</em></td>
 </tr>]]></template>
-		<template name="modcp_finduser" version="1807"><![CDATA[<html>
+		<template name="modcp_finduser" version="1813"><![CDATA[<html>
 <head>
-<title>{$mybb->settings['bbname']} - {$lang->find_users}</title>
+	<title>{$mybb->settings['bbname']} - {$lang->find_users}</title>
 {$headerinclude}
 </head>
 <body>
 	{$header}
-	<form action="modcp.php?action=finduser" method="post">
-		<table width="100%" border="0" align="center">
-			<tr>
-				{$modcp_nav}
-				<td valign="top">
-					<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
-						<tr>
-							<td class="thead" colspan="5"><strong>{$lang->users}</strong></td>
-						</tr>
-						<tr>
-							<td class="tcat" width="30%"><span class="smalltext"><strong>{$lang->username}</strong></span></td>
-							<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->usergroup}</strong></span></td>
-							<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->regdate}</strong></span></td>
-							<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->lastvisit}</strong></span></td>
-							<td class="tcat" align="center" width="10%"><span class="smalltext"><strong>{$lang->postnum}</strong></span></td>
-						</tr>
-						{$users}
-					</table>
-					{$multipage}
-					<br />
+	<table width="100%" border="0" align="center">
+		<tr>
+			{$modcp_nav}
+			<td valign="top">
+				<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+					<tr>
+						<td class="thead" colspan="5"><strong>{$lang->users}</strong></td>
+					</tr>
+					<tr>
+						<td class="tcat" width="30%"><span class="smalltext"><strong>{$lang->username}</strong></span></td>
+						<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->usergroup}</strong></span></td>
+						<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->regdate}</strong></span></td>
+						<td class="tcat" align="center" width="15%"><span class="smalltext"><strong>{$lang->lastvisit}</strong></span></td>
+						<td class="tcat" align="center" width="10%"><span class="smalltext"><strong>{$lang->postnum}</strong></span></td>
+					</tr>
+					{$users}
+				</table>
+				{$multipage}
+				<br />
+				<form action="modcp.php?action=finduser" method="post">
 					<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 						<tr>
 							<td class="thead" colspan="2"><strong>{$lang->find_users}</strong></td>
@@ -7208,10 +7210,10 @@ if(use_xmlhttprequest == "1")
 					<div align="center">
 						<input type="submit" class="button" value="{$lang->find_users}" />
 					</div>
-				</td>
-			</tr>
-		</table>
-	</form>
+				</form>
+			</td>
+		</tr>
+	</table>
 {$footer}
 <link rel="stylesheet" href="{$mybb->asset_url}/jscripts/select2/select2.css?ver=1807" />
 <script type="text/javascript" src="{$mybb->asset_url}/jscripts/select2/select2.min.js?ver=1806"></script>
@@ -7262,20 +7264,19 @@ if(use_xmlhttprequest == "1")
 							<td class="{$alt_row}" align="center">{$lastdate}</td>
 							<td class="{$alt_row}" align="center">{$user['postnum']}</td>
 						</tr>]]></template>
-		<template name="modcp_ipsearch" version="1600"><![CDATA[
-		<html>
+		<template name="modcp_ipsearch" version="1813"><![CDATA[<html>
 <head>
-<title>{$mybb->settings['bbname']} - {$lang->ipsearch}</title>
-{$headerinclude}
+	<title>{$mybb->settings['bbname']} - {$lang->ipsearch}</title>
+	{$headerinclude}
 </head>
 <body>
 	{$header}
-	<form action="modcp.php?action=ipsearch" method="post">
-		<table width="100%" border="0" align="center">
-			<tr>
-				{$modcp_nav}
-				<td valign="top">
-					{$ipsearch_results}
+	<table width="100%" border="0" align="center">
+		<tr>
+			{$modcp_nav}
+			<td valign="top">
+				{$ipsearch_results}
+				<form action="modcp.php?action=ipsearch" method="post">
 					<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 						<tr>
 							<td class="thead" colspan="2"><strong>{$lang->ipaddress_search}</strong></td>
@@ -7296,10 +7297,10 @@ if(use_xmlhttprequest == "1")
 					<div align="center">
 						<input type="submit" class="button" value="{$lang->find}" />
 					</div>
-				</td>
-			</tr>
-		</table>
-	</form>
+				</form>
+			</td>
+		</tr>
+	</table>
 {$footer}
 </body>
 </html>]]></template>
@@ -7370,33 +7371,33 @@ if(use_xmlhttprequest == "1")
 {$modlogresults}
 </table>
 <br />]]></template>
-		<template name="modcp_modlogs" version="1405"><![CDATA[<html>
+		<template name="modcp_modlogs" version="1813"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->modlogs}</title>
 {$headerinclude}
 </head>
 <body>
 	{$header}
-	<form action="modcp.php?action=modlogs" method="post">
-		<table width="100%" border="0" align="center">
-			<tr>
-				{$modcp_nav}
-				<td valign="top">
-					<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
-						<tr>
-							<td class="thead" align="center" colspan="5"><strong>{$lang->modlogs}</strong></td>
-						</tr>
-						<tr>
-							<td class="tcat"><span class="smalltext"><strong>{$lang->username}</strong></span></td>
-							<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->date}</strong></span></td>
-							<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->action}</strong></span></td>
-							<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->information}</strong></span></td>
-							<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->ip}</strong></span></td>
-						</tr>
-						{$results}
-						{$resultspages}
-					</table>
-					<br />
+	<table width="100%" border="0" align="center">
+		<tr>
+			{$modcp_nav}
+			<td valign="top">
+				<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+					<tr>
+						<td class="thead" align="center" colspan="5"><strong>{$lang->modlogs}</strong></td>
+					</tr>
+					<tr>
+						<td class="tcat"><span class="smalltext"><strong>{$lang->username}</strong></span></td>
+						<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->date}</strong></span></td>
+						<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->action}</strong></span></td>
+						<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->information}</strong></span></td>
+						<td class="tcat" align="center"><span class="smalltext"><strong>{$lang->ip}</strong></span></td>
+					</tr>
+					{$results}
+					{$resultspages}
+				</table>
+				<br />
+				<form action="modcp.php?action=modlogs" method="post">
 					<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
 						<tr>
 							<td class="thead" colspan="2"><strong>{$lang->filter_modlogs}</strong></td>
@@ -7443,10 +7444,10 @@ if(use_xmlhttprequest == "1")
 					<div align="center">
 						<input type="submit" class="button" value="{$lang->filter_logs}" />
 					</div>
-				</td>
-			</tr>
-		</table>
-	</form>
+				</form>
+			</td>
+		</tr>
+	</table>
 {$footer}
 </body>
 </html>]]></template>
@@ -11906,68 +11907,68 @@ if(use_xmlhttprequest == "1")
 {$footer}
 </body>
 </html>]]></template>
-		<template name="usercp_attachments" version="1804"><![CDATA[<html>
+		<template name="usercp_attachments" version="1813"><![CDATA[<html>
 <head>
-<title>{$mybb->settings['bbname']} - {$lang->attachments_manager}</title>
-{$headerinclude}
+	<title>{$mybb->settings['bbname']} - {$lang->attachments_manager}</title>
+	{$headerinclude}
 </head>
 <body>
-{$header}
-<form action="usercp.php" method="post" name="attachmentsmanager">
-<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
-<table width="100%" border="0" align="center">
-<tr>
-{$usercpnav}
-<td valign="top">
-<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
-<tr>
-<td class="thead" colspan="5"><strong>{$lang->attachments_manager} {$usagenote}</strong></td>
-</tr>
-<tr>
-<td class="tcat" colspan="2" width="40%"><span class="smalltext"><strong>{$lang->attachments_attachment}</strong></span></td>
-<td class="tcat" width="40%"><span class="smalltext"><strong>{$lang->attachments_post}</strong></span></td>
-<td class="tcat" align="center" width="20%"><span class="smalltext"><strong>{$lang->date_uploaded}</strong></span></td>
-<td class="tcat" width="1"><input type="checkbox" name="allbox" class="checkbox checkall" /></td>
-</tr>
-{$attachments}
-</table>
-{$multipage}
-<br />
-<div align="center">
-<input type="hidden" name="action" value="do_attachments" />
-<input type="submit" class="button" value="{$lang->delete_attachments}" />
-</div>
-<br />
-<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
-<tr>
-<td class="thead" colspan="2"><strong>{$lang->attachments_stats}</strong></td>
-</tr>
-<tr>
-<td class="trow1" width="40%"><strong>{$lang->attachstats_attachs}</strong></td>
-<td class="trow1" width="60%">{$totalattachments}</td>
-</tr>
-<tr>
-<td class="trow2" width="40%"><strong>{$lang->attachstats_spaceused}</strong></td>
-<td class="trow2" width="60%">{$friendlyusage} ({$percent})</td>
-</tr>
-<tr>
-<td class="trow1" width="40%"><strong>{$lang->attachstats_quota}</strong></td>
-<td class="trow1" width="60%">{$attachquota}</td>
-</tr>
-<tr>
-<td class="trow2" width="40%"><strong>{$lang->attachstats_totaldl}</strong></td>
-<td class="trow2" width="60%">{$totaldownloads}</td>
-</tr>
-<tr>
-<td class="trow1" width="40%"><strong>{$lang->attachstats_bandwidth}</strong></td>
-<td class="trow1" width="60%">{$bandwidth}</td>
-</tr>
-</table>
-</td>
-</tr>
-</table>
-</form>
-{$footer}
+	{$header}
+	<table width="100%" border="0" align="center">
+		<tr>
+			{$usercpnav}
+			<td valign="top">
+				<form action="usercp.php" method="post" name="attachmentsmanager">
+					<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
+					<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+						<tr>
+							<td class="thead" colspan="5"><strong>{$lang->attachments_manager} {$usagenote}</strong></td>
+						</tr>
+						<tr>
+							<td class="tcat" colspan="2" width="40%"><span class="smalltext"><strong>{$lang->attachments_attachment}</strong></span></td>
+							<td class="tcat" width="40%"><span class="smalltext"><strong>{$lang->attachments_post}</strong></span></td>
+							<td class="tcat" align="center" width="20%"><span class="smalltext"><strong>{$lang->date_uploaded}</strong></span></td>
+							<td class="tcat" width="1"><input type="checkbox" name="allbox" class="checkbox checkall" /></td>
+						</tr>
+						{$attachments}
+					</table>
+					<br />
+					<div align="center">
+						<input type="hidden" name="action" value="do_attachments" />
+						<input type="submit" class="button" value="{$lang->delete_attachments}" />
+					</div>
+				</form>
+				{$multipage}
+				<br />
+				<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+					<tr>
+						<td class="thead" colspan="2"><strong>{$lang->attachments_stats}</strong></td>
+					</tr>
+					<tr>
+						<td class="trow1" width="40%"><strong>{$lang->attachstats_attachs}</strong></td>
+						<td class="trow1" width="60%">{$totalattachments}</td>
+					</tr>
+					<tr>
+						<td class="trow2" width="40%"><strong>{$lang->attachstats_spaceused}</strong></td>
+						<td class="trow2" width="60%">{$friendlyusage} ({$percent})</td>
+					</tr>
+					<tr>
+						<td class="trow1" width="40%"><strong>{$lang->attachstats_quota}</strong></td>
+						<td class="trow1" width="60%">{$attachquota}</td>
+					</tr>
+					<tr>
+						<td class="trow2" width="40%"><strong>{$lang->attachstats_totaldl}</strong></td>
+						<td class="trow2" width="60%">{$totaldownloads}</td>
+					</tr>
+					<tr>
+						<td class="trow1" width="40%"><strong>{$lang->attachstats_bandwidth}</strong></td>
+						<td class="trow1" width="60%">{$bandwidth}</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+	{$footer}
 </body>
 </html>]]></template>
 		<template name="usercp_attachments_attachment" version="1800"><![CDATA[<tr>
@@ -13294,60 +13295,60 @@ if(use_xmlhttprequest == "1")
 {$referral_link}]]></template>
 		<template name="usercp_reputation" version="1600"><![CDATA[<strong>{$lang->reputation}</strong> {$reputation_link} [<a href="reputation.php?uid={$mybb->user['uid']}">{$lang->details}</a>]<br />]]></template>
 		<template name="usercp_resendactivation" version="1800"><![CDATA[<br />(<a href="member.php?action=resendactivation">{$lang->resend_activation}</a>)]]></template>
-		<template name="usercp_subscriptions" version="1807"><![CDATA[<html>
+		<template name="usercp_subscriptions" version="1813"><![CDATA[<html>
 <head>
-<title>{$mybb->settings['bbname']} - {$lang->subscriptions}</title>
-{$headerinclude}
+	<title>{$mybb->settings['bbname']} - {$lang->subscriptions}</title>
+	{$headerinclude}
 </head>
 <body>
-{$header}
-<form action="usercp.php" method="post" name="input">
-<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
-<input type="hidden" name="action" value="do_subscriptions" />
-<table width="100%" border="0" align="center">
-<tr>
-{$usercpnav}
-<td valign="top">
-{$multipage}
-<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
-	<tr>
-		<td class="thead" colspan="7"><strong>{$lang->subscriptions} ({$threadcount})</strong></td>
-	</tr>
-	<tr>
-		<td width="66%" colspan="3" class="tcat"><span class="smalltext"><strong>{$lang->thread}</strong></span></td>
-		<td class="tcat" align="center" width="7%"><span class="smalltext"><strong>{$lang->replies}</strong></span></td>
-		<td class="tcat" align="center" width="7%"><span class="smalltext"><strong>{$lang->views}</strong></span></td>
-		<td class="tcat" align="center" width="200"><span class="smalltext"><strong>{$lang->lastpost}</strong></span></td>
-		<td class="tcat" align="center" width="1"><input name="allbox" title="Select All" type="checkbox" class="checkbox checkall" value="1" /></td>
-	</tr>
-	{$threads}
-	{$remove_options}
-</table>
-<br />
-<div class="float_left">
-	<div class="float_left">
-		<dl class="thread_legend smalltext">
-			<dd><span class="thread_status newfolder" title="{$lang->new_posts_thread}">&nbsp;</span> {$lang->new_posts_thread}</dd>
-			<dd><span class="thread_status newhotfolder" title="{$lang->new_hot_thread}">&nbsp;</span> {$lang->new_hot_thread}</dd>
-			<dd><span class="thread_status hotfolder" title="{$lang->hot_thread}">&nbsp;</span> {$lang->hot_thread}</dd>
-		</dl>
-	</div>
-
-	<div class="float_left">
-		<dl class="thread_legend smalltext">
-			<dd><span class="thread_status folder" title="{$lang->no_new_thread}">&nbsp;</span> {$lang->no_new_thread}</dd>
-			<dd><span class="thread_status dot_folder" title="{$lang->posts_by_you}">&nbsp;</span> {$lang->posts_by_you}</dd>
-			<dd><span class="thread_status lockfolder" title="{$lang->locked_thread}">&nbsp;</span> {$lang->locked_thread}</dd>
-		</dl>
-	</div>
-	<br class="clear" />
-</div>
-{$multipage}
-</td>
-</tr>
-</table>
-</form>
-{$footer}
+	{$header}
+	<table width="100%" border="0" align="center">
+		<tr>
+			{$usercpnav}
+			<td valign="top">
+				{$multipage}
+				<form action="usercp.php" method="post" name="input">
+					<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
+					<input type="hidden" name="action" value="do_subscriptions" />
+					<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
+						<tr>
+							<td class="thead" colspan="7"><strong>{$lang->subscriptions} ({$threadcount})</strong></td>
+						</tr>
+						<tr>
+							<td width="66%" colspan="3" class="tcat"><span class="smalltext"><strong>{$lang->thread}</strong></span></td>
+							<td class="tcat" align="center" width="7%"><span class="smalltext"><strong>{$lang->replies}</strong></span></td>
+							<td class="tcat" align="center" width="7%"><span class="smalltext"><strong>{$lang->views}</strong></span></td>
+							<td class="tcat" align="center" width="200"><span class="smalltext"><strong>{$lang->lastpost}</strong></span></td>
+							<td class="tcat" align="center" width="1"><input name="allbox" title="Select All" type="checkbox" class="checkbox checkall" value="1" /></td>
+						</tr>
+						{$threads}
+						{$remove_options}
+					</table>
+				</form>
+				{$multipage}
+				<br />
+				<div class="float_left">
+					<div class="float_left">
+						<dl class="thread_legend smalltext">
+							<dd><span class="thread_status newfolder" title="{$lang->new_posts_thread}">&nbsp;</span> {$lang->new_posts_thread}</dd>
+							<dd><span class="thread_status newhotfolder" title="{$lang->new_hot_thread}">&nbsp;</span> {$lang->new_hot_thread}</dd>
+							<dd><span class="thread_status hotfolder" title="{$lang->hot_thread}">&nbsp;</span> {$lang->hot_thread}</dd>
+						</dl>
+					</div>
+				
+					<div class="float_left">
+						<dl class="thread_legend smalltext">
+							<dd><span class="thread_status folder" title="{$lang->no_new_thread}">&nbsp;</span> {$lang->no_new_thread}</dd>
+							<dd><span class="thread_status dot_folder" title="{$lang->posts_by_you}">&nbsp;</span> {$lang->posts_by_you}</dd>
+							<dd><span class="thread_status lockfolder" title="{$lang->locked_thread}">&nbsp;</span> {$lang->locked_thread}</dd>
+						</dl>
+					</div>
+					<br class="clear" />
+				</div>
+			</td>
+		</tr>
+	</table>
+	{$footer}
 </body>
 </html>]]></template>
 		<template name="usercp_subscriptions_none" version="120"><![CDATA[<tr>


### PR DESCRIPTION
#2092 

The PR also tidies up the edited templates' indentation.

Other templates found to have `$multipage` nested into a form:
- modcp_modqueue_attachments
- modcp_modqueue_posts
- modcp_modqueue_threads

I'm not sure where to place the multipage there honestly. To render it usable, it must go either before the table (shifting the table down a little bit) or after the form submit button. Suggestions are appreciated.