### PR TITLE
Add Laravel's caching library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,10 @@
     },
     "require": {
         "php": "^7.0",
+        "illuminate/cache": "^5.5",
         "illuminate/container": "^5.5",
         "illuminate/events": "^5.5",
+        "illuminate/filesystem": "^5.5",
         "illuminate/routing": "^5.5",
         "twig/twig": "^2.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "47eda44965270110f0a074a69b6310dd",
+    "content-hash": "812d9c42eac62dfc71693d38cd67b6e2",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -72,6 +72,55 @@
                 "string"
             ],
             "time": "2017-07-22T12:18:28+00:00"
+        },
+        {
+            "name": "illuminate/cache",
+            "version": "v5.5.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/cache.git",
+                "reference": "709f1c7da68b65421b3590f5258e158232f33836"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/cache/zipball/709f1c7da68b65421b3590f5258e158232f33836",
+                "reference": "709f1c7da68b65421b3590f5258e158232f33836",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "5.5.*",
+                "illuminate/support": "5.5.*",
+                "php": ">=7.0"
+            },
+            "suggest": {
+                "illuminate/database": "Required to use the database cache driver (5.5.*).",
+                "illuminate/filesystem": "Required to use the file cache driver (5.5.*).",
+                "illuminate/redis": "Required to use the redis cache driver (5.5.*)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Cache package.",
+            "homepage": "https://laravel.com",
+            "time": "2017-09-19T17:21:01+00:00"
         },
         {
             "name": "illuminate/container",

--- a/inc/class_datacache.php
+++ b/inc/class_datacache.php
@@ -10,1329 +10,1132 @@
 
 class datacache
 {
-	/**
-	 * Cache contents.
-	 *
-	 * @var array
-	 */
-	public $cache = array();
+    /**
+     * @var \DB_Base $db
+     */
+    private $db;
 
-	/**
-	 * The current cache handler we're using
-	 *
-	 * @var CacheHandlerInterface
-	 */
-	public $handler = null;
+    /**
+     * @var bool $debugMode
+     */
+    private $debugMode;
 
-	/**
-	 * A count of the number of calls.
-	 *
-	 * @var int
-	 */
-	public $call_count = 0;
+    /**
+     * Concrete cache store, used to fetch cache contents.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    private $store;
 
-	/**
-	 * A list of the performed calls.
-	 *
-	 * @var array
-	 */
-	public $calllist = array();
+    /**
+     * Cache contents.
+     *
+     * @var array
+     */
+    private $cache;
 
-	/**
-	 * The time spent on cache operations
-	 *
-	 * @var float
-	 */
-	public $call_time = 0;
+    /**
+     * A count of the number of calls.
+     *
+     * @var int
+     */
+    public $call_count = 0;
 
-	/**
-	 * Explanation of a cache call.
-	 *
-	 * @var string
-	 */
-	public $cache_debug;
+    /**
+     * A list of the performed calls.
+     *
+     * @var array
+     */
+    public $calllist = array();
 
-	/**
-	 * Build cache data.
-	 *
-	 */
-	function cache()
-	{
-		global $db, $mybb;
+    /**
+     * The time spent on cache operations
+     *
+     * @var float
+     */
+    public $call_time = 0;
 
-		require_once MYBB_ROOT."/inc/cachehandlers/interface.php";
+    /**
+     * Explanation of a cache call.
+     *
+     * @var string
+     */
+    public $cache_debug;
 
-		switch($mybb->config['cache_store'])
-		{
-			// Disk cache
-			case "files":
-				require_once MYBB_ROOT."/inc/cachehandlers/disk.php";
-				$this->handler = new diskCacheHandler();
-				break;
-			// Memcache cache
-			case "memcache":
-				require_once MYBB_ROOT."/inc/cachehandlers/memcache.php";
-				$this->handler = new memcacheCacheHandler();
-				break;
-			// Memcached cache
-			case "memcached":
-				require_once MYBB_ROOT."/inc/cachehandlers/memcached.php";
-				$this->handler = new memcachedCacheHandler();
-				break;
-			// eAccelerator cache
-			case "eaccelerator":
-				require_once MYBB_ROOT."/inc/cachehandlers/eaccelerator.php";
-				$this->handler = new eacceleratorCacheHandler();
-				break;
-			// Xcache cache
-			case "xcache":
-				require_once MYBB_ROOT."/inc/cachehandlers/xcache.php";
-				$this->handler = new xcacheCacheHandler();
-				break;
-			// APC cache
-			case "apc":
-				require_once MYBB_ROOT."/inc/cachehandlers/apc.php";
-				$this->handler = new apcCacheHandler();
-				break;
-		}
+    /**
+     * Create a new instance of the data cache.
+     *
+     * @param \DB_Base $db Database instance to load data if it doesn't exist in the cache.
+     * @param bool $debugMode Whether debug stats relating to the cache should be generated.
+     * @param \Illuminate\Contracts\Cache\Repository|null $cacheStore A concrete cache store to use.
+     */
+    public function __construct(
+        \DB_Base $db,
+        bool $debugMode,
+        \Illuminate\Contracts\Cache\Repository $cacheStore = null
+    ) {
+        $this->db = $db;
+        $this->debugMode = $debugMode;
+        $this->store = $cacheStore;
 
-		if($this->handler instanceof CacheHandlerInterface)
-		{
-			if(!$this->handler->connect())
-			{
-				$this->handler = null;
-			}
-		}
-		else
-		{
-			// Database cache
-			$query = $db->simple_select("datacache", "title,cache");
-			while($data = $db->fetch_array($query))
-			{
-				$this->cache[$data['title']] = unserialize($data['cache']);
-			}
-		}
-	}
+        $this->initCache();
+    }
 
-	/**
-	 * Read cache from files or db.
-	 *
-	 * @param string $name The cache component to read.
-	 * @param boolean $hard If true, cannot be overwritten during script execution.
-	 * @return mixed
-	 */
-	function read($name, $hard=false)
-	{
-		global $db, $mybb;
+    /**
+     * Initialise the cache, reading all entries from the database if we are using a database cache.
+     */
+    private function initCache()
+    {
+        $this->cache = [];
 
-		// Already have this cache and we're not doing a hard refresh? Return cached copy
-		if(isset($this->cache[$name]) && $hard == false)
-		{
-			return $this->cache[$name];
-		}
-		// If we're not hard refreshing, and this cache doesn't exist, return false
-		// It would have been loaded pre-global if it did exist anyway...
-		else if($hard == false && !($this->handler instanceof CacheHandlerInterface))
-		{
-			return false;
-		}
+        if (is_null($this->store)) {
+            $query = $this->db->simple_select("datacache", "title,cache");
+            while ($data = $this->db->fetch_array($query)) {
+                $this->cache[$data['title']] = my_unserialize($data['cache']);
+            }
+        }
+    }
 
-		if($this->handler instanceof CacheHandlerInterface)
-		{
-			get_execution_time();
+    /**
+     * Read cache from files or db.
+     *
+     * @param string $name The cache component to read.
+     * @param boolean $hard If true, cannot be overwritten during script execution.
+     *
+     * @return mixed
+     */
+    public function read(string $name, bool $hard = false)
+    {
+        // Already have this cache and we're not doing a hard refresh? Return cached copy
+        if (isset($this->cache[$name]) && $hard == false) {
+            return $this->cache[$name];
+        } else {
+            if ($hard == false && is_null($this->store)) {
+                // If we're not hard refreshing, and this cache doesn't exist, return false
+                // It would have been loaded pre-global if it did exist anyway...
+                return false;
+            }
+        }
 
-			$data = $this->handler->fetch($name);
+        get_execution_time();
 
-			$call_time = get_execution_time();
-			$this->call_time += $call_time;
-			$this->call_count++;
+        if (is_null($this->store)) {
+            $data = $this->readFromDatabase($name);
+        } else {
+            $data = $this->store->rememberForever($name, function () use ($name) {
+                return $this->readFromDatabase($name);
+            });
+        }
 
-			if($mybb->debug_mode)
-			{
-				$hit = true;
-				if($data === false)
-				{
-					$hit = false;
-				}
-				$this->debug_call('read:'.$name, $call_time, $hit);
-			}
+        $callTime = get_execution_time();
+        $this->call_time += $callTime;
+        $this->call_count++;
 
-			// No data returned - cache gone bad?
-			if($data === false)
-			{
-				// Fetch from database
-				$query = $db->simple_select("datacache", "title,cache", "title='".$db->escape_string($name)."'");
-				$cache_data = $db->fetch_array($query);
-				$data = unserialize($cache_data['cache']);
+        if ($this->debugMode) {
+            $hit = !is_null($data);
 
-				// Update cache for handler
-				get_execution_time();
+            $this->debug_call("read:{$name}", $callTime, $hit);
+        }
 
-				$hit = $this->handler->put($name, $data);
+        // Cache locally
+        $this->cache[$name] = $data;
 
-				$call_time = get_execution_time();
-				$this->call_time += $call_time;
-				$this->call_count++;
+        return $data;
+    }
 
-				if($mybb->debug_mode)
-				{
-					$this->debug_call('set:'.$name, $call_time, $hit);
-				}
-			}
-		}
-		// Else, using internal database cache
-		else
-		{
-			$query = $db->simple_select("datacache", "title,cache", "title='$name'");
-			$cache_data = $db->fetch_array($query);
+    /**
+     * Read a cache entry from the database.
+     *
+     * @param string $name The name of the cache item to read.
+     *
+     * @return mixed|null The cached data, or null if it doesn't exist.
+     */
+    private function readFromDatabase(string $name)
+    {
+        $query = $this->db->simple_select('datacache', 'title, cache',
+            "title='{$this->db->escape_string($name)}'");
+        $cacheData = $this->db->fetch_array($query);
 
-			if(!$cache_data['title'])
-			{
-				$data = false;
-			}
-			else
-			{
-				$data = unserialize($cache_data['cache']);
-			}
-		}
+        if (isset($cacheData['title']) && !empty($cacheData['title'])) {
+            return my_unserialize($cacheData['cache']);
+        }
 
-		// Cache locally
-		$this->cache[$name] = $data;
+        return null;
+    }
 
-		if($data !== false)
-		{
-			return $data;
-		}
-		else
-		{
-			return false;
-		}
-	}
+    /**
+     * Update cache contents.
+     *
+     * @param string $name The cache content identifier.
+     * @param mixed $contents The cache content.
+     */
+    public function update(string $name, $contents)
+    {
+        $this->cache[$name] = $contents;
 
-	/**
-	 * Update cache contents.
-	 *
-	 * @param string $name The cache content identifier.
-	 * @param string $contents The cache content.
-	 */
-	function update($name, $contents)
-	{
-		global $db, $mybb;
+        // We ALWAYS keep a running copy in the db just incase we need it
+        $dbContents = $this->db->escape_string(my_serialize($contents));
 
-		$this->cache[$name] = $contents;
+        $replace_array = array(
+            'title' => $this->db->escape_string($name),
+            'cache' => $dbContents,
+        );
+        $this->db->replace_query('datacache', $replace_array, '', false);
 
-		// We ALWAYS keep a running copy in the db just incase we need it
-		$dbcontents = $db->escape_string(serialize($contents));
+        if (!is_null($this->store)) {
+            get_execution_time();
 
-		$replace_array = array(
-			"title" => $db->escape_string($name),
-			"cache" => $dbcontents
-		);
-		$db->replace_query("datacache", $replace_array, "", false);
+            $this->store->forever($name, $contents);
 
-		// Do we have a cache handler we're using?
-		if($this->handler instanceof CacheHandlerInterface)
-		{
-			get_execution_time();
+            $callTime = get_execution_time();
+            $this->call_time += $callTime;
+            $this->call_count++;
 
-			$hit = $this->handler->put($name, $contents);
+            if ($this->debugMode) {
+                $this->debug_call("set:{$name}", $callTime, true);
+            }
+        }
+    }
 
-			$call_time = get_execution_time();
-			$this->call_time += $call_time;
-			$this->call_count++;
+    /**
+     * Delete cache contents.
+     *
+     * @param string $name Cache name or title
+     * @param boolean $greedy To delete all cache starting with `$name_`.
+     */
+    function delete($name, $greedy = false)
+    {
+        // Prepare for database query.
+        $dbName = $this->db->escape_string($name);
+        $where = "title = '{$dbName}'";
 
-			if($mybb->debug_mode)
-			{
-				$this->debug_call('update:'.$name, $call_time, $hit);
-			}
-		}
-	}
+        if (!is_null($this->store)) {
+            try {
+                get_execution_time();
 
-	/**
-	 * Delete cache contents.
-	 * Originally from frostschutz's PluginLibrary
-	 * github.com/frostschutz
-	 *
-	 * @param string $name Cache name or title
-	 * @param boolean $greedy To delete a cache starting with name_
-	 */
-	 function delete($name, $greedy = false)
-	 {
-		 global $db, $mybb, $cache;
+                $hit = $this->store->delete($name);
 
-		// Prepare for database query.
-		$dbname = $db->escape_string($name);
-		$where = "title = '{$dbname}'";
+                $callTime = get_execution_time();
+                $this->call_time += $callTime;
+                $this->call_count++;
 
-		// Delete on-demand or handler cache
-		if($this->handler instanceof CacheHandlerInterface)
-		{
-			get_execution_time();
+                if ($this->debugMode) {
+                    $this->debug_call("delete:{$name}", $callTime, $hit);
+                }
+            } catch (\Psr\SimpleCache\InvalidArgumentException $e) {
+                // ignored - thrown if the name isn't a legal value
+            }
+        }
 
-			$hit = $this->handler->delete($name);
+        // Greedy?
+        if ($greedy) {
+            $name .= '_';
+            $names = array();
+            $keys = array_keys($this->cache);
 
-			$call_time = get_execution_time();
-			$this->call_time += $call_time;
-			$this->call_count++;
+            foreach ($keys as $key) {
+                if (strpos($key, $name) === 0) {
+                    $names[$key] = 0;
+                }
+            }
 
-			if($mybb->debug_mode)
-			{
-				$this->debug_call('delete:'.$name, $call_time, $hit);
-			}
-		}
+            // TODO: Can this query be simplified?
+            $ldbname = strtr($dbName,
+                array(
+                    '%' => '=%',
+                    '=' => '==',
+                    '_' => '=_',
+                )
+            );
 
-		// Greedy?
-		if($greedy)
-		{
-			$name .= '_';
-			$names = array();
-			$keys = array_keys($cache->cache);
+            $where .= " OR title LIKE '{$ldbname}=_%' ESCAPE '='";
 
-			foreach($keys as $key)
-			{
-				if(strpos($key, $name) === 0)
-				{
-					$names[$key] = 0;
-				}
-			}
+            if (!is_null($this->store)) {
+                $query = $this->db->simple_select('datacache', 'title', $where);
 
-			$ldbname = strtr($dbname,
-				array(
-					'%' => '=%',
-					'=' => '==',
-					'_' => '=_'
-				)
-			);
+                while ($row = $this->db->fetch_array($query)) {
+                    $names[$row['title']] = 0;
+                }
 
-			$where .= " OR title LIKE '{$ldbname}=_%' ESCAPE '='";
+                try {
+                    get_execution_time();
 
-			if($this->handler instanceof CacheHandlerInterface)
-			{
-				$query = $db->simple_select("datacache", "title", $where);
+                    $hit = $this->store->deleteMultiple(array_keys($names));
 
-				while($row = $db->fetch_array($query))
-				{
-					$names[$row['title']] = 0;
-				}
+                    $callTime = get_execution_time();
+                    $this->call_time += $callTime;
+                    $this->call_count++;
 
-				// ...from the filesystem...
-				$start = strlen(MYBB_ROOT."cache/");
-				foreach((array)@glob(MYBB_ROOT."cache/{$name}*.php") as $filename)
-				{
-					if($filename)
-					{
-						$filename = substr($filename, $start, strlen($filename)-4-$start);
-						$names[$filename] = 0;
-					}
-				}
+                    if ($this->debugMode) {
+                        $this->debug_call("delete:{$name}", $callTime, $hit);
+                    }
+                } catch (\Psr\SimpleCache\InvalidArgumentException $e) {
+                    // ignored - thrown if the name isn't a legal value
+                }
+            }
+        }
 
-				foreach($names as $key => $val)
-				{
-					get_execution_time();
+        // Delete database cache
+        $this->db->delete_query('datacache', $where);
+    }
 
-					$hit = $this->handler->delete($key);
+    /**
+     * Debug a cache call to a non-database cache handler
+     *
+     * @param string $string The cache key.
+     * @param int $qtime The time it took to perform the call.
+     * @param boolean $hit Hit or miss status.
+     */
+    private function debug_call(string $string, int $qtime, bool $hit)
+    {
+        global $mybb, $plugins;
 
-					$call_time = get_execution_time();
-					$this->call_time += $call_time;
-					$this->call_count++;
+        $debug_extra = '';
+        if ($plugins->current_hook) {
+            $debug_extra = "<div style=\"float_right\">(Plugin Hook: {$plugins->current_hook})</div>";
+        }
 
-					if($mybb->debug_mode)
-					{
-						$this->debug_call('delete:'.$name, $call_time, $hit);
-					}
-				}
-			}
-		}
+        if ($hit) {
+            $hit_status = 'HIT';
+        } else {
+            $hit_status = 'MISS';
+        }
 
-		// Delete database cache
-		$db->delete_query("datacache", $where);
-	}
+        $cache_data = explode(':', $string);
+        $cache_method = $cache_data[0];
+        $cache_key = $cache_data[1];
 
-	/**
-	 * Debug a cache call to a non-database cache handler
-	 *
-	 * @param string $string The cache key
-	 * @param string $qtime The time it took to perform the call.
-	 * @param boolean $hit Hit or miss status
-	 */
-	function debug_call($string, $qtime, $hit)
-	{
-		global $mybb, $plugins;
-
-		$debug_extra = '';
-		if($plugins->current_hook)
-		{
-			$debug_extra = "<div style=\"float_right\">(Plugin Hook: {$plugins->current_hook})</div>";
-		}
-
-		if($hit)
-		{
-			$hit_status = 'HIT';
-		}
-		else
-		{
-			$hit_status = 'MISS';
-		}
-
-		$cache_data = explode(':', $string);
-		$cache_method = $cache_data[0];
-		$cache_key = $cache_data[1];
-
-		$this->cache_debug = "<table style=\"background-color: #666;\" width=\"95%\" cellpadding=\"4\" cellspacing=\"1\" align=\"center\">
+        $this->cache_debug = "<table style=\"background-color: #666;\" width=\"95%\" cellpadding=\"4\" cellspacing=\"1\" align=\"center\">
 <tr>
-	<td style=\"background-color: #ccc;\">{$debug_extra}<div><strong>#{$this->call_count} - ".ucfirst($cache_method)." Call</strong></div></td>
+	<td style=\"background-color: #ccc;\">{$debug_extra}<div><strong>#{$this->call_count} - " . ucfirst($cache_method) . " Call</strong></div></td>
 </tr>
 <tr style=\"background-color: #fefefe;\">
-	<td><span style=\"font-family: Courier; font-size: 14px;\">({$mybb->config['cache_store']}) [{$hit_status}] ".htmlspecialchars_uni($cache_key)."</span></td>
+	<td><span style=\"font-family: Courier; font-size: 14px;\">({$mybb->config['cache_store']}) [{$hit_status}] " . htmlspecialchars_uni($cache_key) . "</span></td>
 </tr>
 <tr>
-	<td bgcolor=\"#ffffff\">Call Time: ".format_time_duration($qtime)."</td>
+	<td bgcolor=\"#ffffff\">Call Time: " . format_time_duration($qtime) . "</td>
 </tr>
 </table>
 <br />\n";
 
-		$this->calllist[$this->call_count]['key'] = $string;
-		$this->calllist[$this->call_count]['time'] = $qtime;
-	}
+        $this->calllist[$this->call_count]['key'] = $string;
+        $this->calllist[$this->call_count]['time'] = $qtime;
+    }
 
-	/**
-	 * Select the size of the cache
-	 *
-	 * @param string $name The name of the cache
-	 * @return integer the size of the cache
-	 */
-	function size_of($name='')
-	{
-		global $db;
+    /**
+     * Select the size of the cache
+     *
+     * @param string $name The name of the cache
+     *
+     * @return int The size of the cache.
+     */
+    public function size_of(string $name = '')
+    {
+        // TODO: Laravel's caching library doesn't provide a convenient way to get the size of a given cache item.
+        if ($name) {
+            $query = $this->db->simple_select('datacache', 'cache', "title='{$this->db->escape_string($name)}'");
+            return my_strlen($this->db->fetch_field($query, "cache"));
+        } else {
+            return $this->db->fetch_size('datacache');
+        }
+    }
 
-		if($this->handler instanceof CacheHandlerInterface)
-		{
-			$size = $this->handler->size_of($name);
-			if(!$size)
-			{
-				if($name)
-				{
-					$query = $db->simple_select("datacache", "cache", "title='{$name}'");
-					return strlen($db->fetch_field($query, "cache"));
-				}
-				else
-				{
-					return $db->fetch_size("datacache");
-				}
-			}
-			else
-			{
-				return $size;
-			}
-		}
-		// Using MySQL as cache
-		else
-		{
-			if($name)
-			{
-				$query = $db->simple_select("datacache", "cache", "title='{$name}'");
-				return strlen($db->fetch_field($query, "cache"));
-			}
-			else
-			{
-				return $db->fetch_size("datacache");
-			}
-		}
-	}
+    /**
+     * Update the MyBB version in the cache.
+     *
+     */
+    public function update_version()
+    {
+        global $mybb;
 
-	/**
-	 * Update the MyBB version in the cache.
-	 *
-	 */
-	function update_version()
-	{
-		global $mybb;
+        $version = array(
+            "version" => $mybb->version,
+            "version_code" => $mybb->version_code,
+        );
 
-		$version = array(
-			"version" => $mybb->version,
-			"version_code" => $mybb->version_code
-		);
+        $this->update("version", $version);
+    }
 
-		$this->update("version", $version);
-	}
+    /**
+     * Update the attachment type cache.
+     *
+     */
+    public function update_attachtypes()
+    {
+        $types = array();
 
-	/**
-	 * Update the attachment type cache.
-	 *
-	 */
-	function update_attachtypes()
-	{
-		global $db;
+        $query = $this->db->simple_select('attachtypes', '*', 'enabled=1');
+        while ($type = $this->db->fetch_array($query)) {
+            $type['extension'] = my_strtolower($type['extension']);
+            $types[$type['extension']] = $type;
+        }
 
-		$types = array();
+        $this->update('attachtypes', $types);
+    }
 
-		$query = $db->simple_select('attachtypes', '*', 'enabled=1');
-		while($type = $db->fetch_array($query))
-		{
-			$type['extension'] = my_strtolower($type['extension']);
-			$types[$type['extension']] = $type;
-		}
+    /**
+     * Update the smilies cache.
+     *
+     */
+    public function update_smilies()
+    {
+        $smilies = array();
 
-		$this->update("attachtypes", $types);
-	}
+        $query = $this->db->simple_select('smilies', '*', '', array('order_by' => 'disporder', 'order_dir' => 'ASC'));
+        while ($smilie = $this->db->fetch_array($query)) {
+            $smilies[$smilie['sid']] = $smilie;
+        }
 
-	/**
-	 * Update the smilies cache.
-	 *
-	 */
-	function update_smilies()
-	{
-		global $db;
+        $this->update('smilies', $smilies);
+    }
 
-		$smilies = array();
+    /**
+     * Update the posticon cache.
+     *
+     */
+    public function update_posticons()
+    {
+        $icons = array();
 
-		$query = $db->simple_select("smilies", "*", "", array('order_by' => 'disporder', 'order_dir' => 'ASC'));
-		while($smilie = $db->fetch_array($query))
-		{
-			$smilies[$smilie['sid']] = $smilie;
-		}
+        $query = $this->db->simple_select('icons', 'iid, name, path');
+        while ($icon = $this->db->fetch_array($query)) {
+            $icons[$icon['iid']] = $icon;
+        }
 
-		$this->update("smilies", $smilies);
-	}
+        $this->update('posticons', $icons);
+    }
 
-	/**
-	 * Update the posticon cache.
-	 *
-	 */
-	function update_posticons()
-	{
-		global $db;
+    /**
+     * Update the badwords cache.
+     *
+     */
+    public function update_badwords()
+    {
+        $badwords = array();
 
-		$icons = array();
+        $query = $this->db->simple_select('badwords', '*');
+        while ($badword = $this->db->fetch_array($query)) {
+            $badwords[$badword['bid']] = $badword;
+        }
 
-		$query = $db->simple_select("icons", "iid, name, path");
-		while($icon = $db->fetch_array($query))
-		{
-			$icons[$icon['iid']] = $icon;
-		}
+        $this->update('badwords', $badwords);
+    }
 
-		$this->update("posticons", $icons);
-	}
+    /**
+     * Update the usergroups cache.
+     *
+     */
+    public function update_usergroups()
+    {
+        $query = $this->db->simple_select('usergroups');
 
-	/**
-	 * Update the badwords cache.
-	 *
-	 */
-	function update_badwords()
-	{
-		global $db;
+        $gs = array();
+        while ($g = $this->db->fetch_array($query)) {
+            $gs[$g['gid']] = $g;
+        }
 
-		$badwords = array();
+        $this->update('usergroups', $gs);
+    }
 
-		$query = $db->simple_select("badwords", "*");
-		while($badword = $db->fetch_array($query))
-		{
-			$badwords[$badword['bid']] = $badword;
-		}
+    /**
+     * Update the forum permissions cache.
+     *
+     * @return bool When failed, returns false.
+     */
+    public function update_forumpermissions()
+    {
+        global $forum_cache;
 
-		$this->update("badwords", $badwords);
-	}
+        $this->built_forum_permissions = array(0);
 
-	/**
-	 * Update the usergroups cache.
-	 *
-	 */
-	function update_usergroups()
-	{
-		global $db;
+        // Get our forum list
+        cache_forums(true);
+        if (!is_array($forum_cache)) {
+            return false;
+        }
 
-		$query = $db->simple_select("usergroups");
+        reset($forum_cache);
+        $fcache = array();
 
-		$gs = array();
-		while($g = $db->fetch_array($query))
-		{
-			$gs[$g['gid']] = $g;
-		}
+        // Resort in to the structure we require
+        foreach ($forum_cache as $fid => $forum) {
+            $this->forum_permissions_forum_cache[$forum['pid']][$forum['disporder']][$forum['fid']] = $forum;
+        }
 
-		$this->update("usergroups", $gs);
-	}
+        // Sort children
+        foreach ($fcache as $pid => $value) {
+            ksort($fcache[$pid]);
+        }
+        ksort($fcache);
 
-	/**
-	 * Update the forum permissions cache.
-	 *
-	 * @return bool When failed, returns false.
-	 */
-	function update_forumpermissions()
-	{
-		global $forum_cache, $db;
+        // Fetch forum permissions from the database
+        $query = $this->db->simple_select('forumpermissions');
+        while ($forum_permission = $this->db->fetch_array($query)) {
+            $this->forum_permissions[$forum_permission['fid']][$forum_permission['gid']] = $forum_permission;
+        }
 
-		$this->built_forum_permissions = array(0);
+        $this->build_forum_permissions();
+        $this->update('forumpermissions', $this->built_forum_permissions);
 
-		// Get our forum list
-		cache_forums(true);
-		if(!is_array($forum_cache))
-		{
-			return false;
-		}
+        return true;
+    }
 
-		reset($forum_cache);
-		$fcache = array();
+    /**
+     * Build the forum permissions array
+     *
+     * @param array $permissions An optional permissions array.
+     * @param int $pid An optional permission id.
+     */
+    private function build_forum_permissions(array $permissions = array(), int $pid = 0)
+    {
+        $usergroups = array_keys($this->read("usergroups", true));
+        if ($this->forum_permissions_forum_cache[$pid]) {
+            foreach ($this->forum_permissions_forum_cache[$pid] as $main) {
+                foreach ($main as $forum) {
+                    $perms = $permissions;
+                    foreach ($usergroups as $gid) {
+                        if ($this->forum_permissions[$forum['fid']][$gid]) {
+                            $perms[$gid] = $this->forum_permissions[$forum['fid']][$gid];
+                        }
+                        if ($perms[$gid]) {
+                            $perms[$gid]['fid'] = $forum['fid'];
+                            $this->built_forum_permissions[$forum['fid']][$gid] = $perms[$gid];
+                        }
+                    }
+                    $this->build_forum_permissions($perms, $forum['fid']);
+                }
+            }
+        }
+    }
 
-		// Resort in to the structure we require
-		foreach($forum_cache as $fid => $forum)
-		{
-			$this->forum_permissions_forum_cache[$forum['pid']][$forum['disporder']][$forum['fid']] = $forum;
-		}
+    /**
+     * Update the stats cache (kept for the sake of being able to rebuild this cache via the cache interface)
+     *
+     */
+    public function update_stats()
+    {
+        require_once MYBB_ROOT . 'inc/functions_rebuild.php';
+        rebuild_stats();
+    }
 
-		// Sort children
-		foreach($fcache as $pid => $value)
-		{
-			ksort($fcache[$pid]);
-		}
-		ksort($fcache);
+    /**
+     * Update the statistics cache
+     *
+     */
+    public function update_statistics()
+    {
+        $query = $this->db->simple_select('users', 'uid, username, referrals', 'referrals>0',
+            array('order_by' => 'referrals', 'order_dir' => 'DESC', 'limit' => 1));
+        $topreferrer = $this->db->fetch_array($query);
 
-		// Fetch forum permissions from the database
-		$query = $db->simple_select("forumpermissions");
-		while($forum_permission = $db->fetch_array($query))
-		{
-			$this->forum_permissions[$forum_permission['fid']][$forum_permission['gid']] = $forum_permission;
-		}
+        $timesearch = TIME_NOW - 86400;
+        switch ($this->db->type) {
+            case 'pgsql':
+                $group_by = $this->db->build_fields_string('users', 'u.');
+                break;
+            default:
+                $group_by = 'p.uid';
+                break;
+        }
 
-		$this->build_forum_permissions();
-		$this->update("forumpermissions", $this->built_forum_permissions);
-
-		return true;
-	}
-
-	/**
-	 * Build the forum permissions array
-	 *
-	 * @access private
-	 * @param array $permissions An optional permissions array.
-	 * @param int $pid An optional permission id.
-	 */
-	private function build_forum_permissions($permissions=array(), $pid=0)
-	{
-		$usergroups = array_keys($this->read("usergroups", true));
-		if($this->forum_permissions_forum_cache[$pid])
-		{
-			foreach($this->forum_permissions_forum_cache[$pid] as $main)
-			{
-				foreach($main as $forum)
-				{
-					$perms = $permissions;
-					foreach($usergroups as $gid)
-					{
-						if($this->forum_permissions[$forum['fid']][$gid])
-						{
-							$perms[$gid] = $this->forum_permissions[$forum['fid']][$gid];
-						}
-						if($perms[$gid])
-						{
-							$perms[$gid]['fid'] = $forum['fid'];
-							$this->built_forum_permissions[$forum['fid']][$gid] = $perms[$gid];
-						}
-					}
-					$this->build_forum_permissions($perms, $forum['fid']);
-				}
-			}
-		}
-	}
-
-	/**
-	 * Update the stats cache (kept for the sake of being able to rebuild this cache via the cache interface)
-	 *
-	 */
-	function update_stats()
-	{
-		require_once MYBB_ROOT."inc/functions_rebuild.php";
-		rebuild_stats();
-	}
-
-	/**
-	 * Update the statistics cache
-	 *
-	 */
-	function update_statistics()
-	{
-		global $db;
-
-		$query = $db->simple_select('users', 'uid, username, referrals', 'referrals>0', array('order_by' => 'referrals', 'order_dir' => 'DESC', 'limit' => 1));
-		$topreferrer = $db->fetch_array($query);
-
-		$timesearch = TIME_NOW - 86400;
-		switch($db->type)
-		{
-			case 'pgsql':
-				$group_by = $db->build_fields_string('users', 'u.');
-				break;
-			default:
-				$group_by = 'p.uid';
-				break;
-		}
-
-		$query = $db->query('
+        $query = $this->db->query('
 			SELECT u.uid, u.username, COUNT(pid) AS poststoday
-			FROM '.TABLE_PREFIX.'posts p
-			LEFT JOIN '.TABLE_PREFIX.'users u ON (p.uid=u.uid)
-			WHERE p.dateline>'.$timesearch.' AND p.visible=1
-			GROUP BY '.$group_by.' ORDER BY poststoday DESC
+			FROM ' . TABLE_PREFIX . 'posts p
+			LEFT JOIN ' . TABLE_PREFIX . 'users u ON (p.uid=u.uid)
+			WHERE p.dateline>' . $timesearch . ' AND p.visible=1
+			GROUP BY ' . $group_by . ' ORDER BY poststoday DESC
 			LIMIT 1
 		');
-		$topposter = $db->fetch_array($query);
+        $topposter = $this->db->fetch_array($query);
 
-		$query = $db->simple_select('users', 'COUNT(uid) AS posters', 'postnum>0');
-		$posters = $db->fetch_field($query, 'posters');
+        $query = $this->db->simple_select('users', 'COUNT(uid) AS posters', 'postnum>0');
+        $posters = $this->db->fetch_field($query, 'posters');
 
-		$statistics = array(
-			'time' => TIME_NOW,
-			'top_referrer' => (array)$topreferrer,
-			'top_poster' => (array)$topposter,
-			'posters' => $posters
-		);
+        $statistics = array(
+            'time' => TIME_NOW,
+            'top_referrer' => (array)$topreferrer,
+            'top_poster' => (array)$topposter,
+            'posters' => $posters,
+        );
 
-		$this->update('statistics', $statistics);
-	}
+        $this->update('statistics', $statistics);
+    }
 
-	/**
-	 * Update the moderators cache.
-	 *
-	 * @return bool Returns false on failure
-	 */
-	function update_moderators()
-	{
-		global $forum_cache, $db;
+    /**
+     * Update the moderators cache.
+     *
+     * @return bool Returns false on failure
+     */
+    public function update_moderators()
+    {
+        global $forum_cache;
 
-		$this->built_moderators = array(0);
+        $this->built_moderators = array(0);
 
-		// Get our forum list
-		cache_forums(true);
-		if(!is_array($forum_cache))
-		{
-			return false;
-		}
+        // Get our forum list
+        cache_forums(true);
+        if (!is_array($forum_cache)) {
+            return false;
+        }
 
-		reset($forum_cache);
-		$fcache = array();
+        reset($forum_cache);
+        $fcache = array();
 
-		// Resort in to the structure we require
-		foreach($forum_cache as $fid => $forum)
-		{
-			$this->moderators_forum_cache[$forum['pid']][$forum['disporder']][$forum['fid']] = $forum;
-		}
+        // Resort in to the structure we require
+        foreach ($forum_cache as $fid => $forum) {
+            $this->moderators_forum_cache[$forum['pid']][$forum['disporder']][$forum['fid']] = $forum;
+        }
 
-		// Sort children
-		foreach($fcache as $pid => $value)
-		{
-			ksort($fcache[$pid]);
-		}
-		ksort($fcache);
+        // Sort children
+        foreach ($fcache as $pid => $value) {
+            ksort($fcache[$pid]);
+        }
+        ksort($fcache);
 
-		$this->moderators = array();
+        $this->moderators = array();
 
-		// Fetch moderators from the database
-		$query = $db->query("
+        // Fetch moderators from the database
+        $query = $this->db->query("
 			SELECT m.*, u.username, u.usergroup, u.displaygroup
-			FROM ".TABLE_PREFIX."moderators m
-			LEFT JOIN ".TABLE_PREFIX."users u ON (m.id=u.uid)
+			FROM " . TABLE_PREFIX . "moderators m
+			LEFT JOIN " . TABLE_PREFIX . "users u ON (m.id=u.uid)
 			WHERE m.isgroup = '0'
 			ORDER BY u.username
 		");
-		while($moderator = $db->fetch_array($query))
-		{
-			$this->moderators[$moderator['fid']]['users'][$moderator['id']] = $moderator;
-		}
+        while ($moderator = $this->db->fetch_array($query)) {
+            $this->moderators[$moderator['fid']]['users'][$moderator['id']] = $moderator;
+        }
 
-		if(!function_exists("sort_moderators_by_usernames"))
-		{
-			function sort_moderators_by_usernames($a, $b)
-			{
-				return strcasecmp($a['username'], $b['username']);
-			}
-		}
+        if (!function_exists("sort_moderators_by_usernames")) {
+            function sort_moderators_by_usernames($a, $b)
+            {
+                return strcasecmp($a['username'], $b['username']);
+            }
+        }
 
-		//Fetch moderating usergroups from the database
-		$query = $db->query("
+        //Fetch moderating usergroups from the database
+        $query = $this->db->query("
 			SELECT m.*, u.title
-			FROM ".TABLE_PREFIX."moderators m
-			LEFT JOIN ".TABLE_PREFIX."usergroups u ON (m.id=u.gid)
+			FROM " . TABLE_PREFIX . "moderators m
+			LEFT JOIN " . TABLE_PREFIX . "usergroups u ON (m.id=u.gid)
 			WHERE m.isgroup = '1'
 			ORDER BY u.title
 		");
-		while($moderator = $db->fetch_array($query))
-		{
-			$this->moderators[$moderator['fid']]['usergroups'][$moderator['id']] = $moderator;
-		}
-
-		if(is_array($this->moderators))
-		{
-			foreach(array_keys($this->moderators) as $fid)
-			{
-				uasort($this->moderators[$fid], 'sort_moderators_by_usernames');
-			}
-		}
-
-		$this->build_moderators();
-
-		$this->update("moderators", $this->built_moderators);
-
-		return true;
-	}
-
-	/**
-	 * Update the users awaiting activation cache.
-	 *
-	 */
-	function update_awaitingactivation()
-	{
-		global $db;
-
-		$query = $db->simple_select('users', 'COUNT(uid) AS awaitingusers', 'usergroup=\'5\'');
-		$awaitingusers = (int)$db->fetch_field($query, 'awaitingusers');
-
-		$data = array(
-			'users'	=> $awaitingusers,
-			'time'	=> TIME_NOW
-		);
-
-		$this->update('awaitingactivation', $data);
-	}
-
-	/**
-	 * Build the moderators array
-	 *
-	 * @access private
-	 * @param array $moderators An optional moderators array (moderators of the parent forum for example).
-	 * @param int $pid An optional parent ID.
-	 */
-	private function build_moderators($moderators=array(), $pid=0)
-	{
-		if(isset($this->moderators_forum_cache[$pid]))
-		{
-			foreach($this->moderators_forum_cache[$pid] as $main)
-			{
-				foreach($main as $forum)
-				{
-					$forum_mods = array();
-					if(count($moderators))
-					{
-						$forum_mods = $moderators;
-					}
-					// Append - local settings override that of a parent - array_merge works here
-					if(isset($this->moderators[$forum['fid']]))
-					{
-						if(is_array($forum_mods) && count($forum_mods))
-						{
-							$forum_mods = array_merge($forum_mods, $this->moderators[$forum['fid']]);
-						}
-						else
-						{
-							$forum_mods = $this->moderators[$forum['fid']];
-						}
-					}
-					$this->built_moderators[$forum['fid']] = $forum_mods;
-					$this->build_moderators($forum_mods, $forum['fid']);
-				}
-			}
-		}
-	}
-
-	/**
-	 * Update the forums cache.
-	 *
-	 */
-	function update_forums()
-	{
-		global $db;
-
-		$forums = array();
-
-		// Things we don't want to cache
-		$exclude = array("unapprovedthreads", "unapprovedposts", "threads", "posts", "lastpost", "lastposter", "lastposttid", "lastposteruid", "lastpostsubject", "deletedthreads", "deletedposts");
-
-		$query = $db->simple_select("forums", "*", "", array('order_by' => 'pid,disporder'));
-		while($forum = $db->fetch_array($query))
-		{
-			foreach($forum as $key => $val)
-			{
-				if(in_array($key, $exclude))
-				{
-					unset($forum[$key]);
-				}
-			}
-			$forums[$forum['fid']] = $forum;
-		}
-
-		$this->update("forums", $forums);
-	}
-
-	/**
-	 * Update usertitles cache.
-	 *
-	 */
-	function update_usertitles()
-	{
-		global $db;
-
-		$usertitles = array();
-		$query = $db->simple_select("usertitles", "utid, posts, title, stars, starimage", "", array('order_by' => 'posts', 'order_dir' => 'DESC'));
-		while($usertitle = $db->fetch_array($query))
-		{
-			$usertitles[] = $usertitle;
-		}
-
-		$this->update("usertitles", $usertitles);
-	}
-
-	/**
-	 * Update reported content cache.
-	 *
-	 */
-	function update_reportedcontent()
-	{
-		global $db, $mybb;
-
-		$query = $db->simple_select("reportedcontent", "COUNT(rid) AS unreadcount", "reportstatus='0'");
-		$num = $db->fetch_array($query);
-
-		$query = $db->simple_select("reportedcontent", "COUNT(rid) AS reportcount");
-		$total = $db->fetch_array($query);
-
-		$query = $db->simple_select("reportedcontent", "dateline", "reportstatus='0'", array('order_by' => 'dateline', 'order_dir' => 'DESC'));
-		$latest = $db->fetch_array($query);
-
-		$reports = array(
-			"unread" => $num['unreadcount'],
-			"total" => $total['reportcount'],
-			"lastdateline" => $latest['dateline']
-		);
-
-		$this->update("reportedcontent", $reports);
-	}
-
-	/**
-	 * Update mycode cache.
-	 *
-	 */
-	function update_mycode()
-	{
-		global $db;
-
-		$mycodes = array();
-		$query = $db->simple_select("mycode", "regex, replacement", "active=1", array('order_by' => 'parseorder'));
-		while($mycode = $db->fetch_array($query))
-		{
-			$mycodes[] = $mycode;
-		}
-
-		$this->update("mycode", $mycodes);
-	}
-
-	/**
-	 * Update the mailqueue cache
-	 *
-	 * @param int $last_run
-	 * @param int $lock_time
-	 */
-	function update_mailqueue($last_run=0, $lock_time=0)
-	{
-		global $db;
-
-		$query = $db->simple_select("mailqueue", "COUNT(*) AS queue_size");
-		$queue_size = $db->fetch_field($query, "queue_size");
-
-		$mailqueue = $this->read("mailqueue");
-		if(!is_array($mailqueue))
-		{
-			$mailqueue = array();
-		}
-		$mailqueue['queue_size'] = $queue_size;
-		if($last_run > 0)
-		{
-			$mailqueue['last_run'] = $last_run;
-		}
-		$mailqueue['locked'] = $lock_time;
-
-		$this->update("mailqueue", $mailqueue);
-	}
-
-	/**
-	 * Update update_check cache (dummy function used by upgrade/install scripts)
-	 */
-	function update_update_check()
-	{
-		$update_cache = array(
-			"dateline" => TIME_NOW
-		);
-
-		$this->update("update_check", $update_cache);
-	}
-
-	/**
-	 * Update default_theme cache
-	 */
-	function update_default_theme()
-	{
-		global $db;
-
-		$query = $db->simple_select("themes", "name, tid, properties, stylesheets", "def='1'", array('limit' => 1));
-		$theme = $db->fetch_array($query);
-		$this->update("default_theme", $theme);
-	}
-
-	/**
-	 * Updates the tasks cache saving the next run time
-	 */
-	function update_tasks()
-	{
-		global $db;
-
-		$query = $db->simple_select("tasks", "nextrun", "enabled=1", array("order_by" => "nextrun", "order_dir" => "asc", "limit" => 1));
-		$next_task = $db->fetch_array($query);
-
-		$task_cache = $this->read("tasks");
-		if(!is_array($task_cache))
-		{
-			$task_cache = array();
-		}
-		$task_cache['nextrun'] = $next_task['nextrun'];
-
-		if(!$task_cache['nextrun'])
-		{
-			$task_cache['nextrun'] = TIME_NOW+3600;
-		}
-
-		$this->update("tasks", $task_cache);
-	}
-
-	/**
-	 * Updates the banned IPs cache
-	 */
-	function update_bannedips()
-	{
-		global $db;
-
-		$banned_ips = array();
-		$query = $db->simple_select("banfilters", "fid,filter", "type=1");
-		while($banned_ip = $db->fetch_array($query))
-		{
-			$banned_ips[$banned_ip['fid']] = $banned_ip;
-		}
-		$this->update("bannedips", $banned_ips);
-	}
-
-	/**
-	 * Updates the banned emails cache
-	 */
-	function update_bannedemails()
-	{
-		global $db;
-
-		$banned_emails = array();
-		$query = $db->simple_select("banfilters", "fid, filter", "type = '3'");
-
-		while($banned_email = $db->fetch_array($query))
-		{
-			$banned_emails[$banned_email['fid']] = $banned_email;
-		}
-
-		$this->update("bannedemails", $banned_emails);
-	}
-
-	/**
-	 * Updates the search engine spiders cache
-	 */
-	function update_spiders()
-	{
-		global $db;
-
-		$spiders = array();
-		$query = $db->simple_select("spiders", "sid, name, useragent, usergroup", "", array("order_by" => "LENGTH(useragent)", "order_dir" => "DESC"));
-		while($spider = $db->fetch_array($query))
-		{
-			$spiders[$spider['sid']] = $spider;
-		}
-		$this->update("spiders", $spiders);
-	}
-
-	function update_most_replied_threads()
-	{
-		global $db, $mybb;
-
-		$threads = array();
-
-		$query = $db->simple_select("threads", "tid, subject, replies, fid, uid", "visible='1'", array('order_by' => 'replies', 'order_dir' => 'DESC', 'limit_start' => 0, 'limit' => $mybb->settings['statslimit']));
-		while($thread = $db->fetch_array($query))
-		{
-			$threads[] = $thread;
-		}
-
-		$this->update("most_replied_threads", $threads);
-	}
-
-	function update_most_viewed_threads()
-	{
-		global $db, $mybb;
-
-		$threads = array();
-
-		$query = $db->simple_select("threads", "tid, subject, views, fid, uid", "visible='1'", array('order_by' => 'views', 'order_dir' => 'DESC', 'limit_start' => 0, 'limit' => $mybb->settings['statslimit']));
-		while($thread = $db->fetch_array($query))
-		{
-			$threads[] = $thread;
-		}
-
-		$this->update("most_viewed_threads", $threads);
-	}
-
-	function update_banned()
-	{
-		global $db;
-
-		$bans = array();
-
-		$query = $db->simple_select("banned");
-		while($ban = $db->fetch_array($query))
-		{
-			$bans[$ban['uid']] = $ban;
-		}
-
-		$this->update("banned", $bans);
-	}
-
-	function update_birthdays()
-	{
-		global $db;
-
-		$birthdays = array();
-
-		// Get today, yesterday, and tomorrow's time (for different timezones)
-		$bdaytime = TIME_NOW;
-		$bdaydate = my_date("j-n", $bdaytime, '', 0);
-		$bdaydatetomorrow = my_date("j-n", ($bdaytime+86400), '', 0);
-		$bdaydateyesterday = my_date("j-n", ($bdaytime-86400), '', 0);
-
-		$query = $db->simple_select("users", "uid, username, usergroup, displaygroup, birthday, birthdayprivacy", "birthday LIKE '$bdaydate-%' OR birthday LIKE '$bdaydateyesterday-%' OR birthday LIKE '$bdaydatetomorrow-%'");
-		while($bday = $db->fetch_array($query))
-		{
-			// Pop off the year from the birthday because we don't need it.
-			$bday['bday'] = explode('-', $bday['birthday']);
-			array_pop($bday['bday']);
-			$bday['bday'] = implode('-', $bday['bday']);
-
-			if($bday['birthdayprivacy'] != 'all')
-			{
-				++$birthdays[$bday['bday']]['hiddencount'];
-				continue;
-			}
-
-			// We don't need any excess caleries in the cache
-			unset($bday['birthdayprivacy']);
-
-			$birthdays[$bday['bday']]['users'][] = $bday;
-		}
-
-		$this->update("birthdays", $birthdays);
-	}
-
-	function update_groupleaders()
-	{
-		global $db;
-
-		$groupleaders = array();
-
-		$query = $db->simple_select("groupleaders");
-		while($groupleader = $db->fetch_array($query))
-		{
-			$groupleaders[$groupleader['uid']][] = $groupleader;
-		}
-
-		$this->update("groupleaders", $groupleaders);
-	}
-
-	function update_threadprefixes()
-	{
-		global $db;
-
-		$prefixes = array();
-		$query = $db->simple_select("threadprefixes", "*", "", array('order_by' => 'prefix', 'order_dir' => 'ASC'));
-
-		while($prefix = $db->fetch_array($query))
-		{
-			$prefixes[$prefix['pid']] = $prefix;
-		}
-
-		$this->update("threadprefixes", $prefixes);
-	}
-
-	function update_forumsdisplay()
-	{
-		global $db;
-
-		$fd_statistics = array();
-
-		$time = TIME_NOW; // Look for announcements that don't end, or that are ending some time in the future
-		$query = $db->simple_select("announcements", "fid", "enddate = '0' OR enddate > '{$time}'", array("order_by" => "aid"));
-
-		if($db->num_rows($query))
-		{
-			while($forum = $db->fetch_array($query))
-			{
-				if(!isset($fd_statistics[$forum['fid']]['announcements']))
-				{
-					$fd_statistics[$forum['fid']]['announcements'] = 1;
-				}
-			}
-		}
-
-		// Do we have any mod tools to use in our forums?
-		$query = $db->simple_select("modtools", "forums, tid", '', array("order_by" => "tid"));
-
-		if($db->num_rows($query))
-		{
-			unset($forum);
-			while($tool = $db->fetch_array($query))
-			{
-				$forums = explode(",", $tool['forums']);
-
-				foreach($forums as $forum)
-				{
-					if(!$forum)
-					{
-						$forum = -1;
-					}
-
-					if(!isset($fd_statistics[$forum]['modtools']))
-					{
-						$fd_statistics[$forum]['modtools'] = 1;
-					}
-				}
-			}
-		}
-
-		$this->update("forumsdisplay", $fd_statistics);
-	}
-
-	/**
-	 * Update profile fields cache.
-	 *
-	 */
-	function update_profilefields()
-	{
-		global $db;
-
-		$fields = array();
-		$query = $db->simple_select("profilefields", "*", "", array('order_by' => 'disporder'));
-		while($field = $db->fetch_array($query))
-		{
-			$fields[] = $field;
-		}
-
-		$this->update("profilefields", $fields);
-	}
-
-	/**
-	 * Update the report reasons cache.
-	 *
-	 */
-	function update_reportreasons($no_plugins = false)
-	{
-		global $db;
-
-		$content_types = array('post', 'profile', 'reputation');
-		if(!$no_plugins)
-		{
-			global $plugins;
-			$content_types = $plugins->run_hooks("report_content_types", $content_types);
-		}
-
-		$reasons = array();
-
-		$query = $db->simple_select("reportreasons", "*", "", array('order_by' => 'disporder'));
-		while($reason = $db->fetch_array($query))
-		{
-			if($reason['appliesto'] == 'all')
-			{
-				foreach($content_types as $content)
-				{
-					$reasons[$content][] = array(
-						'rid' => $reason['rid'],
-						'title' => $reason['title'],
-						'extra' => $reason['extra'],
-					);
-				}
-			}
-			elseif($reason['appliesto'] != '')
-			{
-				$appliesto = explode(",", $reason['appliesto']);
-				foreach($appliesto as $content)
-				{
-					$reasons[$content][] = array(
-						'rid' => $reason['rid'],
-						'title' => $reason['title'],
-						'extra' => $reason['extra'],
-					);
-				}
-			}
-		}
-
-		$this->update("reportreasons", $reasons);
-	}
-
-	/* Other, extra functions for reloading caches if we just changed to another cache extension (i.e. from db -> xcache) */
-	function reload_mostonline()
-	{
-		global $db;
-
-		$query = $db->simple_select("datacache", "title,cache", "title='mostonline'");
-		$this->update("mostonline", unserialize($db->fetch_field($query, "cache")));
-	}
-
-	function reload_plugins()
-	{
-		global $db;
-
-		$query = $db->simple_select("datacache", "title,cache", "title='plugins'");
-		$this->update("plugins", unserialize($db->fetch_field($query, "cache")));
-	}
-
-	function reload_last_backup()
-	{
-		global $db;
-
-		$query = $db->simple_select("datacache", "title,cache", "title='last_backup'");
-		$this->update("last_backup", unserialize($db->fetch_field($query, "cache")));
-	}
-
-	function reload_internal_settings()
-	{
-		global $db;
-
-		$query = $db->simple_select("datacache", "title,cache", "title='internal_settings'");
-		$this->update("internal_settings", unserialize($db->fetch_field($query, "cache")));
-	}
-
-	function reload_version_history()
-	{
-		global $db;
-
-		$query = $db->simple_select("datacache", "title,cache", "title='version_history'");
-		$this->update("version_history", unserialize($db->fetch_field($query, "cache")));
-	}
-
-	function reload_modnotes()
-	{
-		global $db;
-
-		$query = $db->simple_select("datacache", "title,cache", "title='modnotes'");
-		$this->update("modnotes", unserialize($db->fetch_field($query, "cache")));
-	}
-
-	function reload_adminnotes()
-	{
-		global $db;
-
-		$query = $db->simple_select("datacache", "title,cache", "title='adminnotes'");
-		$this->update("adminnotes", unserialize($db->fetch_field($query, "cache")));
-	}
-
-	function reload_mybb_credits()
-	{
-		admin_redirect('index.php?module=home-credits&amp;fetch_new=-2');
-	}
+        while ($moderator = $this->db->fetch_array($query)) {
+            $this->moderators[$moderator['fid']]['usergroups'][$moderator['id']] = $moderator;
+        }
+
+        if (is_array($this->moderators)) {
+            foreach (array_keys($this->moderators) as $fid) {
+                uasort($this->moderators[$fid], 'sort_moderators_by_usernames');
+            }
+        }
+
+        $this->build_moderators();
+
+        $this->update("moderators", $this->built_moderators);
+
+        return true;
+    }
+
+    /**
+     * Update the users awaiting activation cache.
+     *
+     */
+    public function update_awaitingactivation()
+    {
+        $query = $this->db->simple_select('users', 'COUNT(uid) AS awaitingusers', 'usergroup=\'5\'');
+        $awaitingusers = (int)$this->db->fetch_field($query, 'awaitingusers');
+
+        $data = array(
+            'users' => $awaitingusers,
+            'time' => TIME_NOW,
+        );
+
+        $this->update('awaitingactivation', $data);
+    }
+
+    /**
+     * Build the moderators array
+     *
+     * @param array $moderators An optional moderators array (moderators of the parent forum for example).
+     * @param int $pid An optional parent ID.
+     */
+    private function build_moderators(array $moderators = array(), int $pid = 0)
+    {
+        if (isset($this->moderators_forum_cache[$pid])) {
+            foreach ($this->moderators_forum_cache[$pid] as $main) {
+                foreach ($main as $forum) {
+                    $forum_mods = array();
+                    if (count($moderators)) {
+                        $forum_mods = $moderators;
+                    }
+                    // Append - local settings override that of a parent - array_merge works here
+                    if (isset($this->moderators[$forum['fid']])) {
+                        if (is_array($forum_mods) && count($forum_mods)) {
+                            $forum_mods = array_merge($forum_mods, $this->moderators[$forum['fid']]);
+                        } else {
+                            $forum_mods = $this->moderators[$forum['fid']];
+                        }
+                    }
+                    $this->built_moderators[$forum['fid']] = $forum_mods;
+                    $this->build_moderators($forum_mods, $forum['fid']);
+                }
+            }
+        }
+    }
+
+    /**
+     * Update the forums cache.
+     *
+     */
+    public function update_forums()
+    {
+        $forums = array();
+
+        // Things we don't want to cache
+        $exclude = array(
+            "unapprovedthreads",
+            "unapprovedposts",
+            "threads",
+            "posts",
+            "lastpost",
+            "lastposter",
+            "lastposttid",
+            "lastposteruid",
+            "lastpostsubject",
+            "deletedthreads",
+            "deletedposts",
+        );
+
+        $query = $this->db->simple_select('forums', '*', '', array('order_by' => 'pid,disporder'));
+        while ($forum = $this->db->fetch_array($query)) {
+            foreach ($forum as $key => $val) {
+                if (in_array($key, $exclude)) {
+                    unset($forum[$key]);
+                }
+            }
+            $forums[$forum['fid']] = $forum;
+        }
+
+        $this->update("forums", $forums);
+    }
+
+    /**
+     * Update usertitles cache.
+     *
+     */
+    public function update_usertitles()
+    {
+        $usertitles = array();
+        $query = $this->db->simple_select('usertitles', 'utid, posts, title, stars, starimage', '',
+            array('order_by' => 'posts', 'order_dir' => 'DESC'));
+        while ($usertitle = $this->db->fetch_array($query)) {
+            $usertitles[] = $usertitle;
+        }
+
+        $this->update("usertitles", $usertitles);
+    }
+
+    /**
+     * Update reported content cache.
+     *
+     */
+    public function update_reportedcontent()
+    {
+        $query = $this->db->simple_select("reportedcontent", "COUNT(rid) AS unreadcount", "reportstatus='0'");
+        $num = $this->db->fetch_array($query);
+
+        $query = $this->db->simple_select("reportedcontent", "COUNT(rid) AS reportcount");
+        $total = $this->db->fetch_array($query);
+
+        $query = $this->db->simple_select("reportedcontent", "dateline", "reportstatus='0'",
+            array('order_by' => 'dateline', 'order_dir' => 'DESC'));
+        $latest = $this->db->fetch_array($query);
+
+        $reports = array(
+            "unread" => $num['unreadcount'],
+            "total" => $total['reportcount'],
+            "lastdateline" => $latest['dateline'],
+        );
+
+        $this->update("reportedcontent", $reports);
+    }
+
+    /**
+     * Update mycode cache.
+     *
+     */
+    public function update_mycode()
+    {
+        $mycodes = array();
+        $query = $this->db->simple_select("mycode", "regex, replacement", "active=1",
+            array('order_by' => 'parseorder'));
+        while ($mycode = $this->db->fetch_array($query)) {
+            $mycodes[] = $mycode;
+        }
+
+        $this->update("mycode", $mycodes);
+    }
+
+    /**
+     * Update the mailqueue cache
+     *
+     * @param int $last_run
+     * @param int $lock_time
+     */
+    public function update_mailqueue($last_run = 0, $lock_time = 0)
+    {
+        $query = $this->db->simple_select("mailqueue", "COUNT(*) AS queue_size");
+        $queue_size = $this->db->fetch_field($query, "queue_size");
+
+        $mailqueue = $this->read("mailqueue");
+        if (!is_array($mailqueue)) {
+            $mailqueue = array();
+        }
+        $mailqueue['queue_size'] = $queue_size;
+        if ($last_run > 0) {
+            $mailqueue['last_run'] = $last_run;
+        }
+        $mailqueue['locked'] = $lock_time;
+
+        $this->update("mailqueue", $mailqueue);
+    }
+
+    /**
+     * Update update_check cache (dummy function used by upgrade/install scripts)
+     */
+    public function update_update_check()
+    {
+        $update_cache = array(
+            "dateline" => TIME_NOW,
+        );
+
+        $this->update("update_check", $update_cache);
+    }
+
+    /**
+     * Update default_theme cache
+     */
+    public function update_default_theme()
+    {
+        $query = $this->db->simple_select("themes", "name, tid, properties, stylesheets", "def='1'",
+            array('limit' => 1));
+        $theme = $this->db->fetch_array($query);
+        $this->update("default_theme", $theme);
+    }
+
+    /**
+     * Updates the tasks cache saving the next run time
+     */
+    public function update_tasks()
+    {
+        $query = $this->db->simple_select("tasks", "nextrun", "enabled=1",
+            array("order_by" => "nextrun", "order_dir" => "asc", "limit" => 1));
+        $next_task = $this->db->fetch_array($query);
+
+        $task_cache = $this->read("tasks");
+        if (!is_array($task_cache)) {
+            $task_cache = array();
+        }
+        $task_cache['nextrun'] = $next_task['nextrun'];
+
+        if (!$task_cache['nextrun']) {
+            $task_cache['nextrun'] = TIME_NOW + 3600;
+        }
+
+        $this->update("tasks", $task_cache);
+    }
+
+    /**
+     * Updates the banned IPs cache
+     */
+    public function update_bannedips()
+    {
+        $banned_ips = array();
+        $query = $this->db->simple_select("banfilters", "fid,filter", "type=1");
+        while ($banned_ip = $this->db->fetch_array($query)) {
+            $banned_ips[$banned_ip['fid']] = $banned_ip;
+        }
+        $this->update("bannedips", $banned_ips);
+    }
+
+    /**
+     * Updates the banned emails cache
+     */
+    public function update_bannedemails()
+    {
+        $banned_emails = array();
+        $query = $this->db->simple_select("banfilters", "fid, filter", "type = '3'");
+
+        while ($banned_email = $this->db->fetch_array($query)) {
+            $banned_emails[$banned_email['fid']] = $banned_email;
+        }
+
+        $this->update("bannedemails", $banned_emails);
+    }
+
+    /**
+     * Updates the search engine spiders cache
+     */
+    public function update_spiders()
+    {
+        $spiders = array();
+        $query = $this->db->simple_select("spiders", "sid, name, useragent, usergroup", "",
+            array("order_by" => "LENGTH(useragent)", "order_dir" => "DESC"));
+        while ($spider = $this->db->fetch_array($query)) {
+            $spiders[$spider['sid']] = $spider;
+        }
+        $this->update("spiders", $spiders);
+    }
+
+    public function update_most_replied_threads()
+    {
+        global $mybb;
+
+        $threads = array();
+
+        $query = $this->db->simple_select("threads", "tid, subject, replies, fid, uid", "visible='1'", array(
+            'order_by' => 'replies',
+            'order_dir' => 'DESC',
+            'limit_start' => 0,
+            'limit' => $mybb->settings['statslimit'],
+        ));
+        while ($thread = $this->db->fetch_array($query)) {
+            $threads[] = $thread;
+        }
+
+        $this->update("most_replied_threads", $threads);
+    }
+
+    public function update_most_viewed_threads()
+    {
+        global $mybb;
+
+        $threads = array();
+
+        $query = $this->db->simple_select("threads", "tid, subject, views, fid, uid", "visible='1'", array(
+            'order_by' => 'views',
+            'order_dir' => 'DESC',
+            'limit_start' => 0,
+            'limit' => $mybb->settings['statslimit'],
+        ));
+
+        while ($thread = $this->db->fetch_array($query)) {
+            $threads[] = $thread;
+        }
+
+        $this->update("most_viewed_threads", $threads);
+    }
+
+    public function update_banned()
+    {
+        $bans = array();
+
+        $query = $this->db->simple_select("banned");
+        while ($ban = $this->db->fetch_array($query)) {
+            $bans[$ban['uid']] = $ban;
+        }
+
+        $this->update("banned", $bans);
+    }
+
+    public function update_birthdays()
+    {
+        $birthdays = array();
+
+        // Get today, yesterday, and tomorrow's time (for different timezones)
+        $bdaytime = TIME_NOW;
+        $bdaydate = my_date("j-n", $bdaytime, '', 0);
+        $bdaydatetomorrow = my_date("j-n", ($bdaytime + 86400), '', 0);
+        $bdaydateyesterday = my_date("j-n", ($bdaytime - 86400), '', 0);
+
+        $query = $this->db->simple_select("users", "uid, username, usergroup, displaygroup, birthday, birthdayprivacy",
+            "birthday LIKE '$bdaydate-%' OR birthday LIKE '$bdaydateyesterday-%' OR birthday LIKE '$bdaydatetomorrow-%'");
+        while ($bday = $this->db->fetch_array($query)) {
+            // Pop off the year from the birthday because we don't need it.
+            $bday['bday'] = explode('-', $bday['birthday']);
+            array_pop($bday['bday']);
+            $bday['bday'] = implode('-', $bday['bday']);
+
+            if ($bday['birthdayprivacy'] != 'all') {
+                ++$birthdays[$bday['bday']]['hiddencount'];
+                continue;
+            }
+
+            // We don't need any excess caleries in the cache
+            unset($bday['birthdayprivacy']);
+
+            $birthdays[$bday['bday']]['users'][] = $bday;
+        }
+
+        $this->update("birthdays", $birthdays);
+    }
+
+    public function update_groupleaders()
+    {
+        $groupleaders = array();
+
+        $query = $this->db->simple_select("groupleaders");
+        while ($groupleader = $this->db->fetch_array($query)) {
+            $groupleaders[$groupleader['uid']][] = $groupleader;
+        }
+
+        $this->update("groupleaders", $groupleaders);
+    }
+
+    public function update_threadprefixes()
+    {
+        $prefixes = array();
+        $query = $this->db->simple_select("threadprefixes", "*", "",
+            array('order_by' => 'prefix', 'order_dir' => 'ASC'));
+
+        while ($prefix = $this->db->fetch_array($query)) {
+            $prefixes[$prefix['pid']] = $prefix;
+        }
+
+        $this->update("threadprefixes", $prefixes);
+    }
+
+    public function update_forumsdisplay()
+    {
+        $fd_statistics = array();
+
+        $time = TIME_NOW; // Look for announcements that don't end, or that are ending some time in the future
+        $query = $this->db->simple_select("announcements", "fid", "enddate = '0' OR enddate > '{$time}'",
+            array("order_by" => "aid"));
+
+        if ($this->db->num_rows($query)) {
+            while ($forum = $this->db->fetch_array($query)) {
+                if (!isset($fd_statistics[$forum['fid']]['announcements'])) {
+                    $fd_statistics[$forum['fid']]['announcements'] = 1;
+                }
+            }
+        }
+
+        // Do we have any mod tools to use in our forums?
+        $query = $this->db->simple_select("modtools", "forums, tid", '', array("order_by" => "tid"));
+
+        if ($this->db->num_rows($query)) {
+            unset($forum);
+            while ($tool = $this->db->fetch_array($query)) {
+                $forums = explode(",", $tool['forums']);
+
+                foreach ($forums as $forum) {
+                    if (!$forum) {
+                        $forum = -1;
+                    }
+
+                    if (!isset($fd_statistics[$forum]['modtools'])) {
+                        $fd_statistics[$forum]['modtools'] = 1;
+                    }
+                }
+            }
+        }
+
+        $this->update("forumsdisplay", $fd_statistics);
+    }
+
+    /**
+     * Update profile fields cache.
+     *
+     */
+    public function update_profilefields()
+    {
+        $fields = array();
+        $query = $this->db->simple_select("profilefields", "*", "", array('order_by' => 'disporder'));
+        while ($field = $this->db->fetch_array($query)) {
+            $fields[] = $field;
+        }
+
+        $this->update("profilefields", $fields);
+    }
+
+    /**
+     * Update the report reasons cache.
+     *
+     * @param bool $no_plugins Whether to disable the `report_content_types` plugin hook.
+     */
+    public function update_reportreasons(bool $no_plugins = false)
+    {
+        $content_types = array('post', 'profile', 'reputation');
+        if (!$no_plugins) {
+            global $plugins;
+            $content_types = $plugins->run_hooks("report_content_types", $content_types);
+        }
+
+        $reasons = array();
+
+        $query = $this->db->simple_select("reportreasons", "*", "", array('order_by' => 'disporder'));
+        while ($reason = $this->db->fetch_array($query)) {
+            if ($reason['appliesto'] == 'all') {
+                foreach ($content_types as $content) {
+                    $reasons[$content][] = array(
+                        'rid' => $reason['rid'],
+                        'title' => $reason['title'],
+                        'extra' => $reason['extra'],
+                    );
+                }
+            } elseif ($reason['appliesto'] != '') {
+                $appliesto = explode(",", $reason['appliesto']);
+                foreach ($appliesto as $content) {
+                    $reasons[$content][] = array(
+                        'rid' => $reason['rid'],
+                        'title' => $reason['title'],
+                        'extra' => $reason['extra'],
+                    );
+                }
+            }
+        }
+
+        $this->update("reportreasons", $reasons);
+    }
+
+    /* Other, extra functions for reloading caches if we just changed to another cache extension (i.e. from db -> xcache) */
+    public function reload_mostonline()
+    {
+        $query = $this->db->simple_select("datacache", "title,cache", "title='mostonline'");
+        $this->update("mostonline", my_unserialize($this->db->fetch_field($query, "cache")));
+    }
+
+    public function reload_plugins()
+    {
+        $query = $this->db->simple_select("datacache", "title,cache", "title='plugins'");
+        $this->update("plugins", my_unserialize($this->db->fetch_field($query, "cache")));
+    }
+
+    public function reload_last_backup()
+    {
+        $query = $this->db->simple_select("datacache", "title,cache", "title='last_backup'");
+        $this->update("last_backup", my_unserialize($this->db->fetch_field($query, "cache")));
+    }
+
+    public function reload_internal_settings()
+    {
+        $query = $this->db->simple_select("datacache", "title,cache", "title='internal_settings'");
+        $this->update("internal_settings", my_unserialize($this->db->fetch_field($query, "cache")));
+    }
+
+    public function reload_version_history()
+    {
+        $query = $this->db->simple_select("datacache", "title,cache", "title='version_history'");
+        $this->update("version_history", my_unserialize($this->db->fetch_field($query, "cache")));
+    }
+
+    public function reload_modnotes()
+    {
+        $query = $this->db->simple_select("datacache", "title,cache", "title='modnotes'");
+        $this->update("modnotes", my_unserialize($this->db->fetch_field($query, "cache")));
+    }
+
+    public function reload_adminnotes()
+    {
+        $query = $this->db->simple_select("datacache", "title,cache", "title='adminnotes'");
+        $this->update("adminnotes", my_unserialize($this->db->fetch_field($query, "cache")));
+    }
+
+    public function reload_mybb_credits()
+    {
+        admin_redirect('index.php?module=home-credits&amp;fetch_new=-2');
+    }
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -205,7 +205,7 @@ function run_shutdown()
 	if(!is_object($cache))
 	{
 		require_once MYBB_ROOT."inc/class_datacache.php";
-        $cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
+		$cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
 	}
 
 	// And finally.. plugins

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -205,8 +205,7 @@ function run_shutdown()
 	if(!is_object($cache))
 	{
 		require_once MYBB_ROOT."inc/class_datacache.php";
-		$cache = new datacache;
-		$cache->cache();
+        $cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
 	}
 
 	// And finally.. plugins

--- a/inc/init.php
+++ b/inc/init.php
@@ -134,7 +134,7 @@ require_once MYBB_ROOT."inc/class_templates.php";
 $templates = new templates;
 
 require_once MYBB_ROOT."inc/class_datacache.php";
-$cache = new datacache;
+$cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
 
 require_once MYBB_ROOT."inc/class_plugins.php";
 $plugins = new pluginSystem;
@@ -153,8 +153,6 @@ require_once MYBB_ROOT."inc/class_language.php";
 $lang = new MyLanguage;
 $lang->set_path(MYBB_ROOT."inc/languages");
 
-// Load cache
-$cache->cache();
 
 // Load Settings
 if(file_exists(MYBB_ROOT."inc/settings.php"))

--- a/inc/src/Cache/RepositoryFactory.php
+++ b/inc/src/Cache/RepositoryFactory.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace MyBB\Cache;
+
+use Illuminate\Cache\ApcStore;
+use Illuminate\Cache\ApcWrapper;
+use Illuminate\Cache\FileStore;
+use Illuminate\Cache\MemcachedStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Filesystem\Filesystem;
+
+class RepositoryFactory
+{
+    /**
+     * Build a cache repository instance based upon configuration.
+     *
+     * @param \MyBB $mybb The MyBB core instance.
+     * @param \errorHandler|null $errorHandler Error handler instance to handle fatal errors.
+     *
+     * @return \Illuminate\Contracts\Cache\Repository|null The created repository instance, or null if no cache is configured.
+     */
+    public static function getRepository(\MyBB $mybb, \errorHandler $errorHandler = null)
+    {
+        switch ($mybb->config['cache_store']) {
+            case 'apc':
+                $store = new ApcStore(new ApcWrapper());
+                break;
+            case 'files':
+                $store = new FileStore(new Filesystem(), MYBB_ROOT . 'cache');
+                break;
+            case 'memcached':
+                $store = static::getMemcachedStore($mybb, $errorHandler);
+                break;
+            default:
+                return null;
+        }
+
+        return new Repository($store);
+    }
+
+    /**
+     * Create a new store using memcached as the backend.
+     *
+     * @param \MyBB $mybb The MyBB core instance.
+     * @param \errorHandler|null $errorHandler Error handler instance to handle fatal errors.
+     *
+     * @return MemcachedStore The created memcached store.
+     */
+    private static function getMemcachedStore(\MyBB $mybb, \errorHandler $errorHandler = null)
+    {
+        $memcached = new \Memcached();
+
+        if($mybb->config['memcache']['host'])
+        {
+            $mybb->config['memcache'][0] = $mybb->config['memcache'];
+            unset($mybb->config['memcache']['host']);
+            unset($mybb->config['memcache']['port']);
+        }
+
+        foreach($mybb->config['memcache'] as $serverSettings)
+        {
+            if(!$serverSettings['host'])
+            {
+                $message = "Please configure the memcache settings in inc/config.php before attempting to use this cache handler";
+
+                if (!is_null($errorHandler)) {
+                    $errorHandler->trigger($message, MYBB_CACHEHANDLER_LOAD_ERROR);
+                    die;
+                } else {
+                    die($message);
+                }
+            }
+
+            if(!isset($serverSettings['port']))
+            {
+                $serverSettings['port'] = "11211";
+            }
+
+            $memcached->addServer($serverSettings['host'], $serverSettings['port']);
+        }
+
+        return new MemcachedStore($memcached);
+    }
+}

--- a/inc/src/Cache/RepositoryFactory.php
+++ b/inc/src/Cache/RepositoryFactory.php
@@ -17,7 +17,8 @@ class RepositoryFactory
      * @param \MyBB $mybb The MyBB core instance.
      * @param \errorHandler|null $errorHandler Error handler instance to handle fatal errors.
      *
-     * @return \Illuminate\Contracts\Cache\Repository|null The created repository instance, or null if no cache is configured.
+     * @return \Illuminate\Contracts\Cache\Repository|null The created repository instance, or null if no cache is
+     *     configured.
      */
     public static function getRepository(\MyBB $mybb, \errorHandler $errorHandler = null)
     {
@@ -50,17 +51,14 @@ class RepositoryFactory
     {
         $memcached = new \Memcached();
 
-        if($mybb->config['memcache']['host'])
-        {
+        if ($mybb->config['memcache']['host']) {
             $mybb->config['memcache'][0] = $mybb->config['memcache'];
             unset($mybb->config['memcache']['host']);
             unset($mybb->config['memcache']['port']);
         }
 
-        foreach($mybb->config['memcache'] as $serverSettings)
-        {
-            if(!$serverSettings['host'])
-            {
+        foreach ($mybb->config['memcache'] as $serverSettings) {
+            if (!$serverSettings['host']) {
                 $message = "Please configure the memcache settings in inc/config.php before attempting to use this cache handler";
 
                 if (!is_null($errorHandler)) {
@@ -71,8 +69,7 @@ class RepositoryFactory
                 }
             }
 
-            if(!isset($serverSettings['port']))
-            {
+            if (!isset($serverSettings['port'])) {
                 $serverSettings['port'] = "11211";
             }
 

--- a/inc/src/bootstrap.php
+++ b/inc/src/bootstrap.php
@@ -48,3 +48,4 @@ $container->bind(Request::class, function(ContainerInterface $container) {
 });
 
 $container->alias(Request::class, 'request');
+

--- a/install/index.php
+++ b/install/index.php
@@ -1720,9 +1720,9 @@ function insert_templates()
 	$db = db_connection($config);
 
 	require_once MYBB_ROOT.'inc/class_datacache.php';
-    $cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
+	$cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
 
-    $output->print_header($lang->theme_installation, 'theme');
+	$output->print_header($lang->theme_installation, 'theme');
 
 	echo $lang->theme_step_importing;
 
@@ -2383,8 +2383,8 @@ function install_done()
 
 	echo $lang->done_step_cachebuilding;
 	require_once MYBB_ROOT.'inc/class_datacache.php';
-    $cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, null));
-    $cache->update_version();
+	$cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, null));
+	$cache->update_version();
 	$cache->update_attachtypes();
 	$cache->update_smilies();
 	$cache->update_badwords();

--- a/install/index.php
+++ b/install/index.php
@@ -1720,9 +1720,9 @@ function insert_templates()
 	$db = db_connection($config);
 
 	require_once MYBB_ROOT.'inc/class_datacache.php';
-	$cache = new datacache;
+    $cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
 
-	$output->print_header($lang->theme_installation, 'theme');
+    $output->print_header($lang->theme_installation, 'theme');
 
 	echo $lang->theme_step_importing;
 
@@ -2383,8 +2383,8 @@ function install_done()
 
 	echo $lang->done_step_cachebuilding;
 	require_once MYBB_ROOT.'inc/class_datacache.php';
-	$cache = new datacache;
-	$cache->update_version();
+    $cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, null));
+    $cache->update_version();
 	$cache->update_attachtypes();
 	$cache->update_smilies();
 	$cache->update_badwords();

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -131,7 +131,6 @@ $mybb->parse_cookies();
 require_once MYBB_ROOT."inc/class_datacache.php";
 $cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
 
-
 $mybb->cache = &$cache;
 
 require_once MYBB_ROOT."inc/class_session.php";

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -129,10 +129,8 @@ $mybb->settings = &$settings;
 $mybb->parse_cookies();
 
 require_once MYBB_ROOT."inc/class_datacache.php";
-$cache = new datacache;
+$cache = new datacache($db, $mybb->debug_mode, \MyBB\Cache\RepositoryFactory::getRepository($mybb, $error_handler));
 
-// Load cache
-$cache->cache();
 
 $mybb->cache = &$cache;
 


### PR DESCRIPTION
This is a work in progress effort to integrate the `illuminate/cache` component to provide various different cache stores for MyBB. This should make it easier to add support for other cache stores in the future, such as Redis. At the minute, the only stores implemented are:

- APC
- Files
- Memcached
- DB

However, the following cache handlers have been removed:

- eaccelerator - last release of the project was in 2010, seems like it may be abandoned?
- xcache - last release of the project was in 2014, no support for PHP 7.0 as of yet, nor 7.1/7.2. May be abandoned?

I haven't done any testing of this, but wanted to submit the PR now to make sure people agree with the approach.