### PR TITLE
[FIX] string to array conversation causing Illegal string offset warning on PHP 7.2

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -2232,7 +2232,8 @@ if(!$mybb->input['action'])
     $in_month = 0;
 
     // Iterate weeks (each week gets a row)
-	$week = $day_bit = '';
+    $week = [];
+	$day_bit = [];
     for ($row = 0; $row < 6; ++$row) {
         $days = [];
         foreach ($weekdays as $weekday_id => $weekday) {

--- a/calendar.php
+++ b/calendar.php
@@ -2233,7 +2233,7 @@ if(!$mybb->input['action'])
 
     // Iterate weeks (each week gets a row)
     $week = [];
-	$day_bit = [];
+    $day_bit = [];
     for ($row = 0; $row < 6; ++$row) {
         $days = [];
         foreach ($weekdays as $weekday_id => $weekday) {


### PR DESCRIPTION
Fix for calendar.php Illegal string offset warning on PHP 7.2