### PR TITLE
Escaping keyword "groups" for MySQL 8 (#2921)

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -1378,17 +1378,17 @@ if(!empty($threadcache) && is_array($threadcache))
 					foreach($gids as $gid)
 					{
 						$gid = (int)$gid;
-						$gidswhere .= " OR ','||groups||',' LIKE '%,{$gid},%'";
+						$gidswhere .= " OR ','||`groups`||',' LIKE '%,{$gid},%'";
 					}
-					$query = $db->simple_select("modtools", 'tid, name', "(','||forums||',' LIKE '%,$fid,%' OR ','||forums||',' LIKE '%,-1,%' OR forums='') AND (groups='' OR ','||groups||',' LIKE '%,-1,%'{$gidswhere}) AND type = 't'");
+					$query = $db->simple_select("modtools", 'tid, name', "(','||forums||',' LIKE '%,$fid,%' OR ','||forums||',' LIKE '%,-1,%' OR forums='') AND (`groups`='' OR ','||`groups`||',' LIKE '%,-1,%'{$gidswhere}) AND type = 't'");
 					break;
 				default:
 					foreach($gids as $gid)
 					{
 						$gid = (int)$gid;
-						$gidswhere .= " OR CONCAT(',',groups,',') LIKE '%,{$gid},%'";
+						$gidswhere .= " OR CONCAT(',',`groups`,',') LIKE '%,{$gid},%'";
 					}
-					$query = $db->simple_select("modtools", 'tid, name', "(CONCAT(',',forums,',') LIKE '%,$fid,%' OR CONCAT(',',forums,',') LIKE '%,-1,%' OR forums='') AND (groups='' OR CONCAT(',',groups,',') LIKE '%,-1,%'{$gidswhere}) AND type = 't'");
+					$query = $db->simple_select("modtools", 'tid, name', "(CONCAT(',',forums,',') LIKE '%,$fid,%' OR CONCAT(',',forums,',') LIKE '%,-1,%' OR forums='') AND (`groups`='' OR CONCAT(',',`groups`,',') LIKE '%,-1,%'{$gidswhere}) AND type = 't'");
 					break;
 			}
 

--- a/install/resources/mysql_db_tables.php
+++ b/install/resources/mysql_db_tables.php
@@ -103,7 +103,7 @@ $tables[] = "CREATE TABLE mybb_attachtypes (
   maxsize int(15) unsigned NOT NULL default '0',
   icon varchar(100) NOT NULL default '',
   enabled tinyint(1) NOT NULL default '1',
-  groups TEXT NOT NULL,
+  `groups` TEXT NOT NULL,
   forums TEXT NOT NULL,
   avatarfile tinyint(1) NOT NULL default '0',
   PRIMARY KEY (atid)
@@ -481,7 +481,7 @@ $tables[] = "CREATE TABLE mybb_modtools (
 	name varchar(200) NOT NULL,
 	description text NOT NULL,
 	forums text NOT NULL,
-	groups text NOT NULL,
+	`groups` text NOT NULL,
 	type char(1) NOT NULL default '',
 	postoptions text NOT NULL,
 	threadoptions text NOT NULL,
@@ -872,7 +872,7 @@ $tables[] = "CREATE TABLE mybb_threadprefixes (
 	prefix varchar(120) NOT NULL default '',
 	displaystyle varchar(200) NOT NULL default '',
 	forums text NOT NULL,
-	groups text NOT NULL,
+	`groups` text NOT NULL,
 	PRIMARY KEY (pid)
 ) ENGINE=MyISAM;";
 
@@ -1180,5 +1180,3 @@ $tables[] = "CREATE TABLE mybb_warnings (
 	KEY uid (uid),
 	PRIMARY KEY (wid)
 ) ENGINE=MyISAM;";
-
-

--- a/install/resources/upgrade30.php
+++ b/install/resources/upgrade30.php
@@ -681,9 +681,9 @@ function upgrade30_dbchanges4()
 		$db->drop_column("maillogs", "type");
 	}
 
-	if($db->field_exists('groups', 'modtools'))
+	if($db->field_exists('`groups`', 'modtools'))
 	{
-		$db->drop_column("modtools", "groups");
+		$db->drop_column("modtools", "`groups`");
 	}
 
 	switch($db->type)
@@ -717,10 +717,10 @@ function upgrade30_dbchanges4()
 	switch($db->type)
 	{
 		case "sqlite":
-			$db->add_column("modtools", "groups", "text NOT NULL default ''");
+			$db->add_column("modtools", "`groups`", "text NOT NULL default ''");
 			break;
 		default:
-			$db->add_column("modtools", "groups", "text NOT NULL");
+			$db->add_column("modtools", "`groups`", "text NOT NULL");
 			break;
 	}
 

--- a/install/resources/upgrade36.php
+++ b/install/resources/upgrade36.php
@@ -33,9 +33,9 @@ function upgrade36_dbchanges()
 		$db->drop_column('attachtypes', 'enabled');
 	}
 
