### PR TITLE
Fixes #2993 - banning without ban reason results in blank page

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -4267,6 +4267,8 @@ if($mybb->input['action'] == "do_banuser" && $mybb->request_method == "post")
 		}
 	}
 
+	$errors = array();
+
 	// Creating a new ban
 	if(!$existing_ban)
 	{


### PR DESCRIPTION
When you accidentally forget to enter a ban reason when banning a user, you'll end up in a blank modcp.php page.

The issue is caused by $errors not properly being defined as an array.

 This PR fixes issue #2993 