### PR TITLE
Fix cross site scripting vulnerabilities in the admin panel

### DIFF
--- a/admin/modules/config/spiders.php
+++ b/admin/modules/config/spiders.php
@@ -37,7 +37,7 @@ if($mybb->input['action'] == "add")
 		if(!$errors)
 		{
 			$new_spider = array(
-				"name" => $db->escape_string(htmlspecialchars($mybb->input['name'])),
+				"name" => $db->escape_string(htmlspecialchars_uni($mybb->input['name'])),
 				"theme" => $mybb->get_input('theme', MyBB::INPUT_INT),
 				"language" => $db->escape_string($mybb->input['language']),
 				"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT),
@@ -182,7 +182,7 @@ if($mybb->input['action'] == "edit")
 		if(!$errors)
 		{
 			$updated_spider = array(
-				"name" => $db->escape_string(htmlspecialchars($mybb->input['name'])),
+				"name" => $db->escape_string(htmlspecialchars_uni($mybb->input['name'])),
 				"theme" => $mybb->get_input('theme', MyBB::INPUT_INT),
 				"language" => $db->escape_string($mybb->input['language']),
 				"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT),

--- a/admin/modules/config/spiders.php
+++ b/admin/modules/config/spiders.php
@@ -37,7 +37,7 @@ if($mybb->input['action'] == "add")
 		if(!$errors)
 		{
 			$new_spider = array(
-				"name" => $db->escape_string(htmlspecialchars_uni($mybb->input['name'])),
+				"name" => $db->escape_string($mybb->input['name']),
 				"theme" => $mybb->get_input('theme', MyBB::INPUT_INT),
 				"language" => $db->escape_string($mybb->input['language']),
 				"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT),
@@ -182,7 +182,7 @@ if($mybb->input['action'] == "edit")
 		if(!$errors)
 		{
 			$updated_spider = array(
-				"name" => $db->escape_string(htmlspecialchars_uni($mybb->input['name'])),
+				"name" => $db->escape_string($mybb->input['name']),
 				"theme" => $mybb->get_input('theme', MyBB::INPUT_INT),
 				"language" => $db->escape_string($mybb->input['language']),
 				"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT),

--- a/admin/modules/config/spiders.php
+++ b/admin/modules/config/spiders.php
@@ -37,7 +37,7 @@ if($mybb->input['action'] == "add")
 		if(!$errors)
 		{
 			$new_spider = array(
-				"name" => $db->escape_string(htmlspecialchars(($mybb->input['name'])),
+				"name" => $db->escape_string(htmlspecialchars($mybb->input['name'])),
 				"theme" => $mybb->get_input('theme', MyBB::INPUT_INT),
 				"language" => $db->escape_string($mybb->input['language']),
 				"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT),

--- a/admin/modules/config/spiders.php
+++ b/admin/modules/config/spiders.php
@@ -37,7 +37,7 @@ if($mybb->input['action'] == "add")
 		if(!$errors)
 		{
 			$new_spider = array(
-				"name" => $db->escape_string($mybb->input['name']),
+				"name" => $db->escape_string(htmlspecialchars(($mybb->input['name'])),
 				"theme" => $mybb->get_input('theme', MyBB::INPUT_INT),
 				"language" => $db->escape_string($mybb->input['language']),
 				"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT),
@@ -182,7 +182,7 @@ if($mybb->input['action'] == "edit")
 		if(!$errors)
 		{
 			$updated_spider = array(
-				"name" => $db->escape_string($mybb->input['name']),
+				"name" => $db->escape_string(htmlspecialchars($mybb->input['name'])),
 				"theme" => $mybb->get_input('theme', MyBB::INPUT_INT),
 				"language" => $db->escape_string($mybb->input['language']),
 				"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT),

--- a/admin/modules/config/thread_prefixes.php
+++ b/admin/modules/config/thread_prefixes.php
@@ -81,7 +81,7 @@ if($mybb->input['action'] == 'add_prefix')
 		{
 			$new_prefix = array(
 				'prefix'		=> $db->escape_string($mybb->input['prefix']),
-				'displaystyle'	=> $db->escape_string($mybb->input['displaystyle'])
+				'displaystyle'	=> $db->escape_string(my_strip_tags($mybb->input['displaystyle']))
 			);
 
 			if($mybb->input['forum_type'] == 2)

--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -832,8 +832,8 @@ if($mybb->input['action'] == "add")
 				$pid = 0;
 			}
 			$insert_array = array(
-				"name" => $db->escape_string($mybb->input['title']),
-				"description" => $db->escape_string($mybb->input['description']),
+				"name" => $db->escape_string(my_strip_tags($mybb->input['title'])),
+				"description" => $db->escape_string(my_strip_tags($mybb->input['description'])),
 				"linkto" => $db->escape_string($mybb->input['linkto']),
 				"type" => $db->escape_string($type),
 				"pid" => $pid,
@@ -856,8 +856,8 @@ if($mybb->input['action'] == "add")
 				"style" => $mybb->get_input('style', MyBB::INPUT_INT),
 				"overridestyle" => $mybb->get_input('overridestyle', MyBB::INPUT_INT),
 				"rulestype" => $mybb->get_input('rulestype', MyBB::INPUT_INT),
-				"rulestitle" => $db->escape_string($mybb->input['rulestitle']),
-				"rules" => $db->escape_string($mybb->input['rules']),
+				"rulestitle" => $db->escape_string(my_strip_tags($mybb->input['rulestitle'])),
+				"rules" => $db->escape_string(my_strip_tags($mybb->input['rules'])),
 				"defaultdatecut" => $mybb->get_input('defaultdatecut', MyBB::INPUT_INT),
 				"defaultsortby" => $db->escape_string($mybb->input['defaultsortby']),
 				"defaultsortorder" => $db->escape_string($mybb->input['defaultsortorder']),
@@ -1366,8 +1366,8 @@ if($mybb->input['action'] == "edit")
 				$pid = 0;
 			}
 			$update_array = array(
-				"name" => $db->escape_string($mybb->input['title']),
-				"description" => $db->escape_string($mybb->input['description']),
+				"name" => $db->escape_string(my_strip_tags($mybb->input['title'])),
+				"description" => $db->escape_string(my_strip_tags($mybb->input['description'])),
 				"linkto" => $db->escape_string($mybb->input['linkto']),
 				"type" => $db->escape_string($type),
 				"pid" => $pid,
@@ -1389,8 +1389,8 @@ if($mybb->input['action'] == "edit")
 				"style" => $mybb->get_input('style', MyBB::INPUT_INT),
 				"overridestyle" => $mybb->get_input('overridestyle', MyBB::INPUT_INT),
 				"rulestype" => $mybb->get_input('rulestype', MyBB::INPUT_INT),
-				"rulestitle" => $db->escape_string($mybb->input['rulestitle']),
-				"rules" => $db->escape_string($mybb->input['rules']),
+				"rulestitle" => $db->escape_string(my_strip_tags($mybb->input['rulestitle'])),
+				"rules" => $db->escape_string(my_strip_tags($mybb->input['rules'])),
 				"defaultdatecut" => $mybb->get_input('defaultdatecut', MyBB::INPUT_INT),
 				"defaultsortby" => $db->escape_string($mybb->input['defaultsortby']),
 				"defaultsortorder" => $db->escape_string($mybb->input['defaultsortorder']),

--- a/index.php
+++ b/index.php
@@ -112,7 +112,7 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 		elseif(my_strpos($user['sid'], 'bot=') !== false && $spiders[$botkey])
 		{
 			// The user is a search bot.
-			$onlinemembers .= $comma.format_name($spiders[$botkey]['name'], $spiders[$botkey]['usergroup']);
+			$onlinemembers .= $comma.format_name(htmlspecialchars_uni($spiders[$botkey]['name']), $spiders[$botkey]['usergroup']);
 			$comma = $lang->comma;
 			++$botcount;
 		}

--- a/online.php
+++ b/online.php
@@ -235,7 +235,7 @@ else
 		// Otherwise this session is a bot
 		else if(my_strpos($user['sid'], "bot=") !== false && $spiders[$botkey])
 		{
-			$user['bot'] = $spiders[$botkey]['name'];
+			$user['bot'] = htmlspecialchars_uni($spiders[$botkey]['name']);
 			$user['usergroup'] = $spiders[$botkey]['usergroup'];
 			$guests[] = $user;
 		}


### PR DESCRIPTION
This pull request fixes the following cross site scripting vulnerabilities that originate in the admin panel.

1. Forum/Category Name / Description are not sanitized, on add nor update. This allows a limited permission admin to perform a cross site scripting attack on a super admin  (or really any user on the forum). I've resolved using the my_strip_tags that prevents the use of `<script>` tags while still allowing HTML. This affects both the admin panel display and public forum display.
2. Forum/Category rules title / description are not sanitized, on add nor update. On forum display rules description is sanitized at the last minute but the rules title is not allowing a cross site scripting attack to attack a super admin  (or really any user on the forum). account. I've resolved using the my_strip_tags that prevents the use of `<script>` tags while still allowing HTML.
3. Thread prefixes allow you to style with HTML, however this includes `<script>` tags, allowing a limited permission admin to perform cross site scripting to attack a super admin account. I've resolved this using htmlspecialchars to completely block the use of html in the name.
4. The spiders / bots allows you to include a name, the name however allows HTML, this behavior is likely not intended, the lack of sanitization allows a limited permission admin to create a spider with his user agent and use `<script>` tags as the name, view the site as a guest and perform a cross site scripting attack and attack a super admin (or really any user on the forum).