### PR TITLE
Remove my_strip_tags from affecting help documents

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8743,26 +8743,6 @@ function my_validate_url($url, $relative_path=false, $allow_local=false)
 }
 
 /**
- * Strip html tags from string, also removes <script> and <style> contents.
- *
- * @param  string $string         String to stripe
- * @param  string $allowable_tags Allowed html tags
- *
- * @return string                 Striped string
- */
-function my_strip_tags($string, $allowable_tags = '')
-{
-	$pattern = array(
-		'@(&lt;)style[^(&gt;)]*?(&gt;).*?(&lt;)/style(&gt;)@siu',
-		'@(&lt;)script[^(&gt;)]*?.*?(&lt;)/script(&gt;)@siu',
-		'@<style[^>]*?>.*?</style>@siu',
-		'@<script[^>]*?.*?</script>@siu',
-	);
-	$string = preg_replace($pattern, '', $string);
-	return strip_tags($string, $allowable_tags);
-}
-
-/**
  * Escapes a RFC 4180-compliant CSV string.
  * Based on https://github.com/Automattic/camptix/blob/f80725094440bf09861383b8f11e96c177c45789/camptix.php#L2867
  *

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8743,6 +8743,26 @@ function my_validate_url($url, $relative_path=false, $allow_local=false)
 }
 
 /**
+ * Strip html tags from string, also removes <script> and <style> contents.
+ *
+ * @param  string $string         String to stripe
+ * @param  string $allowable_tags Allowed html tags
+ *
+ * @return string                 Striped string
+ */
+function my_strip_tags($string, $allowable_tags = '')
+{
+	$pattern = array(
+		'@(&lt;)style[^(&gt;)]*?(&gt;).*?(&lt;)/style(&gt;)@siu',
+		'@(&lt;)script[^(&gt;)]*?.*?(&lt;)/script(&gt;)@siu',
+		'@<style[^>]*?>.*?</style>@siu',
+		'@<script[^>]*?.*?</script>@siu',
+	);
+	$string = preg_replace($pattern, '', $string);
+	return strip_tags($string, $allowable_tags);
+}
+
+/**
  * Escapes a RFC 4180-compliant CSV string.
  * Based on https://github.com/Automattic/camptix/blob/f80725094440bf09861383b8f11e96c177c45789/camptix.php#L2867
  *

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8745,6 +8745,7 @@ function my_validate_url($url, $relative_path=false, $allow_local=false)
 /**
  * Strip html tags from string, also removes <script> and <style> contents.
  *
+ * @deprecated
  * @param  string $string         String to stripe
  * @param  string $allowable_tags Allowed html tags
  *

--- a/misc.php
+++ b/misc.php
@@ -333,7 +333,7 @@ elseif($mybb->input['action'] == "helpresults")
 			'allow_imgcode' => 0,
 			'filter_badwords' => 1
 		);
-		$helpdoc['helpdoc'] = my_strip_tags($parser->parse_message($helpdoc['document'], $parser_options));
+		$helpdoc['helpdoc'] = $parser->parse_message($helpdoc['document'], $parser_options);
 
 		if(my_strlen($helpdoc['helpdoc']) > 350)
 		{


### PR DESCRIPTION
As Euan and I previously discussed in private inquiries, help documents should allow Javascript code to execute. This pull request removes my_strip_tags in-order to allow them.