### PR TITLE
Added more duct-tape to search.php (fixes #2915)

### DIFF
--- a/search.php
+++ b/search.php
@@ -1303,17 +1303,17 @@ elseif($mybb->input['action'] == "finduser")
 }
 elseif($mybb->input['action'] == "finduserthreads")
 {
-	$where_sql = "t.uid='".$mybb->get_input('uid', MyBB::INPUT_INT)."'";
+	$where_sql = "uid='".$mybb->get_input('uid', MyBB::INPUT_INT)."'";
 
 	$unsearchforums = get_unsearchable_forums();
 	if($unsearchforums)
 	{
-		$where_sql .= " AND t.fid NOT IN ($unsearchforums)";
+		$where_sql .= " AND fid NOT IN ($unsearchforums)";
 	}
 	$inactiveforums = get_inactive_forums();
 	if($inactiveforums)
 	{
-		$where_sql .= " AND t.fid NOT IN ($inactiveforums)";
+		$where_sql .= " AND fid NOT IN ($inactiveforums)";
 	}
 
 	$permsql = "";
@@ -1330,7 +1330,16 @@ elseif($mybb->input['action'] == "finduserthreads")
 	}
 	if(!empty($onlyusfids))
 	{
-		$where_sql .= "AND ((t.fid IN(".implode(',', $onlyusfids).") AND t.uid='{$mybb->user['uid']}') OR t.fid NOT IN(".implode(',', $onlyusfids)."))";
+		$where_sql .= "AND ((fid IN(".implode(',', $onlyusfids).") AND uid='{$mybb->user['uid']}') OR fid NOT IN(".implode(',', $onlyusfids)."))";
+	}
+
+	$tids = '';
+	$comma = '';
+	$query = $db->simple_select("threads", "tid", $where_sql);
+	while($tid = $db->fetch_field($query, "tid"))
+	{
+			$tids .= $comma.$tid;
+			$comma = ',';
 	}
 
 	$sid = md5(uniqid(microtime(), true));
@@ -1339,7 +1348,7 @@ elseif($mybb->input['action'] == "finduserthreads")
 		"uid" => $mybb->user['uid'],
 		"dateline" => TIME_NOW,
 		"ipaddress" => $db->escape_binary($session->packedip),
-		"threads" => '',
+		"threads" => $db->escape_string($tids),
 		"posts" => '',
 		"resulttype" => "threads",
 		"querycache" => $db->escape_string($where_sql),


### PR DESCRIPTION
The entire latter half of `search.php` needs to be rewritten. Almost identical code is replicated in at least 6 places and the interaction between the code and the database is inconsistent as hell. One of these broken promises is what caused the distant failure of moderation "select all" on user thread lists (#2915). `getallids()` in `moderation.php` expects `search.php` to behave in a sane way wrt interacting with the `searchlog` table but it doesn't and therefore `search.php` is at fault for the issue.

Notably, although there aren't issues related to #2915 yet, there should be and will be eventually. Trying to mass moderate "recent threads" as well as "today's threads" will exhibit exactly the same failure until someone fixes `search.php` more thoroughly. I'm happy to do that since I already understand exactly what the problems are. And I get great pleasure out of refactoring massively duplicated code (unironically).

In the meantime, this is a band-aid over a bullet wound. But it fixes #2915 and that'll do for now.