### PR TITLE
Fixes #2108 Skipping CSS Inclusion

### DIFF
--- a/global.php
+++ b/global.php
@@ -318,7 +318,9 @@ foreach($stylesheet_scripts as $stylesheet_script)
 			// Actually add the stylesheets to the list
 			foreach($theme['stylesheets'][$stylesheet_script][$stylesheet_action] as $page_stylesheet)
 			{
-				if(!empty($already_loaded[$page_stylesheet]))
+				$code = file_get_contents('./'.$page_stylesheet, FILE_USE_INCLUDE_PATH);
+				
+				if(trim($code) === "" || !empty($already_loaded[$page_stylesheet]))
 				{
 					continue;
 				}

--- a/global.php
+++ b/global.php
@@ -318,12 +318,15 @@ foreach($stylesheet_scripts as $stylesheet_script)
 			// Actually add the stylesheets to the list
 			foreach($theme['stylesheets'][$stylesheet_script][$stylesheet_action] as $page_stylesheet)
 			{
-				// Get the activation state of the file
-				$active = ($theme['styleactive'][basename($page_stylesheet)]);
-				// Load the content to check whether empty
-				$code = file_get_contents('./'.$page_stylesheet, FILE_USE_INCLUDE_PATH);
+				$code = "";
 				
-				if(!$active || trim($code) === "" || !empty($already_loaded[$page_stylesheet]))
+				// If the stylesheet is active and not already loaded then get the content to check whether its empty
+				if($theme['styleactive'][basename($page_stylesheet)] && empty($already_loaded[$page_stylesheet]))
+				{
+					$code = file_get_contents('./'.$page_stylesheet, FILE_USE_INCLUDE_PATH);
+				}
+
+				if(trim($code) === "")
 				{
 					continue;
 				}

--- a/global.php
+++ b/global.php
@@ -318,9 +318,12 @@ foreach($stylesheet_scripts as $stylesheet_script)
 			// Actually add the stylesheets to the list
 			foreach($theme['stylesheets'][$stylesheet_script][$stylesheet_action] as $page_stylesheet)
 			{
+				// Get the activation state of the file
+				$active = ($theme['styleactive'][basename($page_stylesheet)]);
+				// Load the content to check whether empty
 				$code = file_get_contents('./'.$page_stylesheet, FILE_USE_INCLUDE_PATH);
 				
-				if(trim($code) === "" || !empty($already_loaded[$page_stylesheet]))
+				if(!$active || trim($code) === "" || !empty($already_loaded[$page_stylesheet]))
 				{
 					continue;
 				}

--- a/global.php
+++ b/global.php
@@ -320,8 +320,11 @@ foreach($stylesheet_scripts as $stylesheet_script)
 			{
 				$code = "";
 				
+				// Fallback for stylesheets with unsaved states : default to show
+				$state = isset($theme['styleactive'][basename($page_stylesheet)]) ? $theme['styleactive'][basename($page_stylesheet)] : 1;
+				
 				// If the stylesheet is active and not already loaded then get the content to check whether its empty
-				if($theme['styleactive'][basename($page_stylesheet)] && empty($already_loaded[$page_stylesheet]))
+				if($state && empty($already_loaded[$page_stylesheet]))
 				{
 					$code = file_get_contents('./'.$page_stylesheet, FILE_USE_INCLUDE_PATH);
 				}

--- a/inc/languages/english/admin/style_themes.lang.php
+++ b/inc/languages/english/admin/style_themes.lang.php
@@ -87,6 +87,7 @@ $l['duplicate_templates_desc'] = "If this theme contains custom templates should
 $l['create_a_theme'] = "Create a Theme";
 $l['name'] = "Name";
 $l['name_desc'] = "Specify a name for the new theme.";
+$l['style_active'] = "Active";
 $l['display_order'] = "Order";
 
 $l['edit_theme_properties'] = "Edit Theme Properties";
@@ -107,7 +108,6 @@ $l['table_spacing_desc'] = "The width of the inner padding of table cells, in pi
 $l['inner_border'] = "Inner Table Border Width";
 $l['inner_border_desc'] = "The amount of padding between each table cell, in pixels. This is HTML's <em>cellspacing</em> attribute of the <em>table</em> tag.";
 $l['save_theme_properties'] = "Save Theme Properties";
-$l['save_stylesheet_order'] = "Save Stylesheet Orders";
 
 $l['background'] = "Background";
 $l['extra_css_atribs'] = "Extra CSS Attributes";
@@ -207,7 +207,7 @@ $l['success_theme_set_default'] = "The selected theme is now the forum default."
 $l['success_theme_forced'] = "All users have been forced to use the selected theme successfully.";
 $l['success_theme_properties_updated'] = "The properties for the select theme have been updated successfully.";
 $l['success_stylesheet_added'] = "The stylesheet for this theme has been created successfully.";
-$l['success_stylesheet_order_updated'] = "The display orders for the stylesheets have been updated successfully.";
+$l['success_stylesheet_actorder_updated'] = "The active states and display orders for the stylesheets have been updated successfully.";
 
 $l['confirm_theme_deletion'] = "Are you sure you want to delete this theme?";
 $l['confirm_stylesheet_deletion'] = "Are you sure you want to delete / revert this stylesheet?";


### PR DESCRIPTION
https://github.com/mybb/mybb/issues/2108

Global Modification:
- [x] Not allowing empty stylesheets to be loaded while loading. (Need decision about implementation)
- [x] Not including stylesheets that are opted to be inactive.

AdminCP Modifications:
- [x] Modify frontend to include activation radio switch groups. (May be replace with check boxes?)
- [x] Modify order update function to combine order and active state. (existing form reuse)
- [x] Add checks while rendering 'style-themes' module and set radio values as per database.
Disable switch with value set to 'No' while stylesheet is empty. (Possible???)
Modify edit stylesheet function to check whether stylesheet is empty and set inactive.