### PR TITLE
modcp.php: use `l.fid <> 0` instead of `!l.fid`

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -4725,7 +4725,7 @@ if(!$mybb->input['action'])
 		$where = '';
 		if($tflist_modlog)
 		{
-			$where = "WHERE (t.fid <> 0 {$tflist_modlog}) OR (!l.fid)";
+			$where = "WHERE (t.fid <> 0 {$tflist_modlog}) OR (l.fid <> 0)";
 		}
 
 		$query = $db->query("


### PR DESCRIPTION
PostgreSQL doesn't use the `!` operator