### PR TITLE
Fix #2865 - SQL error with PostgreSQL when running reputation recount

### DIFF
--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -236,7 +236,7 @@ function acp_recount_reputation()
 		$query2 = $db->query("
 			SELECT SUM(reputation) as total_rep
 			FROM ".TABLE_PREFIX."reputation
-			WHERE `uid`='{$user['uid']}'
+			WHERE uid='{$user['uid']}'
 		");
 		$total_rep = $db->fetch_field($query2, "total_rep");
 


### PR DESCRIPTION
Fixes #2865.

PostgreSQL doesn't use backtick characters to quote identifiers.