### PR TITLE
Remove slashes from moderator log during upgrade

### DIFF
--- a/install/resources/upgrade41.php
+++ b/install/resources/upgrade41.php
@@ -45,11 +45,11 @@ function upgrade41_dbchanges()
 	while($row = $db->fetch_array($query))
 	{
 		$original = $row['action'];
-		$stripped = $db->escape_string(stripslashes($original));
+		$stripped = stripslashes($original);
 
 		if($stripped !== $original)
 		{
-			$db->update_query("moderatorlog", "action" => $stripped, "WHERE tid = '".$row['tid']."'");
+			$db->update_query("moderatorlog", "action" => $db->escape_string($stripped), "WHERE tid = '".$row['tid']."'");
 		}
 	}
 

--- a/install/resources/upgrade41.php
+++ b/install/resources/upgrade41.php
@@ -36,20 +36,23 @@ function upgrade41_dbchanges()
 	$db->insert_query('spiders', array("name" => "UptimeRobot", "useragent" => "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)"));
 
 	// Remove backslashes from last 1,000 log files.
-	$query = $db->simple_select('moderatorlog', '*', "action LIKE '%\\\\\\%", "limit" => 1000);
+	$query = $db->simple_select('moderatorlog', 'tid, action', "action LIKE '%\\\\\\%", array(
+		"order_by" => 'tid',
+		"order_dir" => 'DESC',
+		"limit" => 1000
+	));
 
 	while($row = $db->fetch_array($query))
 	{
-    $original = $row['action'];
-    $stripped = stripslashes($original);
+		$original = $row['action'];
+		$stripped = $db->escape_string(stripslashes($original));
 
-    if($stripped !== $original)
-    {
-        $db->update_query("moderatorlog", "action" => stripped, "WHERE tid = '".$row['tid']."'");
-    }
-
+		if($stripped !== $original)
+		{
+			$db->update_query("moderatorlog", "action" => $stripped, "WHERE tid = '".$row['tid']."'");
+		}
 	}
 
-  $output->print_contents("<p>Click next to continue with the upgrade process.</p>");
+	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
 	$output->print_footer("41_done");
 }

--- a/install/resources/upgrade41.php
+++ b/install/resources/upgrade41.php
@@ -36,7 +36,8 @@ function upgrade41_dbchanges()
 	$db->insert_query('spiders', array("name" => "UptimeRobot", "useragent" => "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)"));
 
 	// Iterate through moderator log and remove slashes
-	for ($x = 1; $x < $db->num_rows('moderatorlog'); $x++) {
+	for ($x = 1; $x < $db->num_rows('moderatorlog'); $x++)
+	{
 
 		$moderatorlogitemarray = $db->simple_select("moderatorlog", "*", "tid='".$x."'", array(
 			"limit" => 1

--- a/install/resources/upgrade41.php
+++ b/install/resources/upgrade41.php
@@ -36,7 +36,7 @@ function upgrade41_dbchanges()
 	$db->insert_query('spiders', array("name" => "UptimeRobot", "useragent" => "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)"));
 
 	// Iterate through moderator log and remove slashes
-	for ($x = 0; $x < $db->num_rows('moderatorlog'); $x++) {
+	for ($x = 1; $x < $db->num_rows('moderatorlog'); $x++) {
 
 		$moderatorlogitemarray = $db->simple_select("moderatorlog", "*", "tid='".$x."'", array(
 			"limit" => 1

--- a/install/resources/upgrade41.php
+++ b/install/resources/upgrade41.php
@@ -35,6 +35,27 @@ function upgrade41_dbchanges()
 	$db->insert_query('spiders', array("name" => "DuckDuckGo", "useragent" => "DuckDuckBot/1.1; (+http://duckduckgo.com/duckduckbot.html)"));
 	$db->insert_query('spiders', array("name" => "UptimeRobot", "useragent" => "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)"));
 
+	// Iterate through moderator log and remove slashes
+	for ($x = 0; $x < $db->num_rows('moderatorlog'); $x++) {
+
+		$moderatorlogitemarray = $db->simple_select("moderatorlog", "*", "tid='".$x."'", array(
+			"limit" => 1
+		));
+
+		$update_log_array = array(
+			"uid" => $moderatorlogitemarray[0],
+			"dateline" => $moderatorlogitemarray[1],
+			"fid" => $moderatorlogitemarray[2],
+			"tid" => $moderatorlogitemarray[3],
+			"pid" => $moderatorlogitemarray[4],
+			"action" => stripslashes($moderatorlogitemarray[5]),
+			"data" => $moderatorlogitemarray[6],
+			"ipaddress" => $moderatorlogitemarray[7]
+		);
+
+		$db->update_query("moderatorlog", $update_log_array, "WHERE tid = '".$x."'");
+	}
+	
   	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
 	$output->print_footer("41_done");
 }


### PR DESCRIPTION
This PR Iterates through the moderator log and removes slashes. As decided in PR #2839.