### PR TITLE
Working on #2972 Template Conversion to Twig Format (forumbit)

### DIFF
--- a/inc/views/base/forumbit/depth3.twig
+++ b/inc/views/base/forumbit/depth3.twig
@@ -1,0 +1,12 @@
+{{ comma }}
+{% set forum_viewers %}
+    {% if forum.viewers == 1 %}
+        {{ lang.viewing_one }}
+    {% else %}
+        {{ trans('viewing_multiple', forum.viewers) }}
+    {% endif %}
+{% endset %}
+{% if mybb.settings.subforumsstatusicons %}
+    <div title="{{ lightbulb.altonoff }}" class="subforumicon subforum_mini{{ lightbulb.folder }} ajax_mark_read" id="mark_read_{{ forum.fid }}"></div>
+{% endif %}
+<a href="{{ forum.url }}" title="{{ forum_viewers }}">{{ forum.name }}</a>

--- a/inc/views/base/forumbit/depth_1/cat.twig
+++ b/inc/views/base/forumbit/depth_1/cat.twig
@@ -1,0 +1,41 @@
+{% if collapsed['cat_' ~ forum.fid ~ '_c'] == 'display: show;' %}
+    {% set expcolhead = ' thead_collapsed' %}
+    {% set expdisplay = 'display: none;' %}
+{% endif %}
+<table border="0" cellspacing="{{ theme.borderwidth }}" cellpadding="{{ theme.tablespace }}" class="tborder">
+    <thead>
+        <tr>
+            <td class="thead{{ expcolhead }}" colspan="5">
+                <div class="expcolimage">
+                    {% if collapsed['cat_' ~ forum.fid ~ '_c'] == 'display: show;' %}
+                        <img src="{{ theme.imgdir }}/collapse_collapsed.png" id="cat_{{ forum.fid }}_img" class="expander" alt="[+]" title="[+]" />
+                    {% else %}
+                        <img src="{{ theme.imgdir }}/collapse.png" id="cat_{{ forum.fid }}_img" class="expander" alt="[-]" title="[-]" />
+                    {% endif %}
+                </div>
+                <div>
+                    <strong><a href="{{ forum.url }}">{{ forum.name }}</a></strong><br />
+                    <div class="smalltext">{{ forum.description }}</div>
+                </div>
+            </td>
+        </tr>
+    </thead>
+    <tbody style="{{ expdisplay }}" id="cat_{{ forum.fid }}_e">
+        <tr>
+            <td class="tcat" colspan="2">
+                <span class="smalltext"><strong>{{ lang.forumbit_forum }}</strong></span>
+            </td>
+            <td class="tcat" width="85" align="center" style="white-space: nowrap">
+                <span class="smalltext"><strong>{{ lang.forumbit_threads }}</strong></span>
+            </td>
+            <td class="tcat" width="85" align="center" style="white-space: nowrap">
+                <span class="smalltext"><strong>{{ lang.forumbit_posts }}</strong></span>
+            </td>
+            <td class="tcat" width="200" align="center">
+                <span class="smalltext"><strong>{{ lang.forumbit_lastpost }}</strong></span>
+            </td>
+        </tr>
+        {{ sub_forums|raw }}
+    </tbody>
+</table>
+<br />

--- a/inc/views/base/forumbit/depth_1/last_post.twig
+++ b/inc/views/base/forumbit/depth_1/last_post.twig
@@ -1,0 +1,1 @@
+{% extends 'forumbit/depth_2/last_post.twig' %}

