### PR TITLE
Fixes #2844 #2801 ACP Set '0 to disable' issue

### DIFF
--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -336,7 +336,7 @@ function upload_avatar($avatar=array(), $uid=0)
 	}
 
 	// Next check the file size
-	if(($avatar['size'] > ($mybb->settings['avatarsize']*1024) && $mybb->settings['avatarsize'] > 0) || $avatar['size'] > $allowed_mime_types[$avatar['type']] && !($mybb->settings['avatarsize'] > 0))
+	if(($mybb->settings['avatarsize'] > 0 && $avatar['size'] > ($mybb->settings['avatarsize']*1024)) && $avatar['size'] > ($allowed_mime_types[$avatar['type']]*1024))
 	{
 		delete_uploaded_file($avatarpath."/".$filename);
 		$ret['error'] = $lang->error_uploadsize;

--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -336,7 +336,7 @@ function upload_avatar($avatar=array(), $uid=0)
 	}
 
 	// Next check the file size
-	if(($mybb->settings['avatarsize'] > 0 && $avatar['size'] > ($mybb->settings['avatarsize']*1024)) && $avatar['size'] > ($allowed_mime_types[$avatar['type']]*1024))
+	if(($mybb->settings['avatarsize'] > 0 && $avatar['size'] > ($mybb->settings['avatarsize']*1024)) || $avatar['size'] > ($allowed_mime_types[$avatar['type']]*1024))
 	{
 		delete_uploaded_file($avatarpath."/".$filename);
 		$ret['error'] = $lang->error_uploadsize;

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -225,7 +225,7 @@ email=Sent via Email and shown in the Mod CP]]></optionscode>
 			<description><![CDATA[Here you can set the number of next and previous page links to show in the pagination for threads or forums with more than one page of results. Set to 0 to disable the limitation.]]></description>
 			<disporder>10</disporder>
 			<optionscode><![CDATA[numeric
-min=1]]></optionscode>
+min=0]]></optionscode>
 			<settingvalue><![CDATA[5]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
@@ -1158,7 +1158,7 @@ x=X]]></optionscode>
 			<description><![CDATA[Maximum file size (in kilobytes) of uploaded avatars. Set to 0 to disable the limitation.]]></description>
 			<disporder>14</disporder>
 			<optionscode><![CDATA[numeric
-min=1]]></optionscode>
+min=0]]></optionscode>
 			<settingvalue><![CDATA[25]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
@@ -1375,7 +1375,7 @@ min=0]]></optionscode>
 			<description><![CDATA[The maximum number of options for polls that users can post. Set to 0 to disable the limitation.]]></description>
 			<disporder>18</disporder>
 			<optionscode><![CDATA[numeric
-min=2]]></optionscode>
+min=0]]></optionscode>
 			<settingvalue><![CDATA[10]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
@@ -1435,7 +1435,7 @@ min=0]]></optionscode>
 			<description><![CDATA[The maximum number of attachments a user is allowed to upload per post. Set to 0 to disable.]]></description>
 			<disporder>2</disporder>
 			<optionscode><![CDATA[numeric
-min=1]]></optionscode>
+min=0]]></optionscode>
 			<settingvalue><![CDATA[5]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
@@ -2151,7 +2151,7 @@ min=0]]></optionscode>
 			<description><![CDATA[If the person trying to login reaches the max number of attempts, how long should they have to wait before being able to login again (in minutes)? Set to 0 to disable.]]></description>
 			<disporder>4</disporder>
 			<optionscode><![CDATA[numeric
-min=1]]></optionscode>
+min=0]]></optionscode>
 			<settingvalue><![CDATA[15]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>

--- a/install/resources/upgrade43.php
+++ b/install/resources/upgrade43.php
@@ -28,6 +28,7 @@ function upgrade43_dbchanges()
 	echo "<p>Performing necessary upgrade queries...</p>";
 	flush();
 
+	$db->update_query('settings', array('optionscode' => 'numeric\r\nmin=0'), "name IN ('avatarsize', 'loginattemptstimeout', 'maxattachments', 'maxmultipagelinks', 'maxpolloptions')");
 	$db->update_query('settings', array('optionscode' => 'select\r\n0=No CAPTCHA\r\n1=MyBB Default CAPTCHA\r\n4=NoCAPTCHA reCAPTCHA\r\n5=reCAPTCHA invisible'), "name='captchaimage'");
 
 	if($mybb->settings['captchaimage'] == 2)


### PR DESCRIPTION
This fixes:
#2844 Impossible To Allow Unlimited Maximum Avatar Upload Size
#2801 I can't set to 0 to disable some feature in AdminCP

Fixed fields:
- Max Uploaded Avatar Size
- Login Attempts Timeout
- Maximum Attachments Per Post
- Maximum Page Links in Pagination
- Maximum Number of Poll Options

Old reference PR:
#1915 Numeric fields - default values