### PR TITLE
Restored z-index for modal overlay

### DIFF
--- a/admin/styles/default/modal.css
+++ b/admin/styles/default/modal.css
@@ -7,7 +7,7 @@
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-	z-index: 1;
+	z-index: 9999;
 	padding: 20px;
 	box-sizing: border-box;
 	background-color: rgb(0,0,0);

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -1601,7 +1601,7 @@ a.button.report_user_button span {
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-	z-index: 1;
+	z-index: 9999;
 	padding: 20px;
 	box-sizing: border-box;
 	background-color: rgb(0,0,0);


### PR DESCRIPTION
This PR restores the old z-index to the modal's overlay (CSS rule: `.blocker`) which was introduced with jQuery Modal 0.5.9, in order to display the overlay above anything else (such as SCEditor or other z-indexed items).