### PR TITLE
Fixes #2543 Hide invalid Calendar links

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -11,11 +11,11 @@
 define("IN_MYBB", 1);
 define('THIS_SCRIPT', 'calendar.php');
 
-$templatelist = "calendar_weekdayheader,calendar_weekrow_day,calendar_weekrow,calendar,calendar_addevent,calendar_year,calendar_day,calendar_select,calendar_repeats,calendar_weekview_day_event_time";
-$templatelist .= ",calendar_weekview_day,calendar_weekview_day_event,calendar_mini_weekdayheader,calendar_mini_weekrow_day,calendar_mini_weekrow,calendar_mini,calendar_mini_weekrow_day_link,calendar_move";
-$templatelist .= ",calendar_event_editbutton,calendar_event_modoptions,calendar_dayview_event,calendar_dayview,codebuttons,calendar_weekrow_day_events,calendar_weekview_month,calendar_addeventlink";
-$templatelist .= ",calendar_jump,calendar_jump_option,calendar_editevent,calendar_dayview_birthdays_bday,calendar_dayview_birthdays,calendar_dayview_noevents,calendar_addevent_calendarselect_hidden";
-$templatelist .= ",calendar_weekrow_day_birthdays,calendar_weekview_day_birthdays,calendar_year_sel,calendar_event_userstar,calendar_addevent_calendarselect,calendar_eventbit,calendar_event,calendar_weekview";
+$templatelist = "calendar_weekdayheader,calendar_weekrow_day,calendar_weekrow,calendar,calendar_addevent,calendar_year,calendar_day,calendar_select,calendar_repeats,calendar_weekview_day_event_time,calendar_weekview_nextlink";
+$templatelist .= ",calendar_weekview_day,calendar_weekview_day_event,calendar_mini_weekdayheader,calendar_mini_weekrow_day,calendar_mini_weekrow,calendar_mini,calendar_mini_weekrow_day_link,calendar_weekview_prevlink";
+$templatelist .= ",calendar_event_editbutton,calendar_event_modoptions,calendar_dayview_event,calendar_dayview,codebuttons,calendar_weekrow_day_events,calendar_weekview_month,calendar_addeventlink,calendar_weekview";
+$templatelist .= ",calendar_jump,calendar_jump_option,calendar_editevent,calendar_dayview_birthdays_bday,calendar_dayview_birthdays,calendar_dayview_noevents,calendar_addevent_calendarselect_hidden,calendar_nextlink";
+$templatelist .= ",calendar_weekrow_day_birthdays,calendar_weekview_day_birthdays,calendar_year_sel,calendar_event_userstar,calendar_addevent_calendarselect,calendar_eventbit,calendar_event,calendar_move,calendar_prevlink";
 
 require_once "./global.php";
 require_once MYBB_ROOT."inc/functions_calendar.php";
@@ -2077,10 +2077,31 @@ if($mybb->input['action'] == "weekview")
 
 	$today = my_date("dnY");
 
-	$next_week = $mybb->input['week'] + 604800;
-	$next_link = get_calendar_week_link($calendar['cid'], $next_week);
 	$prev_week = $mybb->input['week'] - 604800;
-	$prev_link = get_calendar_week_link($calendar['cid'], $prev_week);
+
+	$prev_week_link = '';
+	if(my_date("Y", $prev_week) >= 1901)
+	{
+		$prev_link = get_calendar_week_link($calendar['cid'], $prev_week);
+
+		eval("\$prev_week_link = \"".$templates->get("calendar_weekview_prevlink")."\";");
+	}
+
+	$next_week = $mybb->input['week'] + 604800;
+
+	$next_week_link = '';
+	if(my_date("Y", $next_week)+1 <= my_date("Y")+5)
+	{
+		$next_link = get_calendar_week_link($calendar['cid'], $next_week);
+
+		eval("\$next_week_link = \"".$templates->get("calendar_weekview_nextlink")."\";");
+	}
+
+	$sep = '';
+	if(!empty($prev_week_link) && !empty($next_week_link))
+	{
+		$sep = " | ";
+	}
 
 	$weekday_date = $mybb->input['week'];
 
@@ -2277,7 +2298,7 @@ if(!$mybb->input['action'])
 	$plugins->run_hooks("calendar_main_view");
 
 	// Incoming year?
-	if(isset($mybb->input['year']) && $mybb->get_input('year', MyBB::INPUT_INT) <= my_date("Y")+5)
+	if(isset($mybb->input['year']) && $mybb->get_input('year', MyBB::INPUT_INT) <= my_date("Y")+5 && $mybb->get_input('year', MyBB::INPUT_INT) >= 1901)
 	{
 		$year = $mybb->get_input('year', MyBB::INPUT_INT);
 	}
@@ -2300,11 +2321,31 @@ if(!$mybb->input['action'])
 	add_breadcrumb(htmlspecialchars_uni($calendar['name']), get_calendar_link($calendar['cid']));
 	add_breadcrumb("$monthnames[$month] $year", get_calendar_link($calendar['cid'], $year, $month));
 
-	$next_month = get_next_month($month, $year);
 	$prev_month = get_prev_month($month, $year);
 
