### PR TITLE
Fixes #2137 Stylesheet order reset after importing a theme

### DIFF
--- a/admin/inc/functions_themes.php
+++ b/admin/inc/functions_themes.php
@@ -330,23 +330,6 @@ function import_theme_xml($xml, $options=array())
 			"stylesheets" => $db->escape_string(my_serialize($theme_stylesheets))
 		);
 
-		if(is_array($properties['disporder']))
-		{
-			asort($properties['disporder'], SORT_NUMERIC);
-
-			// Because inherited stylesheets can mess this up
-			$loop = 1;
-			$orders = array();
-			foreach($properties['disporder'] as $filename => $order)
-			{
-				$orders[$filename] = $loop;
-				++$loop;
-			}
-
-			$properties['disporder'] = $orders;
-			$updated_theme['properties'] = $db->escape_string(my_serialize($properties));
-		}
-
 		$db->update_query("themes", $updated_theme, "tid='{$theme_id}'");
 	}
 


### PR DESCRIPTION
Attempt to fix #2137 
Preserve Stylesheet Disporder, remove unwanted process to reset disporder.