-	if($db->field_exists('groups', 'attachtypes'))
+	if($db->field_exists('`groups`', 'attachtypes'))
 	{
-		$db->drop_column('attachtypes', 'groups');
+		$db->drop_column('attachtypes', '`groups`');
 	}
 
 	if($db->field_exists('forums', 'attachtypes'))
@@ -52,17 +52,17 @@ function upgrade36_dbchanges()
 	{
 		case "pgsql":
 			$db->add_column('attachtypes', 'enabled', "smallint NOT NULL default '1'");
-			$db->add_column('attachtypes', 'groups', "text NOT NULL default '-1'");
+			$db->add_column('attachtypes', '`groups`', "text NOT NULL default '-1'");
 			$db->add_column('attachtypes', 'forums', "text NOT NULL default '-1'");
 			$db->add_column('attachtypes', 'avatarfile', "smallint NOT NULL default '0'");
 			break;
 		default:
 			$db->add_column('attachtypes', 'enabled', "tinyint(1) NOT NULL default '1'");
-			$db->add_column('attachtypes', 'groups', "TEXT NOT NULL");
+			$db->add_column('attachtypes', '`groups`', "TEXT NOT NULL");
 			$db->add_column('attachtypes', 'forums', "TEXT NOT NULL");
 			$db->add_column('attachtypes', 'avatarfile', "tinyint(1) NOT NULL default '0'");
 
-			$db->update_query('attachtypes', array('groups' => '-1', 'forums' => '-1'));
+			$db->update_query('attachtypes', array('`groups`' => '-1', 'forums' => '-1'));
 			break;
 	}
 

--- a/moderation.php
+++ b/moderation.php
@@ -248,10 +248,10 @@ switch($mybb->input['action'])
 			{
 				case "pgsql":
 				case "sqlite":
-					$query = $db->simple_select("modtools", 'tid, name, groups', "(','||forums||',' LIKE '%,$fid,%' OR ','||forums||',' LIKE '%,-1,%' OR forums='') AND type = 't'");
+					$query = $db->simple_select("modtools", 'tid, name, `groups`', "(','||forums||',' LIKE '%,$fid,%' OR ','||forums||',' LIKE '%,-1,%' OR forums='') AND type = 't'");
 					break;
 				default:
-					$query = $db->simple_select("modtools", 'tid, name, groups', "(CONCAT(',',forums,',') LIKE '%,$fid,%' OR CONCAT(',',forums,',') LIKE '%,-1,%' OR forums='') AND type = 't'");
+					$query = $db->simple_select("modtools", 'tid, name, `groups`', "(CONCAT(',',forums,',') LIKE '%,$fid,%' OR CONCAT(',',forums,',') LIKE '%,-1,%' OR forums='') AND type = 't'");
 			}
 			while($tool = $db->fetch_array($query))
 			{

--- a/showthread.php
+++ b/showthread.php
@@ -1298,17 +1298,17 @@ if($mybb->input['action'] == "thread")
 					foreach($gids as $gid)
 					{
 						$gid = (int)$gid;
-						$gidswhere .= " OR ','||groups||',' LIKE '%,{$gid},%'";
+						$gidswhere .= " OR ','||`groups`||',' LIKE '%,{$gid},%'";
 					}
-					$query = $db->simple_select("modtools", 'tid, name, type', "(','||forums||',' LIKE '%,$fid,%' OR ','||forums||',' LIKE '%,-1,%' OR forums='') AND (groups='' OR ','||groups||',' LIKE '%,-1,%'{$gidswhere})");
+					$query = $db->simple_select("modtools", 'tid, name, type', "(','||forums||',' LIKE '%,$fid,%' OR ','||forums||',' LIKE '%,-1,%' OR forums='') AND (`groups`='' OR ','||`groups`||',' LIKE '%,-1,%'{$gidswhere})");
 					break;
 				default:
 					foreach($gids as $gid)
 					{
 						$gid = (int)$gid;
-						$gidswhere .= " OR CONCAT(',',groups,',') LIKE '%,{$gid},%'";
+						$gidswhere .= " OR CONCAT(',',`groups`,',') LIKE '%,{$gid},%'";
 					}
-					$query = $db->simple_select("modtools", 'tid, name, type', "(CONCAT(',',forums,',') LIKE '%,$fid,%' OR CONCAT(',',forums,',') LIKE '%,-1,%' OR forums='') AND (groups='' OR CONCAT(',',groups,',') LIKE '%,-1,%'{$gidswhere})");
+					$query = $db->simple_select("modtools", 'tid, name, type', "(CONCAT(',',forums,',') LIKE '%,$fid,%' OR CONCAT(',',forums,',') LIKE '%,-1,%' OR forums='') AND (`groups`='' OR CONCAT(',',`groups`,',') LIKE '%,-1,%'{$gidswhere})");
 					break;
 			}
 


### PR DESCRIPTION
I used a regex search to find instances of "groups" in query string parameters and backtick them.

Unfortunately, I can't get MySQL 8 working on my WAMP stack for some reason so I'd appreciate it if someone else could test to see if this does indeed fix #2921 

Thanks :)