-	$prev_link = get_calendar_link($calendar['cid'], $prev_month['year'], $prev_month['month']);
-	$next_link = get_calendar_link($calendar['cid'], $next_month['year'], $next_month['month']);
+	$prev_month_link = '';
+	if($prev_month['year'] >= 1901)
+	{
+		$prev_link = get_calendar_link($calendar['cid'], $prev_month['year'], $prev_month['month']);
+
+		eval("\$prev_month_link = \"".$templates->get("calendar_prevlink")."\";");
+	}
+
+	$next_month = get_next_month($month, $year);
+
+	$next_month_link = '';
+	if($next_month['year'] <= my_date("Y")+5)
+	{
+		$next_link = get_calendar_link($calendar['cid'], $next_month['year'], $next_month['month']);
+
+		eval("\$next_month_link = \"".$templates->get("calendar_nextlink")."\";");
+	}
+
+	$sep = '';
+	if(!empty($prev_month_link) && !empty($next_month_link))
+	{
+		$sep = " | ";
+	}
 
 	// Start constructing the calendar
 

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -2409,7 +2409,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 </html>]]></template>
 		<template name="announcement_edit" version="1800"><![CDATA[<a href="modcp.php?action=edit_announcement&amp;aid={$post['aid']}" title="{$lang->announcement_edit}" class="postbit_edit"><span>{$lang->postbit_button_edit}</span></a>]]></template>
 		<template name="announcement_quickdelete" version="1800"><![CDATA[<a href="modcp.php?action=delete_announcement&amp;aid={$post['aid']}&amp;my_post_key={$mybb->post_code}" onclick="MyBB.deleteAnnouncement(this); return false;" class="postbit_qdelete"><span>{$lang->postbit_button_qdelete}</span></a>]]></template>
-		<template name="calendar" version="1800"><![CDATA[<html>
+		<template name="calendar" version="1813"><![CDATA[<html>
 <head>
 	<title>{$mybb->settings['bbname']} - {$lang->calendar}</title>
 	{$headerinclude}
@@ -2421,7 +2421,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 			<tr>
 				<td class="thead" colspan="8">
 					<div class="float_right">
-						<a href="{$prev_link}">&laquo; {$prev_month['name']} {$prev_month['year']}</a> | <a href="{$next_link}">{$next_month['name']} {$next_month['year']} &raquo;</a>
+						{$prev_month_link}{$sep}{$next_month_link}
 					</div>
 					<div><strong>{$monthnames[$month]} {$year}</strong></div>
 				</td>
@@ -3359,6 +3359,8 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 {$footer}
 </body>
 </html>]]></template>
+		<template name="calendar_nextlink" version="1813"><![CDATA[<a href="{$next_link}">{$next_month['name']} {$next_month['year']} &raquo;</a>]]></template>
+		<template name="calendar_prevlink" version="1813"><![CDATA[<a href="{$prev_link}">&laquo; {$prev_month['name']} {$prev_month['year']}</a>]]></template>
 		<template name="calendar_repeats" version="1800"><![CDATA[<span class="smalltext"><strong>{$lang->repeats}</strong><br />{$repeats}</span>]]></template>
 		<template name="calendar_select" version="1800"><![CDATA[<option value="{$calendar_option['cid']}"{$selected}>{$calendar_option['name']}</option>]]></template>
 		<template name="calendar_weekdayheader" version="1400"><![CDATA[				<td class="tcat" align="center" width="14%"><strong>{$weekday_name}</strong></td>]]></template>
@@ -3389,7 +3391,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 					{$day_birthdays}
 					</div>
 				</td>]]></template>
-		<template name="calendar_weekview" version="1800"><![CDATA[<html>
+		<template name="calendar_weekview" version="1813"><![CDATA[<html>
 <head>
 	<title>{$mybb->settings['bbname']} - {$lang->calendar}</title>
 	{$headerinclude}
@@ -3404,7 +3406,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 			<tr>
 				<td class="thead" colspan="2">
 					<div class="float_right">
-						<a href="{$prev_link}">&laquo; {$lang->previous_week}</a> | <a href="{$next_link}">{$lang->next_week} &raquo;</a>
+						{$prev_week_link}{$sep}{$next_week_link}
 					</div>
 					<div><strong>{$lang->weekly_overview} ({$friendly_week_from} - {$friendly_week_to})</strong></div>
 				</td>
@@ -3476,6 +3478,8 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 				<td class="tcat" colspan="2"><strong>{$weekday_month} {$weekday_year}</strong></td>
 			</tr>
 			{$days}]]></template>
+		<template name="calendar_weekview_nextlink" version="1813"><![CDATA[<a href="{$next_link}">{$lang->next_week} &raquo;</a>]]></template>
+		<template name="calendar_weekview_prevlink" version="1813"><![CDATA[<a href="{$prev_link}">&laquo; {$lang->previous_week}</a>]]></template>
 		<template name="calendar_year" version="1800"><![CDATA[<option value="{$year}" {$selected}>{$year}</option>]]></template>
 		<template name="calendar_year_sel" version="1800"><![CDATA[<option value="{$year_sel}">{$year_sel}</option>]]></template>
 		<template name="editpost" version="1809"><![CDATA[<html>


### PR DESCRIPTION
Fixes #2543 

Will hide all month and week links outside of the valid date range (January 1901 - December 5 years from now).