### PR TITLE
Fix #3006 - custom moderation tool SQL error on postgresql

### DIFF
--- a/inc/class_custommoderation.php
+++ b/inc/class_custommoderation.php
@@ -32,7 +32,7 @@ class CustomModeration extends Moderation
 		global $db;
 
 		// Get tool info
-		$query = $db->simple_select("modtools", "*", 'tid="'.(int)$tool_id.'"');
+		$query = $db->simple_select("modtools", "*", 'tid='.(int)$tool_id);
 		$tool = $db->fetch_array($query);
 		if(!$tool['tid'])
 		{
@@ -57,7 +57,7 @@ class CustomModeration extends Moderation
 		global $db;
 
 		// Get tool info
-		$query = $db->simple_select("modtools", '*', 'tid="'.(int)$tool_id.'"');
+		$query = $db->simple_select("modtools", '*', 'tid='.(int)$tool_id);
 		$tool = $db->fetch_array($query);
 		if(!$tool['tid'])
 		{


### PR DESCRIPTION
Fixes #3006 by removing `"` around moderation tool ID in query. Should still work on both postgres and mysql.