### PR TITLE
Fixed swapped field/table in field_exists check

### DIFF
--- a/install/resources/upgrade43.php
+++ b/install/resources/upgrade43.php
@@ -110,7 +110,7 @@ function upgrade43_dbchanges()
 	$cache->delete("mybb_credits");
 
 	// Add lockout column
-	if(!$db->field_exists("users", "loginlockoutexpiry"))
+	if(!$db->field_exists("loginlockoutexpiry", "users"))
 	{
 		$db->add_column("users", "loginlockoutexpiry", "int NOT NULL default '0'");
 	}


### PR DESCRIPTION
This PR fixes an error when upgrading from 1.8.15 to 1.8.16 caused by `field_exists` holding the field before the table, and not the other way round.