### PR TITLE
Fixes #3263 – Missing array casting produces warning when posticons cache is empty

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1813,7 +1813,7 @@ function get_post_icons()
 	$iconlist = '';
 	$no_icons_checked = " checked=\"checked\"";
 	// read post icons from cache, and sort them accordingly
-	$posticons_cache = $cache->read("posticons");
+	$posticons_cache = (array)$cache->read("posticons");
 	$posticons = array();
 	foreach($posticons_cache as $posticon)
 	{


### PR DESCRIPTION
Fixes #3263 by casting the posticons cache as array to prevent the `foreach` to loop into a non-array if the posticons cache is empty (eg.: during partial installs or other odd configurations).