### PR TITLE
fix contributor link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Visit the [MyBB Community Forums](https://community.mybb.com) or [Documentation]
 ### Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="graphs/contributors"><img src="https://opencollective.com/mybb/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/mybb/mybb/graphs/contributors"><img src="https://opencollective.com/mybb/contributors.svg?width=890&button=false" /></a>
 
 
 ### Backers


### PR DESCRIPTION
Fix the contributor link by using a static link.

Github prepends a link to relative urls (`https://github.com/mybb/mybb/blob/feature/`), the resulting final url 404s.