### PR TITLE
Fixes #3081 Empty Email Address can result in PHP Warning on user validation

### DIFF
--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -972,6 +972,10 @@ class UserDataHandler extends DataHandler
 		{
 			$this->verify_usertitle();
 		}
+		if($this->method == "insert" || array_key_exists('email', $user))
+		{
+			$this->verify_email();
+		}
 		if($this->method == "insert" || array_key_exists('password', $user))
 		{
 			$this->verify_password();
@@ -979,10 +983,6 @@ class UserDataHandler extends DataHandler
 		if($this->method == "insert" || array_key_exists('usergroup', $user))
 		{
 			$this->verify_usergroup();
-		}
-		if($this->method == "insert" || array_key_exists('email', $user))
-		{
-			$this->verify_email();
 		}
 		if($this->method == "insert" || array_key_exists('website', $user))
 		{


### PR DESCRIPTION
Attempt to fix #3081 
Verify email before password.