### PR TITLE
Added stripslashes()  to the action listing on modcp.

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -904,7 +904,7 @@ if($mybb->input['action'] == "modlogs")
 	while($logitem = $db->fetch_array($query))
 	{
 		$information = '';
-		$logitem['action'] = htmlspecialchars_uni($logitem['action']);
+		$logitem['action'] = stripslashes(htmlspecialchars_uni($logitem['action']));
 		$log_date = my_date('relative', $logitem['dateline']);
 		$trow = alt_trow();
 		$logitem['username'] = htmlspecialchars_uni($logitem['username']);
@@ -4671,7 +4671,7 @@ if(!$mybb->input['action'])
 		while($logitem = $db->fetch_array($query))
 		{
 			$information = '';
-			$logitem['action'] = htmlspecialchars_uni($logitem['action']);
+			$logitem['action'] = stripslashes(htmlspecialchars_uni($logitem['action']));
 			$log_date = my_date('relative', $logitem['dateline']);
 			$trow = alt_trow();
 			$logitem['username'] = htmlspecialchars_uni($logitem['username']);


### PR DESCRIPTION
In some cases a thread title with a single quote in it may display with a backslash in front of the single quote. This fixes that issue.

Edit: I also ammended this commit so this will also fix the issue in moderator logs.