### PR TITLE
Working on #2972 Template Conversion to Twig Format (miscellaneous)

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -270,7 +270,7 @@ $captcha = '';
 
 if($mybb->settings['captchaimage'] && !$mybb->user['uid'])
 {
-	$post_captcha = new captcha(true, "post_captcha");
+	$post_captcha = new captcha(true, "post");
 
 	if($post_captcha->html)
 	{

--- a/editpost.php
+++ b/editpost.php
@@ -453,7 +453,7 @@ if (!$mybb->input['action'] || $mybb->input['action'] == "editpost") {
         $posticons = get_post_icons();
     }
 
-    eval("\$loginbox = \"".$templates->get("changeuserbox")."\";");
+    $loginbox = \MyBB\template('misc/changeuserbox.twig');
 
     $editpost['showdelete'] = false;
     // Can we delete posts?

--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -260,29 +260,9 @@ class errorHandler {
 			$lang->warnings = "The following warnings occurred:";
 		}
 
-		$template_exists = false;
-
-		if(!is_object($templates) || !method_exists($templates, 'get'))
-		{
-			if(@file_exists(MYBB_ROOT."inc/class_templates.php"))
-			{
-				@require_once MYBB_ROOT."inc/class_templates.php";
-				$templates = new templates;
-				$template_exists = true;
-			}
-		}
-		else
-		{
-			$template_exists = true;
-		}
-
-		$warning = '';
-		if($template_exists == true)
-		{
-			eval("\$warning = \"".$templates->get("php_warnings")."\";");
-		}
-
-		return $warning;
+		return \MyBB\template('misc/php_warnings.twig', [
+            'warnings' => $this->warnings
+        ]);
 	}
 
 	/**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -39,7 +39,7 @@ function output_page($contents)
             $serverload = get_server_load();
 
             if (my_strpos(getenv("REQUEST_URI"), "?")) {
-                $debuglink = getenv("REQUEST_URI") . "&amp;debug=1";
+                $debuglink = getenv("REQUEST_URI") . "&debug=1";
             } else {
                 $debuglink = getenv("REQUEST_URI") . "?debug=1";
             }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -39,30 +39,29 @@ function output_page($contents)
             $serverload = get_server_load();
 
             if (my_strpos(getenv("REQUEST_URI"), "?")) {
-                $debuglink = htmlspecialchars_uni(getenv("REQUEST_URI")) . "&amp;debug=1";
+                $debuglink = getenv("REQUEST_URI") . "&amp;debug=1";
             } else {
-                $debuglink = htmlspecialchars_uni(getenv("REQUEST_URI")) . "?debug=1";
+                $debuglink = getenv("REQUEST_URI") . "?debug=1";
             }
 
             $memory_usage = get_memory_usage();
 
-            if ($memory_usage) {
-                $memory_usage = $lang->sprintf($lang->debug_memory_usage, get_friendly_size($memory_usage));
-            } else {
-                $memory_usage = '';
-            }
             // MySQLi is still MySQL, so present it that way to the user
             $database_server = $db->short_title;
 
             if ($database_server == 'MySQLi') {
                 $database_server = 'MySQL';
             }
-            $generated_in = $lang->sprintf($lang->debug_generated_in, $totaltime);
             $debug_weight = $lang->sprintf($lang->debug_weight, $percentphp, $percentsql, $database_server);
             $sql_queries = $lang->sprintf($lang->debug_sql_queries, $db->query_count);
-            $server_load = $lang->sprintf($lang->debug_server_load, $serverload);
 
-            eval("\$debugstuff = \"".$templates->get("debug_summary")."\";");
+            $debugstuff = \MyBB\template('misc/debugsummary.twig', [
+                'debug_weight' => $debug_weight,
+                'sql_queries' => $sql_queries,
+                'serverload' => $serverload,
+                'totaltime' => $totaltime,
+                'memory_usage' => get_friendly_size($memory_usage)
+            ]);
             $contents = str_replace("<debugstuff>", $debugstuff, $contents);
         }
 
@@ -816,10 +815,12 @@ function redirect($url, $message="", $title="", $force_redirect=false)
     // Show redirects only if both ACP and UCP settings are enabled, or ACP is enabled, and user is a guest, or they are forced.
     if ($force_redirect == true || ($mybb->settings['redirects'] == 1 && ($mybb->user['showredirect'] == 1 || !$mybb->user['uid']))) {
         $url = str_replace("&amp;", "&", $url);
-        $url = htmlspecialchars_uni($url);
 
-        eval("\$redirectpage = \"".$templates->get("redirect")."\";");
-        output_page($redirectpage);
+        output_page(\MyBB\template('misc/redirect.twig', [
+            'url' => $url,
+            'title' => $title,
+            'message' => $message
+        ]));
     } else {
         $url = htmlspecialchars_decode($url);
         $url = str_replace(array("\n","\r",";"), "", $url);
@@ -2739,13 +2740,14 @@ function build_mycode_inserter($bind="message", $smilies = true)
 
         $editor_language .= "}})(jQuery);";
 
+        $toolbar = [];
+
         if (defined("IN_ADMINCP")) {
             global $page;
             $codeinsert = $page->build_codebuttons_editor($bind, $editor_language, $smilies);
         } else {
             // Smilies
-            $emoticon = "";
-            $emoticons_enabled = "false";
+            $emoticons = [];
             if ($smilies) {
                 if (!$smiliecache) {
                     if (!isset($smilie_cache) || !is_array($smilie_cache)) {
@@ -2758,16 +2760,14 @@ function build_mycode_inserter($bind="message", $smilies = true)
                 }
 
                 if ($mybb->settings['smilieinserter'] && $mybb->settings['smilieinsertercols'] && $mybb->settings['smilieinsertertot'] && !empty($smiliecache)) {
-                    $emoticon = ",emoticon";
+                    $toolbar['emoticon'] = ",emoticon";
                 }
-                $emoticons_enabled = "true";
 
                 unset($smilie);
 
                 if (is_array($smiliecache)) {
                     reset($smiliecache);
 
-                    $dropdownsmilies = $moresmilies = $hiddensmilies = "";
                     $i = 0;
 
                     foreach ($smiliecache as $smilie) {
@@ -2782,70 +2782,69 @@ function build_mycode_inserter($bind="message", $smilies = true)
                         $image = str_replace(array('\\', '"'), array('\\\\', '\"'), $image);
 
                         if (!$mybb->settings['smilieinserter'] || !$mybb->settings['smilieinsertercols'] || !$mybb->settings['smilieinsertertot'] || !$smilie['showclickable']) {
-                            $hiddensmilies .= '"'.$find.'": "'.$image.'",';
+                            $emoticons['hidden'] .= '"'.$find.'": "'.$image.'",';
                         } elseif ($i < $mybb->settings['smilieinsertertot']) {
-                            $dropdownsmilies .= '"'.$find.'": "'.$image.'",';
+                            $emoticons['dropdown'] .= '"'.$find.'": "'.$image.'",';
                             ++$i;
                         } else {
-                            $moresmilies .= '"'.$find.'": "'.$image.'",';
+                            $emoticons['more'] .= '"'.$find.'": "'.$image.'",';
                         }
 
                         for ($j = 1; $j < $finds_count; ++$j) {
                             $find = str_replace(array('\\', '"'), array('\\\\', '\"'), htmlspecialchars_uni($finds[$j]));
-                            $hiddensmilies .= '"'.$find.'": "'.$image.'",';
+                            $emoticons['hidden'] .= '"'.$find.'": "'.$image.'",';
                         }
                     }
                 }
             }
 
-            $basic1 = $basic2 = $align = $font = $size = $color = $removeformat = $email = $link = $list = $code = $sourcemode = "";
-
             if ($mybb->settings['allowbasicmycode'] == 1) {
-                $basic1 = "bold,italic,underline,strike|";
-                $basic2 = "horizontalrule,";
+                $toolbar['basic1'] = "bold,italic,underline,strike|";
+                $toolbar['basic2'] = "horizontalrule,";
             }
 
             if ($mybb->settings['allowalignmycode'] == 1) {
-                $align = "left,center,right,justify|";
+                $toolbar['align'] = "left,center,right,justify|";
             }
 
             if ($mybb->settings['allowfontmycode'] == 1) {
-                $font = "font,";
+                $toolbar['font'] = "font,";
             }
 
             if ($mybb->settings['allowsizemycode'] == 1) {
-                $size = "size,";
+                $toolbar['size'] = "size,";
             }
 
             if ($mybb->settings['allowcolormycode'] == 1) {
-                $color = "color,";
+                $toolbar['color'] = "color,";
             }
 
             if ($mybb->settings['allowfontmycode'] == 1 || $mybb->settings['allowsizemycode'] == 1 || $mybb->settings['allowcolormycode'] == 1) {
-                $removeformat = "removeformat|";
+                $toolbar['removeformat'] = "removeformat|";
             }
 
             if ($mybb->settings['allowemailmycode'] == 1) {
-                $email = "email,";
+                $toolbar['email'] = "email,";
             }
 
             if ($mybb->settings['allowlinkmycode'] == 1) {
-                $link = "link,unlink";
+                $toolbar['link'] = "link,unlink";
             }
 
             if ($mybb->settings['allowlistmycode'] == 1) {
-                $list = "bulletlist,orderedlist|";
+                $toolbar['list'] = "bulletlist,orderedlist|";
             }
 
             if ($mybb->settings['allowcodemycode'] == 1) {
-                $code = "code,php,";
+                $toolbar['code'] = "code,php,";
             }
 
-            if ($mybb->user['sourceeditor'] == 1) {
-                $sourcemode = "MyBBEditor.sourceMode(true);";
-            }
-
-            eval("\$codeinsert = \"".$templates->get("codebuttons")."\";");
+            $codeinsert = \MyBB\template('misc/codebuttons.twig', [
+                'toolbar' => $toolbar,
+                'emoticons' => $emoticons,
+                'editor_language' => $editor_language,
+                'bind' => $bind
+            ]);
         }
     }
 
@@ -3415,7 +3414,7 @@ function get_attachment_icon($ext)
 
         $icon = $attach_icons_schemes[$ext];
 
-        $name = htmlspecialchars_uni($attachtypes[$ext]['name']);
+        $name = $attachtypes[$ext]['name'];
     } else {
         if (defined("IN_ADMINCP")) {
             $theme['imgdir'] = "../images";
@@ -3429,9 +3428,11 @@ function get_attachment_icon($ext)
         $name = $lang->unknown;
     }
 
-    $icon = htmlspecialchars_uni($icon);
-    eval("\$attachment_icon = \"".$templates->get("attachment_icon")."\";");
-    return $attachment_icon;
+    return \MyBB\template('misc/attachment_icon.twig', [
+        'ext' => $ext,
+        'icon' => $icon,
+        'name' => $name
+    ]);
 }
 
 /**

--- a/inc/views/base/layouts/master.twig
+++ b/inc/views/base/layouts/master.twig
@@ -59,10 +59,10 @@
     </script>
 </head>
 <body>
-{% include 'partials/header.twig' %}
+{% block header %}{% include 'partials/header.twig' %}{% endblock %}
 
 {% block body %}{% endblock %}
 
-{% include 'partials/footer.twig' %}
+{% block footer %}{% include 'partials/footer.twig' %}{% endblock %}
 </body>
 </html>

--- a/inc/views/base/misc/attachment_icon.twig
+++ b/inc/views/base/misc/attachment_icon.twig
@@ -1,0 +1,1 @@
+<img src="{{ icon }}" title="{{ name }}" border="0" alt=".{{ ext }}" />

--- a/inc/views/base/misc/captcha/hidden.twig
+++ b/inc/views/base/misc/captcha/hidden.twig
@@ -1,0 +1,2 @@
+<input type="hidden" name="{{ fields.names.hash }}" value="{{ fields.hash }}" />
+<input type="hidden" name="{{ fields.names.string }}" value="{{ fields.string }}" />

--- a/inc/views/base/misc/captcha/post.twig
+++ b/inc/views/base/misc/captcha/post.twig
@@ -1,0 +1,95 @@
+{# NoCAPTCHA #}
+{% if type == 4 %}
+    <tr id="captcha_trow">
+        <td class="trow1" valign="top"><strong>{{ lang.human_verification }}</strong></td>
+        <td class="trow1">
+            <table style="width: 300px; padding: 4px;">
+                <tr>
+                    <td>
+                        <span class="smalltext">{{ lang.verification_note_nocaptcha }}</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <script type="text/javascript" src="{{ server }}"></script>
+                        <div class="g-recaptcha" data-sitekey="{{ mybb.settings.captchapublickey }}"></div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+{# ReCAPTCHA v2 #}
+{% elseif type == 5 %}
+    <br />
+    <script src="{{ server }}?onload=captchaOnloadCallback&render=explicit" async defer></script>
+    <script type="text/javascript">
+
+        var captchaTarget = '';
+
+        var captchaOnSubmit = function(token) {
+
+            if (!captchaTarget.is('#quick_reply_submit')) {
+                document.createElement('form').submit.apply(captchaTarget.closest('form')[0]);
+            } else {
+                captchaTarget.bind('click', function(e) {
+                    return Thread.quickReply(e);
+                }).trigger('click').unbind('click');
+                grecaptcha.reset();
+            }
+
+        };
+
+        var captchaOnloadCallback = function() {
+
+            captchaTarget = $('input[name="regsubmit"], #quick_reply_submit').filter(function(){
+                return $(this).closest('#quick_login').length == 0
+            });
+
+            captchaTarget.attr('data-size', 'invisible').unbind('click');
+
+            grecaptcha.render(captchaTarget.get(0), {
+                    'sitekey': '{{ mybb.settings.captchapublickey }}',
+                    'callback': captchaOnSubmit
+                }, true);
+
+        }
+
+    </script>
+{# MyBB Captcha #}
+{% else %}
+    <tr id="captcha_trow">
+        <td class="trow1" valign="top" width="350">
+            <strong>{{ lang.image_verification }}</strong><br />
+            <span class="smalltext">{{ lang.verification_note }}</span>
+        </td>
+        <td class="trow1">
+            <script type="text/javascript">
+            <!--
+                lang.captcha_fetch_failure = "{{ lang.captcha_fetch_failure }}";
+            // -->
+            </script>
+            <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/captcha.js?ver=1808"></script>
+            <table style="width: 300px; padding: 4px;">
+                <tr>
+                    <td style="vertical-align: middle;">
+                        <img src="{{ mybb.settings.bburl }}/captcha.php?imagehash={{ imagehash }}" alt="{{ lang.image_verification }}" title="{{ lang.image_verification }}" id="captcha_img" /><br />
+                        <span style="color: red;" class="smalltext">{{ lang.verification_subnote }}</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <input type="text" class="textbox" name="imagestring" value="" id="imagestring" size="16" /><input type="hidden" name="imagehash" value="{{ imagehash }}" id="imagehash" />
+                        <script type="text/javascript">
+                        <!--
+                            if(use_xmlhttprequest == "1")
+                            {
+                                document.write('<input type="button" class="button" name="refresh" value="{{ lang.refresh }}" onclick="return captcha.refresh();" \/>');
+                            }
+                        // -->
+                        </script>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+{% endif %}

--- a/inc/views/base/misc/captcha/post.twig
+++ b/inc/views/base/misc/captcha/post.twig
@@ -48,9 +48,9 @@
             captchaTarget.attr('data-size', 'invisible').unbind('click');
 
             grecaptcha.render(captchaTarget.get(0), {
-                    'sitekey': '{{ mybb.settings.captchapublickey }}',
-                    'callback': captchaOnSubmit
-                }, true);
+                'sitekey': '{{ mybb.settings.captchapublickey }}',
+                'callback': captchaOnSubmit
+            }, true);
 
         }
 

--- a/inc/views/base/misc/captcha/register.twig
+++ b/inc/views/base/misc/captcha/register.twig
@@ -1,0 +1,78 @@
+{# NoCAPTCHA #}
+{% if type == 4 %}
+    <br />
+    <fieldset class="trow2">
+        <legend><strong>{{ lang.human_verification }}</strong></legend>
+        <table cellspacing="0" cellpadding="{{ theme.tablespace }}">
+            <tr>
+                <td><span class="smalltext">{{ lang.verification_note_nocaptcha }}</span></td>
+            </tr>
+            <tr>
+                <td><script type="text/javascript" src="{{ server }}"></script><div class="g-recaptcha" data-sitekey="{{ mybb.settings.captchapublickey }}"></div></td>
+            </tr>
+        </table>
+    </fieldset>
+{# ReCAPTCHA v2 #}
+{% elseif type == 5 %}
+    <br />
+    <script src="{{ server }}?onload=captchaOnloadCallback&render=explicit" async defer></script>
+    <script type="text/javascript">
+
+        var captchaOnSubmit = function(token) {
+            $("#registration_form").submit();
+        };
+
+        var captchaOnloadCallback = function() {
+
+            var target = $('input[name="regsubmit"]');
+            target.attr('data-size', 'invisible');
+
+            grecaptcha.render(target.get(0), {
+                    'sitekey': '{{ mybb.settings.captchapublickey }}',
+                    'callback': captchaOnSubmit
+                }, true);
+
+        }
+
+    </script>
+{# MyBB Captcha #}
+{% else %}
+    <br />
+    <fieldset class="trow2">
+        <script type="text/javascript">
+        <!--
+            lang.captcha_fetch_failure = "{{ lang.captcha_fetch_failure }}";
+        // -->
+        </script>
+        <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/captcha.js?ver=1808"></script>
+        <legend><strong>{{ lang.image_verification }}</strong></legend>
+        <table cellspacing="0" cellpadding="{{ theme.tablespace }}">
+            <tr>
+                <td>
+                    <span class="smalltext">{{ lang.verification_note }}</span>
+                </td>
+                <td rowspan="2" align="center">
+                    <img src="captcha.php?action=regimage&amp;imagehash={{ imagehash }}" alt="{{ lang.image_verification }}" title="{{ lang.image_verification }}" id="captcha_img" /><br />
+                    <span style="color: red;" class="smalltext">{{ lang.verification_subnote }}</span>
+                    <script type="text/javascript">
+                    <!--
+                        if(use_xmlhttprequest == "1")
+                        {
+                            document.write('<br \/><br \/><input type="button" class="button" tabindex="10000" name="refresh" value="{{ lang.refresh }}" onclick="return captcha.refresh();" \/>');
+                        }
+                    // -->
+                    </script>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <input type="text" class="textbox" name="imagestring" value="" id="imagestring" style="width: 100%;" />
+                    <input type="hidden" name="imagehash" value="{{ imagehash }}" id="imagehash" />
+                </td>
+            </tr>
+            <tr>
+                <td id="imagestring_status"  style="display: none;" colspan="2">&nbsp;</td>
+            </tr>
+        </table>
+    </fieldset>
+{% endif %}

--- a/inc/views/base/misc/captcha/register.twig
+++ b/inc/views/base/misc/captcha/register.twig
@@ -28,9 +28,9 @@
             target.attr('data-size', 'invisible');
 
             grecaptcha.render(target.get(0), {
-                    'sitekey': '{{ mybb.settings.captchapublickey }}',
-                    'callback': captchaOnSubmit
-                }, true);
+                'sitekey': '{{ mybb.settings.captchapublickey }}',
+                'callback': captchaOnSubmit
+            }, true);
 
         }
 

--- a/inc/views/base/misc/changeuserbox.twig
+++ b/inc/views/base/misc/changeuserbox.twig
@@ -1,0 +1,9 @@
+<tr>
+    <td class="trow1" width="20%"><strong>{{ lang.username }}</strong></td>
+    <td class="trow1">
+        {{ mybb.user.username }}
+        <span class="smalltext">
+            [<strong><a href="member.php?action=logout&amp;logoutkey={{ mybb.user.logoutkey }}">{{ lang.change_user }}</a></strong>]
+        </span>
+    </td>
+</tr>

--- a/inc/views/base/misc/codebuttons.twig
+++ b/inc/views/base/misc/codebuttons.twig
@@ -1,0 +1,39 @@
+<link rel="stylesheet" href="{{ mybb.asset_url }}/jscripts/sceditor/editor_themes/{{ theme.editortheme }}" type="text/css" media="all" />
+<script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/sceditor/jquery.sceditor.bbcode.min.js?ver=1805"></script>
+<script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/bbcodes_sceditor.js?ver=1808"></script>
+<script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/sceditor/editor_plugins/undo.js?ver=1805"></script>
+<script type="text/javascript">
+    var partialmode = {{ mybb.settings.partialmode }},
+    opt_editor = {
+        plugins: "bbcode,undo",
+        style: "{{ mybb.asset_url }}/jscripts/sceditor/textarea_styles/jquery.sceditor.{{ theme.editortheme }}?ver=1808",
+        rtl: {{ lang.settings.rtl }},
+        locale: "mybblang",
+        enablePasteFiltering: true,
+        autoUpdate: true,
+        emoticonsEnabled: {% if emoticons.dropdown %}true{% else %}false{% endif %},
+        emoticons: {
+            // Emoticons to be included in the dropdown
+            dropdown: {
+                {{ emoticons.dropdown|raw }}
+            },
+            // Emoticons to be included in the more section
+            more: {
+                {{ emoticons.more|raw }}
+            },
+            // Emoticons that are not shown in the dropdown but will still be converted. Can be used for things like aliases
+            hidden: {
+                {{ emoticons.hidden|raw }}
+            }
+        },
+        emoticonsCompat: true,
+        toolbar: "{{ toolbar.basic1 }}{{ toolbar.align }}{{ toolbar.font }}{{ toolbar.size }}{{ toolbar.color }}{{ toolbar.removeformat }}{{ toolbar.basic2 }}image,{{ toolbar.email }}{{ toolbar.link }}|video{{ toolbar.emoticon }}|{{ toolbar.list }}{{ toolbar.code }}quote|maximize,source",
+    };
+    {{ editor_language|raw }}
+    $(function() {
+        $("#{{ bind }}").sceditor(opt_editor);
+
+        MyBBEditor = $("#{{ bind }}").sceditor("instance");
+        {% if mybb.user.sourceeditor %}MyBBEditor.sourceMode(true);{% endif %}
+    });
+</script>

--- a/inc/views/base/misc/debugsummary.twig
+++ b/inc/views/base/misc/debugsummary.twig
@@ -1,0 +1,5 @@
+<div id="debug">
+    {{ trans('debug_generated_in', totaltime) }} {{ debug_weight }} <br />
+    {{ sql_queries }} / {{ trans('debug_server_load', serverload) }} / {{ trans('debug_memory_usage', memory_usage) }}<br />
+    [<a href="{{ debuglink }}" target="_blank">{{ lang.debug_advanced_details }}</a>]<br />
+</div>

--- a/inc/views/base/misc/loginbox.twig
+++ b/inc/views/base/misc/loginbox.twig
@@ -1,0 +1,6 @@
+<tr>
+    <td class="trow2"><strong>{{ lang.username }}</strong></td>
+    <td class="trow2">
+        <input type="text" class="textbox" name="username" size="30" value="{% if mybb.input.previewpost and mybb.input.action not in ["do_newreply", "do_newthread"] %}{% else %}{{ mybb.input.username }}{% endif %}" />
+    </td>
+</tr>

--- a/inc/views/base/misc/php_warnings.twig
+++ b/inc/views/base/misc/php_warnings.twig
@@ -1,0 +1,14 @@
+<table border="0" cellspacing="1" cellpadding="4" align="center" class="tborder">
+    <tr>
+        <td class="tcat">
+            <strong>{{ lang.warnings }}</strong>
+        </td>
+    </tr>
+    <tr>
+        <td class="trow1">
+            <span class="smalltext">{{ warnings|raw }}</span><br />
+        </td>
+    </tr>
+</table>
+<br />
+<br />

--- a/inc/views/base/misc/redirect.twig
+++ b/inc/views/base/misc/redirect.twig
@@ -1,7 +1,7 @@
 {% extends 'layouts/master.twig' %}
 
 {% block head %}
-	<title>{{ title }}</title>
+    <title>{{ title }}</title>
     <meta http-equiv="refresh" content="2;URL={{ url }}" />
 {% endblock head %}
 

--- a/inc/views/base/misc/redirect.twig
+++ b/inc/views/base/misc/redirect.twig
@@ -1,0 +1,34 @@
+{% extends 'layouts/master.twig' %}
+
+{% block head %}
+	<title>{{ title }}</title>
+    <meta http-equiv="refresh" content="2;URL={{ url }}" />
+{% endblock head %}
+
+{% block header %}{% endblock header %}
+{% block body %}
+    <br />
+    <br />
+    <br />
+    <br />
+    <div style="margin: auto auto; width: {{ lang.redirect_width }}" align="center">
+        <table border="0" cellspacing="{{ theme.borderwidth }}" cellpadding="{{ theme.tablespace }}" class="tborder">
+            <tr>
+                <td class="thead"><strong>{{ title }}</strong></td>
+            </tr>
+            <tr>
+                <td class="trow1" align="center">
+                    <p>{{ message|raw }}</p>
+                </td>
+            </tr>
+            <tr>
+                <td class="trow2" align="right">
+                    <a href="{{ url }}">
+                        <span class="smalltext">{{ lang.click_no_wait }}</span>
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </div>
+{% endblock body %}
+{% block footer %}{% endblock footer %}

--- a/member.php
+++ b/member.php
@@ -1059,7 +1059,7 @@ $(document).ready(function() {
 		if($mybb->settings['captchaimage'])
 		{
 			require_once MYBB_ROOT.'inc/class_captcha.php';
-			$captcha = new captcha(true, "member_register_regimage");
+			$captcha = new captcha(true, "register");
 
 			if($captcha->html)
 			{
@@ -1752,7 +1752,7 @@ if($mybb->input['action'] == "login")
     // Show captcha image for guests if enabled and only if we have to do
     if ($mybb->settings['captchaimage'] && $do_captcha == true) {
         require_once MYBB_ROOT.'inc/class_captcha.php';
-        $login_captcha = new captcha(false, "post_captcha");
+        $login_captcha = new captcha(false, "post");
 
         if ($login_captcha->type == 1) {
             if (!$correct) {
@@ -2730,7 +2730,7 @@ if($mybb->input['action'] == "emailuser")
 	$captcha = '';
     if ($mybb->settings['captchaimage'] && $mybb->user['uid'] == 0) {
         require_once MYBB_ROOT.'inc/class_captcha.php';
-        $post_captcha = new captcha(true, "post_captcha");
+        $post_captcha = new captcha(true, "post");
 
         if ($post_captcha->html) {
             $captcha = $post_captcha->html;

--- a/moderation.php
+++ b/moderation.php
@@ -127,8 +127,7 @@ if(in_array($mybb->input['action'], $log_multithreads_actions))
 	unset($tids);
 }
 
-$mybb->user['username'] = htmlspecialchars_uni($mybb->user['username']);
-eval("\$loginbox = \"".$templates->get("changeuserbox")."\";");
+$loginbox = \MyBB\template('misc/changeuserbox.twig');
 
 $allowable_moderation_actions = array("getip", "getpmip", "cancel_delayedmoderation", "delayedmoderation", "threadnotes", "purgespammer", "viewthreadnotes");
 

--- a/newreply.php
+++ b/newreply.php
@@ -159,19 +159,11 @@ if($mybb->settings['bbcodeinserter'] != 0 && $forum['allowmycode'] != 0 && (!$my
 // Display a login box or change user box?
 if($mybb->user['uid'] != 0)
 {
-	eval("\$loginbox = \"".$templates->get("changeuserbox")."\";");
+	$loginbox = \MyBB\template('misc/changeuserbox.twig');
 }
 else
 {
-	if(empty($mybb->input['previewpost']) && $mybb->input['action'] != "do_newreply")
-	{
-		$username = '';
-	}
-	else
-	{
-		$username = htmlspecialchars_uni($mybb->get_input('username'));
-	}
-	eval("\$loginbox = \"".$templates->get("loginbox")."\";");
+    $loginbox = \MyBB\template('misc/loginbox.twig');
 }
 
 // Check to see if the thread is closed, and if the user is a mod.
@@ -453,7 +445,7 @@ if($mybb->input['action'] == "do_newreply" && $mybb->request_method == "post")
 	if($mybb->settings['captchaimage'] && !$mybb->user['uid'])
 	{
 		require_once MYBB_ROOT.'inc/class_captcha.php';
-		$post_captcha = new captcha(false, "post_captcha");
+		$post_captcha = new captcha(false, "post");
 
 		if($post_captcha->validate_captcha() == false)
 		{
@@ -1129,7 +1121,7 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 	{
 		$correct = false;
 		require_once MYBB_ROOT.'inc/class_captcha.php';
-		$post_captcha = new captcha(false, "post_captcha");
+		$post_captcha = new captcha(false, "post");
 
 		if((!empty($mybb->input['previewpost']) || $hide_captcha == true) && $post_captcha->type == 1)
 		{

--- a/newthread.php
+++ b/newthread.php
@@ -113,21 +113,13 @@ if($forum['allowpicons'] != 0)
 // If we have a currently logged in user then fetch the change user box.
 if($mybb->user['uid'] != 0)
 {
-	eval("\$loginbox = \"".$templates->get("changeuserbox")."\";");
+	$loginbox = \MyBB\template('misc/changeuserbox.twig');
 }
 
 // Otherwise we have a guest, determine the "username" and get the login box.
 else
 {
-	if(!isset($mybb->input['previewpost']) && $mybb->input['action'] != "do_newthread")
-	{
-		$username = '';
-	}
-	else
-	{
-		$username = htmlspecialchars_uni($mybb->get_input('username'));
-	}
-	eval("\$loginbox = \"".$templates->get("loginbox")."\";");
+	$loginbox = \MyBB\template('misc/loginbox.twig');
 }
 
 // If we're not performing a new thread insert and not editing a draft then we're posting a new thread.
@@ -931,7 +923,7 @@ if($mybb->input['action'] == "newthread" || $mybb->input['action'] == "editdraft
 	{
 		$correct = false;
 		require_once MYBB_ROOT.'inc/class_captcha.php';
-		$post_captcha = new captcha(false, "post_captcha");
+		$post_captcha = new captcha(false, "post");
 
 		if((!empty($mybb->input['previewpost']) || $hide_captcha == true) && $post_captcha->type == 1)
 		{

--- a/polls.php
+++ b/polls.php
@@ -24,12 +24,11 @@ $plugins->run_hooks("polls_start");
 
 if($mybb->user['uid'] != 0)
 {
-	$mybb->user['username'] = htmlspecialchars_uni($mybb->user['username']);
-	eval("\$loginbox = \"".$templates->get("changeuserbox")."\";");
+	$loginbox = \MyBB\template('misc/changeuserbox.twig');
 }
 else
 {
-	eval("\$loginbox = \"".$templates->get("loginbox")."\";");
+    $loginbox = \MyBB\template('misc/loginbox.twig');
 }
 
 $mybb->input['action'] = $mybb->get_input('action');

--- a/sendthread.php
+++ b/sendthread.php
@@ -264,7 +264,7 @@ if (!$mybb->input['action']) {
     // Generate CAPTCHA?
     if ($mybb->settings['captchaimage'] && $mybb->user['uid'] == 0) {
         require_once MYBB_ROOT.'inc/class_captcha.php';
-        $post_captcha = new captcha(true, "post_captcha");
+        $post_captcha = new captcha(true, "post");
 
         if ($post_captcha->html) {
             $captcha = $post_captcha->html;

--- a/showthread.php
+++ b/showthread.php
@@ -1024,7 +1024,7 @@ if($mybb->input['action'] == "thread")
 		if($mybb->settings['captchaimage'] && !$mybb->user['uid'])
 		{
 			require_once MYBB_ROOT.'inc/class_captcha.php';
-			$post_captcha = new captcha(true, "post_captcha");
+			$post_captcha = new captcha(true, "post");
 
 			if($post_captcha->html)
 			{


### PR DESCRIPTION
For #2972. Templates converted:
- [x] attachment_icon
- [x] changeuserbox
- [x] codebuttons
- [x] debug_summary
- [x] loginbox
- [x] php_warnings
- [x] post_captcha
- [x] post_captcha_hidden
- [x] post_captcha_nocaptcha
- [x] post_captcha_recaptcha_invisible
- [x] redirect
- [x] task_image

Templates dropped because discontinued in 1.8 already:
- member_register_captcha_recaptcha
- post_captcha_recaptcha