--- a/inc/views/base/forumbit/depth_2/cat.twig
+++ b/inc/views/base/forumbit/depth_2/cat.twig
@@ -1,0 +1,53 @@
+{% set bgcolor = alt_trow() %}
+<tr>
+    <td class="{{ bgcolor }}" align="center" width="1">
+        <span class="forum_status forum_{{ lightbulb.folder }} ajax_mark_read" title="{{ lightbulb.altonoff }}" id="mark_read_{{ forum.fid }}"></span>
+    </td>
+    <td class="{{ bgcolor }}">
+        <strong><a href="{{ forum.url }}">{{ forum.name }}</a></strong>
+        {# Forum viewers #}
+        {% if mybb.settings.showforumviewing != 0 and forum.viewers > 0 %}
+            <span class="smalltext">
+                {% if forum.viewers == 1 %}
+                    {{ lang.viewing_one }}
+                {% else %}
+                    {{ trans('viewing_multiple', forum.viewers) }}
+                {% endif %}
+            </span>
+        {% endif %}
+        <div class="smalltext">
+            {{ forum.description }}
+            {% block moderators %}{% endblock moderators %}
+            {{ subforums|raw }}
+        </div>
+    </td>
+    <td class="{{ bgcolor }}" align="center" style="white-space: nowrap">
+        {{ forum.fthreads }}
+        {% if forum.showunapproved %}
+            {% spaceless %}
+                <span title="
+                    {% if forum.unapprovedthreads == 1 %}
+                        {{ trans('forum_unapproved_thread_count', 1) }}
+                    {% else %}
+                        {{ trans('forum_unapproved_threads_count', forum.unapprovedthreads) }} {# TODO: my_number_format #}
+                    {% endif %}">({{ forum.unapprovedthreads }})</span>
+            {% endspaceless %}
+        {% endif %}
+    </td>
+    <td class="{{ bgcolor }}" align="center" style="white-space: nowrap">
+        {{ forum.fposts }}
+        {% if forum.showunapproved %}
+            {% spaceless %}
+                <span title="
+                    {% if forum.unapprovedposts == 1 %}
+                        {{ trans('forum_unapproved_post_count', 1) }}
+                    {% else %}
+                        {{ trans('forum_unapproved_posts_count', forum.unapprovedposts) }} {# TODO: my_number_format #}
+                    {% endif %}">({{ forum.unapprovedposts }})</span>
+            {% endspaceless %}
+        {% endif %}
+    </td>
+    <td class="{{ bgcolor }}" align="right" style="white-space: nowrap">
+        {{ lastpost|raw }}
+    </td>
+</tr>

--- a/inc/views/base/forumbit/depth_2/cat.twig
+++ b/inc/views/base/forumbit/depth_2/cat.twig
@@ -23,7 +23,7 @@
     </td>
     <td class="{{ bgcolor }}" align="center" style="white-space: nowrap">
         {{ forum.fthreads }}
-        {% if forum.showunapproved %}
+        {% if forum.showunapproved and forum.unapprovedthreads > 0 %}
             {% spaceless %}
                 <span title="
                     {% if forum.unapprovedthreads == 1 %}
@@ -36,7 +36,7 @@
     </td>
     <td class="{{ bgcolor }}" align="center" style="white-space: nowrap">
         {{ forum.fposts }}
-        {% if forum.showunapproved %}
+        {% if forum.showunapproved and forum.unapprovedposts > 0 %}
             {% spaceless %}
                 <span title="
                     {% if forum.unapprovedposts == 1 %}

--- a/inc/views/base/forumbit/depth_2/forum.twig
+++ b/inc/views/base/forumbit/depth_2/forum.twig
@@ -1,0 +1,15 @@
+{% extends 'forumbit/depth_2/cat.twig' %}
+
+{% block moderators %}
+	{% if moderators %}
+        <br />{{ lang.forumbit_moderated_by }}
+        {% for moderator in moderators %}
+            {% if loop.last != true %}{{ lang.comma }} {% endif %}
+            {% if moderator.type == 'group' %}
+                {{ moderator.title }}
+            {% elseif moderator.type == 'user' %}
+                <a href="{{ moderator.profilelink }}">{{ moderator.username }}</a>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endblock moderators %}

--- a/inc/views/base/forumbit/subforums.twig
+++ b/inc/views/base/forumbit/subforums.twig
@@ -1,0 +1,2 @@
+<br />
+<strong>{{ lang.subforums }}</strong> {{ sub_forums|raw }}


### PR DESCRIPTION
For #2972. Templates converted:
- [x] forumbit_depth1_cat
- [x] forumbit_depth1_cat_subforum
- [x] forumbit_depth1_forum_lastpost
- [x] forumbit_depth2_cat
- [x] forumbit_depth2_forum
- [x] forumbit_depth2_forum_unapproved_posts
- [x] forumbit_depth2_forum_unapproved_threads
- [x] forumbit_depth2_forum_viewers
- [x] forumbit_depth3
- [x] forumbit_depth3_statusicon
- [x] forumbit_moderators
- [x] forumbit_moderators_group
- [x] forumbit_moderators_user
- [x] forumbit_subforums

This is still untested 100%, but everything should be fine. `get_forum_unapproved` has been deprecated, as the only function using it was `build_forumbits` and I handled its routines in Twig instead. To ensure backwards compatibility, I have just added a `@deprecated` mark.