### PR TITLE
Restored Cookies wrapping to reflect MyBB's ACP options

### DIFF
--- a/jscripts/general.js
+++ b/jscripts/general.js
@@ -516,7 +516,7 @@ var Cookie = {
 	get: function(name)
 	{
 		name = cookiePrefix + name;
-		return $.cookie(name);
+		return Cookies.get(name);
 	},
 
 	set: function(name, value, expires)
@@ -537,7 +537,7 @@ var Cookie = {
 			secure: cookieSecureFlag == true,
 		};
 
-		return $.cookie(name, value, options);
+		return Cookies.set(name, value, options);
 	},
 
 	unset: function(name)
@@ -548,7 +548,7 @@ var Cookie = {
 			path: cookiePath,
 			domain: cookieDomain
 		};
-		return $.removeCookie(name, options);
+		return Cookies.remove(name, options);
 	}
 };
 
@@ -645,7 +645,7 @@ var expandables = {
 	{
 		var saved = [];
 		var newCollapsed = [];
-		var collapsed = Cookies.get('collapsed');
+		var collapsed = Cookie.get('collapsed');
 
 		if(collapsed)
 		{
@@ -664,7 +664,7 @@ var expandables = {
 		{
 			newCollapsed[newCollapsed.length] = id;
 		}
-		Cookies.set('collapsed', newCollapsed.join("|"));
+		Cookie.set('collapsed', newCollapsed.join("|"));
 	}
 };
 

--- a/jscripts/inline_moderation.js
+++ b/jscripts/inline_moderation.js
@@ -209,8 +209,8 @@ var inlineModeration = {
 		});
 
 		$('#inline_go').val(go_text+' (0)');
-		Cookies.remove(inlineModeration.cookieName);
-		Cookies.remove(inlineModeration.cookieName + '_removed');
+		Cookie.unset(inlineModeration.cookieName);
+		Cookie.unset(inlineModeration.cookieName + '_removed');
 
 		return true;
 	},
@@ -343,7 +343,7 @@ var inlineModeration = {
 
 	getCookie: function(name)
 	{
-		var inlineCookie = Cookies.get(name);
+		var inlineCookie = Cookie.get(name);
 
 		var ids = new Array();
 		if(inlineCookie)
@@ -364,13 +364,11 @@ var inlineModeration = {
 		if(array.length != 0)
 		{
 			var data = '|'+array.join('|')+'|';
-			Cookies.set(name, data, {
-				expires: 1000
-			});
+			Cookie.set(name, data, 60 * 60 * 1000);
 		}
 		else
 		{
-			Cookies.remove(name);
+			Cookie.unset(name);
 		}
 	},
 

--- a/jscripts/inline_reports.js
+++ b/jscripts/inline_reports.js
@@ -173,8 +173,8 @@ var inlineReports = {
 		});
 
 		$('#inline_read').val(mark_read_text+' (0)');
-		Cookies.remove(inlineReports.cookieName);
-		Cookies.remove(inlineReports.cookieName + '_removed');
+		Cookie.unset(inlineReports.cookieName);
+		Cookie.unset(inlineReports.cookieName + '_removed');
 
 		return true;
 	},
@@ -282,7 +282,7 @@ var inlineReports = {
 
 	getCookie: function(name)
 	{
-		var inlineCookie = Cookies.get(name);
+		var inlineCookie = Cookie.get(name);
 
 		var ids = new Array();
 		if(inlineCookie)
@@ -303,11 +303,11 @@ var inlineReports = {
 		if(array.length != 0)
 		{
 			var data = '|'+array.join('|')+'|';
-			Cookies.set(name, data, 60 * 60 * 1000);
+			Cookie.set(name, data, 60 * 60 * 1000);
 		}
 		else
 		{
-			Cookies.remove(name);
+			Cookie.unset(name);
 		}
 	},
 

--- a/jscripts/post.js
+++ b/jscripts/post.js
@@ -87,7 +87,7 @@ var Post = {
 	clearMultiQuoted: function()
 	{
 		$('#multiquote_unloaded').hide();
-		Cookies.remove('multiquote');
+		Cookie.unset('multiquote');
 	},
 	
 	removeAttachment: function(aid)

--- a/jscripts/thread.js
+++ b/jscripts/thread.js
@@ -13,7 +13,7 @@ var Thread = {
 
 	initMultiQuote: function()
 	{
-		var quoted = Cookies.get('multiquote');
+		var quoted = Cookie.get('multiquote');
 		if(quoted)
 		{
 			var post_ids = quoted.split("|");
@@ -38,7 +38,7 @@ var Thread = {
 	multiQuote: function(pid)
 	{
 		var new_post_ids = new Array();
-		var quoted = Cookies.get("multiquote");
+		var quoted = Cookie.get("multiquote");
 		var is_new = true;
 		if(quoted)
 		{
@@ -79,7 +79,7 @@ var Thread = {
 				mquote_quick.hide();
 			}
 		}
-		Cookies.set("multiquote", new_post_ids.join("|"));
+		Cookie.set("multiquote", new_post_ids.join("|"));
 	},
 
 	loadMultiQuoted: function()
@@ -150,7 +150,7 @@ var Thread = {
 	clearMultiQuoted: function()
 	{
 		$('#quickreply_multiquote').hide();
-		var quoted = Cookies.get("multiquote");
+		var quoted = Cookie.get("multiquote");
 		if(quoted)
 		{
 			var post_ids = quoted.split("|");
@@ -163,7 +163,7 @@ var Thread = {
 				}
 			});
 		}
-		Cookies.remove('multiquote');
+		Cookie.unset('multiquote');
 	},
 
 	quickEdit: function(el)


### PR DESCRIPTION
This PRs restores the MyBB-specific wrapping for the Cookies library which was updated within #2697. The previous state was not accounting for any of the options set in the ACP; therefore, cookies were set without any prefix, path, domain or secure flag.