### PR TITLE
Fixes #3113 – Added default language to set_language()

### DIFF
--- a/inc/class_language.php
+++ b/inc/class_language.php
@@ -74,16 +74,16 @@ class MyLanguage
 	 * @param string $language The language to use.
 	 * @param string $area The area to set the language for.
 	 */
-	function set_language($language="english", $area="user")
+	function set_language($language="", $area="user")
 	{
 		global $mybb;
 
 		$language = preg_replace("#[^a-z0-9\-_]#i", "", $language);
 
-		// Default language is English.
+		// Use the board's default language
 		if($language == "")
 		{
-			$language = "english";
+			$language = $mybb->settings['bblanguage'];
 		}
 
 		// Check if the language exists.


### PR DESCRIPTION
This PR fixes #3113 by allowing `set_language` to use the board's default `bblanguage`.