### PR TITLE
Consider both primary and secondary groups for Moderator CP

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -58,7 +58,14 @@ $flist_queue_attach = $wflist_reports = $tflist_reports = $flist_reports = $tfli
 $moderated_forums = array();
 if($mybb->usergroup['issupermod'] != 1)
 {
-	$query = $db->simple_select("moderators", "*", "(id='{$mybb->user['uid']}' AND isgroup = '0') OR (id='{$mybb->user['usergroup']}' AND isgroup = '1')");
+	$in = explode(',', $mybb->user['additionalgroups']);
+	$in = array_map('intval', $in);
+	$in[] = (int) $mybb->user['usergroup'];
+	$in = array_unique($in);
+
+	$in_query = implode(',', $in);
+
+	$query = $db->simple_select("moderators", "*", "(id='{$mybb->user['uid']}' AND isgroup = '0') OR (id IN ({$in_query}) AND isgroup = '1')");
 
 	$numannouncements = $nummodqueuethreads = $nummodqueueposts = $nummodqueueattach = $numreportedposts = $nummodlogs = 0;
 	while($forum = $db->fetch_array($query))

--- a/modcp.php
+++ b/modcp.php
@@ -58,14 +58,7 @@ $flist_queue_attach = $wflist_reports = $tflist_reports = $flist_reports = $tfli
 $moderated_forums = array();
 if($mybb->usergroup['issupermod'] != 1)
 {
-	$in = explode(',', $mybb->user['additionalgroups']);
-	$in = array_map('intval', $in);
-	$in[] = (int)$mybb->user['usergroup'];
-	$in = array_unique($in);
-
-	$in_query = implode(',', $in);
-
-	$query = $db->simple_select("moderators", "*", "(id='{$mybb->user['uid']}' AND isgroup = '0') OR (id IN ({$in_query}) AND isgroup = '1')");
+	$query = $db->simple_select("moderators", "*", "(id='{$mybb->user['uid']}' AND isgroup = '0') OR (id IN ({$mybb->usergroup['all_usergroups']}) AND isgroup = '1')");
 
 	$numannouncements = $nummodqueuethreads = $nummodqueueposts = $nummodqueueattach = $numreportedposts = $nummodlogs = 0;
 	while($forum = $db->fetch_array($query))

--- a/modcp.php
+++ b/modcp.php
@@ -60,7 +60,7 @@ if($mybb->usergroup['issupermod'] != 1)
 {
 	$in = explode(',', $mybb->user['additionalgroups']);
 	$in = array_map('intval', $in);
-	$in[] = (int) $mybb->user['usergroup'];
+	$in[] = (int)$mybb->user['usergroup'];
 	$in = array_unique($in);
 
 	$in_query = implode(',', $in);


### PR DESCRIPTION
Fixes #2990 

The code in the current `feature` branch runs a query globally in the Mod CP if a user isn't a super moderator to see if they have any moderator access at all and sets up various variables (such as `$numreportedposts` which was causing the problem in #2990 itself). However, it only considers the user's UID and their primary usergroup (`$mybb->user['usergroup']`) and ignores any additional groups that may be configured when running this query.

I'm not sure if it was like that for a reason, so hopefully this patch doesn't break anything else - it really needs testing with some different permission setups to make sure it doesn't cause problems.