### PR TITLE
Fix mycode_auto_url to detect links when adjacent to square bracket

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1512,8 +1512,8 @@ class postParser
 	{
 		$message = " ".$message;
 		// Links should end with slashes, numbers, characters and braces but not with dots, commas or question marks
-		$message = preg_replace_callback("#([\>\s\(\)])(http|https|ftp|news|irc|ircs|irc6){1}://([^\/\"\s\<\[\.]+\.([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/([^\"\s<\[]|\[\])*)?([\w\/\)]))#iu", array($this, 'mycode_auto_url_callback'), $message);
-		$message = preg_replace_callback("#([\>\s\(\)])(www|ftp)\.(([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/([^\"\s<\[]|\[\])*)?([\w\/\)]))#iu", array($this, 'mycode_auto_url_callback'), $message);
+		$message = preg_replace_callback("#([\>\s\(\)\[]|(?:\[(?!url)(?:.*?)\]))(http|https|ftp|news|irc|ircs|irc6){1}://([^\/\"\s\<\[\.]+\.([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/([^\"\s<\[]|\[\])*)?([\w\/\)]))#iu", array($this, 'mycode_auto_url_callback'), $message);
+		$message = preg_replace_callback("#([\>\s\(\)\[]|(?:\[(?!url)(?:.*?)\]))(www|ftp)\.(([^\/\"\s\<\[\.]+\.)*[\w]+(:[0-9]+)?(/([^\"\s<\[]|\[\])*)?([\w\/\)]))#iu", array($this, 'mycode_auto_url_callback'), $message);
 		$message = my_substr($message, 1);
 
 		return $message;


### PR DESCRIPTION
Before this change all of these URLs would not be parsed:
```
[list]
[*]https://mybb.com
[/list]

[b]https://mybb.com[/b]

MyBB [https://mybb.com]
```

The following function as they did before this change:
```
[url=https://mybb.com]MyBB[/url]

[url=https://mybb.com/about/]https://mybb.com[/url]

[url]https://mybb.com[/url]
```

My only concern is the efficiency of the new regex. Would it be better to only do this change?
```diff
-[\>\s\(\)]
+[\>\s\(\)\[]|(?:\[\*\])
```
Even though this would result in the `[b]https://mybb.com[/b]` continue to not be detected?