### PR TITLE
Move composer autoloader to bootstrap file

### DIFF
--- a/global.php
+++ b/global.php
@@ -16,7 +16,7 @@ if(!$working_dir)
 
 // Load main MyBB core file which begins all of the magic
 require_once $working_dir.'/inc/init.php';
-require_once $working_dir.'/inc/vendor/autoload.php';
+require_once $working_dir.'/inc/src/bootstrap.php';
 
 $shutdown_queries = $shutdown_functions = array();
 

--- a/inc/src/bootstrap.php
+++ b/inc/src/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace MyBB;
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Move the composer autoloader to a boostrap file so the files that do not require global.php have access to the autoloader without having to load global.php