### PR TITLE
Fix #257 - Change to SMTP mail composition to comply with standards

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -223,7 +223,7 @@ if($mybb->request_method == "post")
 		$message = $lang->sprintf($lang->email_contact, $mybb->input['email'], $user, $session->ipaddress, $mybb->input['message']);
 
 		// Email the administrator
-		my_mail($contactemail, $subject, $message, $mybb->input['email']);
+		my_mail($contactemail, $subject, $message, '', '', '', false, 'text', '', $mybb->get_input('email', MyBB::INPUT_STRING));
 
 		$plugins->run_hooks('contact_do_end');
 

--- a/member.php
+++ b/member.php
@@ -2955,7 +2955,7 @@ if($mybb->input['action'] == "do_emailuser" && $mybb->request_method == "post")
 		}
 
 		$message = $lang->sprintf($lang->email_emailuser, $to_user['username'], $mybb->input['fromname'], $mybb->settings['bbname'], $mybb->settings['bburl'], $mybb->get_input('message'));
-		my_mail($to_user['email'], $mybb->get_input('subject'), $message, $from, "", "", false, "text", "", $mybb->input['fromemail']);
+		my_mail($to_user['email'], $mybb->get_input('subject'), $message, '', '', '', false, 'text', '', $from);
 
 		if($mybb->settings['mail_logging'] > 0)
 		{


### PR DESCRIPTION
This partially fixes #257 by using the `$return_email` parameter of `my_mail` when sending an email from the `Contact Us` page.

This replaces #2873