### PR TITLE
#2907 - Add Composer configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Thumbs.db
 
 # Generic git files
 *.orig
+
+inc/vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "mybb/mybb",
+    "description": "MyBB is a free and open source, community-based forum software project.",
+    "type": "project",
+    "keywords": [
+        "forum",
+        "community"
+    ],
+    "homepage": "https://mybb.com",
+    "license": "LGPL-3.0",
+    "authors": [
+        {
+            "name": "MyBB Group",
+            "email": "contact@mybb.com"
+        }
+    ],
+    "support": {
+        "forum": "https://community.mybb.com",
+        "docs": "https://docs.mybb.com",
+        "source": "https://github.com/mybb/mybb",
+        "issues": "https://github.com/mybb/mybb/issues"
+    },
+    "require": {
+        "php": "^5.6 || ^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "MyBB\\": "inc/src/"
+        },
+        "files": [
+            "inc/functions.php"
+        ]
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
+    "config": {
+        "vendor-dir": "inc/vendor",
+        "bin-dir": "inc/vendor/bin",
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
             "MyBB\\": "inc/src/"
         },
         "files": [
-            "inc/functions.php"
         ]
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ab509c7218859e6745963ef4457859f5",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^5.6 || ^7.0"
+    },
+    "platform-dev": []
+}

--- a/global.php
+++ b/global.php
@@ -16,6 +16,7 @@ if(!$working_dir)
 
 // Load main MyBB core file which begins all of the magic
 require_once $working_dir.'/inc/init.php';
+require_once $working_dir.'/inc/vendor/autoload.php';
 
 $shutdown_queries = $shutdown_functions = array();
 


### PR DESCRIPTION
Fixes #2907 by adding a Composer configuration file and ammends the `.gitignore` to ignore the vendor directory.

Dependencies are set to be installed to the `inc/vendor` folder, with classes autoloaded following the PSR-4 standard from `inc/src`.