### PR TITLE
Fix #2614 - Hooks with same class method of different objects not being added

### DIFF
--- a/inc/class_plugins.php
+++ b/inc/class_plugins.php
@@ -60,15 +60,18 @@ class pluginSystem
 			}
 
 			if(is_string($function[0]))
-			{ // Static class method
+			{
+				// Static class method
 				$method_representation = sprintf('%s::%s', $function[0], $function[1]);
 			}
 			elseif(is_object($function[0]))
-			{ // Instance class method
-				$method_representation = sprintf('%s->%s', get_class($function[0]), $function[1]);
+			{
+				// Instance class method
+				$method_representation = sprintf('%s->%s', spl_object_hash($function[0]), $function[1]);
 			}
 			else
-			{ // Unknown array type
+			{
+				// Unknown array type
 				return false;
 			}
 


### PR DESCRIPTION
Fixes #2614 

Rather than using `get_class`, use [`spl_object_hash`](http://php.net/manual/en/function.spl-object-hash.php):

> This function returns a unique identifier for the object. This id can be used as a hash key for storing objects, or for identifying an object, as long as the object is not destroyed. Once the object is destroyed, its hash may be reused for other objects.