### PR TITLE
#2976 - add `my_date` filter and other useful twig functions

### DIFF
--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -132,8 +132,6 @@ $l['no_subscribe_notification'] = "Subscribe without receiving any notification 
 $l['instant_email_subscribe'] = "Subscribe and receive email notification of new replies";
 $l['instant_pm_subscribe'] = "Subscribe and receive PM notification of new replies";
 
-$l['today_rel'] = "<span title=\"{1}\">Today</span>";
-$l['yesterday_rel'] = "<span title=\"{1}\">Yesterday</span>";
 $l['today'] = "Today";
 $l['yesterday'] = "Yesterday";
 $l['error'] = "Board Message";
@@ -352,7 +350,7 @@ $l['seconds_short'] = "s";
 $l['rel_in'] = "In ";
 $l['rel_ago'] = "ago";
 $l['rel_less_than'] = "Less than ";
-$l['rel_time'] = "<span title=\"{5}{6}\">{1}{2} {3} {4}</span>";
+$l['rel_time'] = "{1}{2} {3} {4}";
 $l['rel_minutes_single'] = "minute";
 $l['rel_minutes_plural'] = "minutes";
 $l['rel_hours_single'] = "hour";

--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace MyBB\Twig\Extensions;
+
+class CoreExtension extends \Twig_Extension
+{
+    /**
+     * @var \MyBB $mybb
+     */
+    private $mybb;
+
+    /**
+     * @var \MyLanguage $lang
+     */
+    private $lang;
+
+    /**
+     * @var \pluginSystem $plugins
+     */
+    private $plugins;
+
+    public function __construct(\MyBB $mybb, \MyLanguage $lang, \pluginSystem $plugins)
+    {
+        $this->mybb = $mybb;
+        $this->lang = $lang;
+        $this->plugins = $plugins;
+    }
+
+    public function getFilters()
+    {
+        return [
+            new \Twig_Filter('my_date', [$this, 'myDate'], [
+                'needs_environment' => true,
+                'is_safe' => ['html'],
+            ]),
+        ];
+    }
+
+    public function myDate(\Twig_Environment $environment, $timestamp, string $format = 'relative',
+        string $offset = '', bool $useRelativeFormatting = true): string
+    {
+        if (is_numeric($timestamp)) {
+            // timestamp is a numeric timestamp
+            $dateTime = (new \DateTime())->setTimestamp($timestamp);
+        } else if (is_string($timestamp)) {
+            // timestamp string
+            $dateTime = new \DateTime($timestamp);
+        } else if ($timestamp instanceof \DateTime) {
+            // timestamp is already a DateTime
+            $dateTime = $timestamp;
+        } else {
+            // no valid timestamp passed, so use the current date time
+            $dateTime = new \DateTime();
+        }
+
+        if (!$offset && $offset != '0') {
+            if (isset($this->mybb->user['uid']) && $this->mybb->user['uid'] != 0 && isset($this->mybb->user['timezone'])) {
+                $offset = $this->mybb->user['timezone'];
+                $dstCorrection = (bool)$this->mybb->user['dst'];
+            } elseif (defined("IN_ADMINCP")) {
+                global $mybbadmin;
+                $offset = $mybbadmin['timezone'];
+                $dstCorrection = (bool)$mybbadmin['dst'];
+            } else {
+                $offset = $this->mybb->settings['timezoneoffset'];
+                $dstCorrection = (bool)$this->mybb->settings['dstcorrection'];
+            }
+
+            if (is_numeric($offset)) {
+                // Support both numeric timezones, and string timezones such as 'Europe/London'.
+                $offset = (float)$offset;
+            }
+
+            // If DST correction is enabled, add an additional hour to the timezone.
+            if ($dstCorrection && is_float($offset)) {
+                ++$offset;
+            }
+        }
+
+        if ($offset == '-') {
+            $offset = 0.0;
+        }
+
+        // Offset is a float, so now convert it into hour representation. Example: +9.5 becomes +09:30.
+        if (is_float($offset)) {
+            $hours = floor($offset);
+            $minutes = ($offset - $hours) * 60;
+
+            $offset = sprintf("%+'.02d:%'.02d", $hours, $minutes);
+        }
+
+        // \DateTimeZone supports both string style timezone specifiers, such as 'Europe/London' and time style.
+        $timezone = new \DateTimeZone($offset);
+        $dateTime->setTimezone($timezone);
+
+        // The date portion of the date time, with the time being 00:00:00
+        $date = \DateTime::createFromFormat('!Y-m-d', $dateTime->format('Y-m-d'), $timezone);
+
+        /** @var ?\DateTime $dateToday */
+        /** @var ?\DateTime $dateYesterday */
+        $dateToday = $dateYesterday = null;
+        if ($useRelativeFormatting && ($format == $this->mybb->settings['dateformat'] || $format == 'relative' || $format == 'normal')) {
+            $currentDateTime = new \DateTime('now', $timezone);
+
+            $dateToday = \DateTime::createFromFormat('!Y-m-d', $currentDateTime->format('Y-m-d'), $timezone);
+
+            // clone dateToday, rather than copy reference as datetime methods apply modifications to the instance
+            $dateYesterday = clone $dateToday;
+            $dateYesterday->modify('-1 day');
+        }
+
+        // Format the time using the setting values, to be used in the title
+        $formattedUsingSettings = $dateTime->format($this->mybb->settings['dateformat']);
+        $formattedUsingSettings .= $this->mybb->settings['datetimesep'];
+        $formattedUsingSettings .= $dateTime->format($this->mybb->settings['timeformat']);
+
+        $formattedDateString = $formattedUsingSettings;
+
+        switch ($format) {
+            case 'relative':
+                // Get the difference between now and the timestamp, in seconds
+                $diff = (new \DateTime('now', $timezone))->getTimestamp() - $dateTime->getTimestamp();
+
+                $relative = [
+                    'prefix' => '',
+                    'suffix' => '',
+                ];
+
+                if ($useRelativeFormatting && abs($diff) < 3600) {
+                    // less than an hour ago
+                    if ($diff < 0) {
+                        $diff = abs($diff);
+                    } else {
+                        $relative['suffix'] = $this->lang->rel_ago;
+                    }
+
+                    $relative['minute'] = floor($diff / 60);
+
+                    if ($relative['minute'] <= 1) {
+                        $relative['minute'] = 1;
+                        $relative['plural'] = $this->lang->rel_minutes_single;
+                    } else {
+                        $relative['plural'] = $this->lang->rel_minutes_plural;
+                    }
+
+                    if ($diff < 60) {
+                        // less than a minute
+                        $relative['prefix'] = $this->lang->rel_less_than;
+                    }
+
+                    $formattedDateString = $this->lang->sprintf(
+                        $this->lang->rel_time,
+                        $relative['prefix'],
+                        $relative['minute'],
+                        $relative['plural'],
+                        $relative['suffix']
+                    );
+                } else if ($useRelativeFormatting && abs($diff) < 43200) {
+                    // less than 12 hours ago
+                    if ($diff < 0) {
+                        $diff = abs($diff);
+                        $relative['prefix'] = $this->lang->rel_in;
+                    } else {
+                        $relative['suffix'] = $this->lang->rel_ago;
+                    }
+
+                    $relative['hour'] = floor($diff / 3600);
+
+                    if ($relative['hour'] <= 1) {
+                        $relative['hour'] = 1;
+                        $relative['plural'] = $this->lang->rel_hours_single;
+                    } else {
+                        $relative['plural'] = $this->lang->rel_hours_plural;
+                    }
+
+                    $formattedDateString = $this->lang->sprintf(
+                        $this->lang->rel_time,
+                        $relative['prefix'],
+                        $relative['hour'],
+                        $relative['plural'],
+                        $relative['suffix']
+                    );
+                } else {
+                    $formattedDateString = $date->format($this->mybb->settings['dateformat']);
+                    if ($useRelativeFormatting) {
+                        if ($dateToday == $date) {
+                            $formattedDateString = $this->lang->today;
+                        } elseif ($dateYesterday == $date) {
+                            $formattedDateString = $this->lang->yeserday;
+                        }
+                    }
+
+                    $formattedDateString .= $this->mybb->settings['datetimesep'];
+                    $formattedDateString .= $dateTime->format($this->mybb->settings['timeformat']);
+                }
+                break;
+            case 'normal':
+                // Normal format both date and time
+                $formattedDateString = $dateTime->format($this->mybb->settings['dateformat']);
+
+                if ($useRelativeFormatting) {
+                    if ($dateToday == $date) {
+                        $formattedDateString = $this->lang->today;
+                    } else if ($dateYesterday == $date) {
+                        $formattedDateString = $this->lang->yesterday;
+                    }
+                }
+
+                $formattedDateString .= $this->mybb->settings['datetimesep'];
+                $formattedDateString .= $dateTime->format($this->mybb->settings['timeformat']);
+                break;
+            default:
+                if ($useRelativeFormatting && $format == $this->mybb->settings['dateformat']) {
+                    if ($dateToday == $date) {
+                        $formattedDateString = $this->lang->today;
+                    } elseif ($dateYesterday == $date) {
+                        $formattedDateString = $this->lang->yesterday;
+                    }
+                } else {
+                    $formattedDateString = $dateTime->format($format);
+                }
+                break;
+        }
+
+        return $environment->render('partials/time.twig', [
+            'iso_date' => $dateTime->format(\DateTime::RFC3339),
+            'formatted_date' => $formattedDateString,
+            'formatted_using_settings' => $formattedUsingSettings,
+        ]);
+    }
+}

--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -15,11 +15,11 @@ class CoreExtension extends \Twig_Extension
     private $lang;
 
     /**
-     * @var \pluginSystem $plugins
+     * @var ?\pluginSystem $plugins
      */
     private $plugins;
 
-    public function __construct(\MyBB $mybb, \MyLanguage $lang, \pluginSystem $plugins)
+    public function __construct(\MyBB $mybb, \MyLanguage $lang, ?\pluginSystem $plugins)
     {
         $this->mybb = $mybb;
         $this->lang = $lang;
@@ -245,6 +245,16 @@ class CoreExtension extends \Twig_Extension
                     $formattedDateString = $dateTime->format($format);
                 }
                 break;
+        }
+
+        if (!is_null($this->plugins)) {
+            $args = [
+                'dateTime' => &$dateTime,
+                'formattedDateString' => &$formattedDateString,
+                'formattedUsingSettings' => &$formattedUsingSettings,
+            ];
+
+            $this->plugins->run_hooks('my_date', $args);
         }
 
         return $environment->render('partials/time.twig', [

--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -36,16 +36,37 @@ class CoreExtension extends \Twig_Extension
         ];
     }
 
-    public function myDate(\Twig_Environment $environment, $timestamp, string $format = 'relative',
-        string $offset = '', bool $useRelativeFormatting = true): string
-    {
+    /**
+     * Format a timestamp to a readable value.
+     *
+     * @param \Twig_Environment $environment twig environment to use to render the timestamp template.
+     * @param \DateTime|int|string|null $timestamp The timestamp to format. If empty, the current date will be used.
+     * @param string $format The format to use when formatting the timestamp. Defaults to 'relative'.
+     * @param string $offset The offset to use when formatting the timestamp.
+     * Defaults to using the user's settings or the board's settings if the user doesn't have a preference set.
+     * @param bool $useRelativeFormatting Whether to use relative formatting for the day: 'today' and 'yesterday'.
+     * Defaults to true.
+     *
+     * @return string The formatted timestamp, using the `partials/time.twig` template to wrap the timestamp.
+     *
+     * @throws \Twig_Error_Loader Thrown if the `partials/time.twig` template could not be loaded.
+     * @throws \Twig_Error_Runtime Thrown if an error occurs when rendering the `partials/time.twig` template.
+     * @throws \Twig_Error_Syntax Thrown if the `partials/time.twig` template contains invalid syntax.
+     */
+    public function myDate(
+        \Twig_Environment $environment,
+        $timestamp,
+        string $format = 'relative',
+        string $offset = '',
+        bool $useRelativeFormatting = true
+    ): string {
         if (is_numeric($timestamp)) {
             // timestamp is a numeric timestamp
             $dateTime = (new \DateTime())->setTimestamp($timestamp);
-        } else if (is_string($timestamp)) {
+        } elseif (is_string($timestamp)) {
             // timestamp string
             $dateTime = new \DateTime($timestamp);
-        } else if ($timestamp instanceof \DateTime) {
+        } elseif ($timestamp instanceof \DateTime) {
             // timestamp is already a DateTime
             $dateTime = $timestamp;
         } else {
@@ -54,7 +75,8 @@ class CoreExtension extends \Twig_Extension
         }
 
         if (!$offset && $offset != '0') {
-            if (isset($this->mybb->user['uid']) && $this->mybb->user['uid'] != 0 && isset($this->mybb->user['timezone'])) {
+            if (isset($this->mybb->user['uid']) && $this->mybb->user['uid'] != 0 &&
+                isset($this->mybb->user['timezone'])) {
                 $offset = $this->mybb->user['timezone'];
                 $dstCorrection = (bool)$this->mybb->user['dst'];
             } elseif (defined("IN_ADMINCP")) {
@@ -82,7 +104,8 @@ class CoreExtension extends \Twig_Extension
         }
 
         // Offset is a float, so now convert it into hour representation. Example: +9.5 becomes +09:30.
-        if (is_float($offset)) {
+        if (is_numeric($offset)) {
+            $offset = (float)$offset;
             $hours = floor($offset);
             $minutes = ($offset - $hours) * 60;
 
@@ -99,7 +122,8 @@ class CoreExtension extends \Twig_Extension
         /** @var ?\DateTime $dateToday */
         /** @var ?\DateTime $dateYesterday */
         $dateToday = $dateYesterday = null;
-        if ($useRelativeFormatting && ($format == $this->mybb->settings['dateformat'] || $format == 'relative' || $format == 'normal')) {
+        if ($useRelativeFormatting &&
+            ($format == $this->mybb->settings['dateformat'] || $format == 'relative' || $format == 'normal')) {
             $currentDateTime = new \DateTime('now', $timezone);
 
             $dateToday = \DateTime::createFromFormat('!Y-m-d', $currentDateTime->format('Y-m-d'), $timezone);
@@ -155,7 +179,7 @@ class CoreExtension extends \Twig_Extension
                         $relative['plural'],
                         $relative['suffix']
                     );
-                } else if ($useRelativeFormatting && abs($diff) < 43200) {
+                } elseif ($useRelativeFormatting && abs($diff) < 43200) {
                     // less than 12 hours ago
                     if ($diff < 0) {
                         $diff = abs($diff);
@@ -201,7 +225,7 @@ class CoreExtension extends \Twig_Extension
                 if ($useRelativeFormatting) {
                     if ($dateToday == $date) {
                         $formattedDateString = $this->lang->today;
-                    } else if ($dateYesterday == $date) {
+                    } elseif ($dateYesterday == $date) {
                         $formattedDateString = $this->lang->yesterday;
                     }
                 }

--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -29,10 +29,11 @@ class CoreExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_Filter('my_date', [$this, 'myDate'], [
+            new \Twig_Filter('my_date', [$this, 'date'], [
                 'needs_environment' => true,
                 'is_safe' => ['html'],
             ]),
+            new \Twig_Filter('my_number_format', [$this, 'numberFormat']),
         ];
     }
 
@@ -53,7 +54,7 @@ class CoreExtension extends \Twig_Extension
      * @throws \Twig_Error_Runtime Thrown if an error occurs when rendering the `partials/time.twig` template.
      * @throws \Twig_Error_Syntax Thrown if the `partials/time.twig` template contains invalid syntax.
      */
-    public function myDate(
+    public function date(
         \Twig_Environment $environment,
         $timestamp,
         string $format = 'relative',
@@ -251,5 +252,43 @@ class CoreExtension extends \Twig_Extension
             'formatted_date' => $formattedDateString,
             'formatted_using_settings' => $formattedUsingSettings,
         ]);
+    }
+
+    /**
+     * Format a number according to settings.
+     *
+     * @param mixed $number The number to format.
+     *
+     * @return string The formatted numerical value.
+     */
+    public function numberFormat($number): string
+    {
+        if ($number == '-') {
+            return $number;
+        }
+        
+        if (is_int($number)) {
+            return number_format(
+                $number,
+                0,
+                $this->mybb->settings['decpoint'],
+                $this->mybb->settings['thousandssep']
+            );
+        } else {
+            $parts = explode('.', $number, 2);
+
+            if (count($parts) == 2) {
+                $decimals = my_strlen($parts[1]);
+            } else {
+                $decimals = 0;
+            }
+
+            return number_format(
+                (double)$number,
+                $decimals,
+                $this->mybb->settings['decpoint'],
+                $this->mybb->settings['thousandssep']
+            );
+        }
     }
 }

--- a/inc/src/bootstrap.php
+++ b/inc/src/bootstrap.php
@@ -5,6 +5,7 @@ namespace MyBB;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use MyBB\Twig\Extensions\CoreExtension;
 use MyBB\Twig\Extensions\LangExtension;
 use MyBB\Twig\Extensions\ThemeExtension;
 use Psr\Container\ContainerInterface;
@@ -71,8 +72,14 @@ $container->singleton(\Twig_Environment::class, function (ContainerInterface $co
         'cache' => __DIR__ . '/../../cache/views',
     ]);
 
-    $env->addExtension(new ThemeExtension($container->get(\MyBB::class), $container->get(\DB_Base::class)));
-    $env->addExtension(new LangExtension($container->get(\MyLanguage::class)));
+    /** @var \MyBB $mybb */
+    $mybb = $container->get(\MyBB::class);
+    /** @var \MyLanguage $lang */
+    $lang = $container->get(\MyLanguage::class);
+
+    $env->addExtension(new CoreExtension($mybb, $lang, $container->get(\pluginSystem::class)));
+    $env->addExtension(new ThemeExtension($mybb, $container->get(\DB_Base::class)));
+    $env->addExtension(new LangExtension($lang));
 
     $plugins->run_hooks('twig_environment_env', $env);
 

--- a/inc/views/base/member/profile.twig
+++ b/inc/views/base/member/profile.twig
@@ -88,7 +88,7 @@
                     <tr>
                         <td class="trow1"><strong>{{ lang.total_posts }}</strong></td>
                         <td class="trow1">
-                            {{ memprofile.postnum }} ({{ trans('ppd_percent_total', memprofile.ppd, memprofile.post_percent) }})
+                            {{ memprofile.postnum|my_number_format }} ({{ trans('ppd_percent_total', memprofile.ppd|my_number_format, memprofile.post_percent) }})
                             {% if mybb.usergroup.cansearch %}
                                 <br /><span class="smalltext">(<a href="search.php?action=finduser&amp;uid={{ memprofile.uid }}">{{ lang.find_posts }}</a>)</span>
                             {% endif %}
@@ -97,7 +97,7 @@
                     <tr>
                         <td class="trow2"><strong>{{ lang.total_threads }}</strong></td>
                         <td class="trow2">
-                            {{ memprofile.threadnum }} ({{ trans('tpd_percent_total', memprofile.tpd, memprofile.thread_percent) }})
+                            {{ memprofile.threadnum|my_number_format }} ({{ trans('tpd_percent_total', memprofile.tpd|my_number_format, memprofile.thread_percent) }})
                             {% if mybb.usergroup.cansearch %}
                                 <br /><span class="smalltext">(<a href="search.php?action=finduserthreads&amp;uid={{ memprofile.uid }}">{{ lang.find_threads }}</a>)</span>
                             {% endif %}

--- a/inc/views/base/partials/time.twig
+++ b/inc/views/base/partials/time.twig
@@ -1,0 +1,3 @@
+<time datetime="{{ iso_date }}" title="{{ formatted_using_settings }}">
+    {{ formatted_date }}
+</time>

--- a/inc/views/base/postbit/postbit.twig
+++ b/inc/views/base/postbit/postbit.twig
@@ -95,7 +95,7 @@
 			{% if post.showicon %}
 				<img src="{{ icon.path }}" alt="{{ icon.name }}" title="{{ icon.name }}" style="vertical-align: middle;" />&nbsp;
 			{% endif %}
-			<span class="post_date">{{ post.postdate|raw }} <span class="post_edit" id="edited_by_{{ post.pid }}">
+			<span class="post_date">{{ post.dateline|my_date }} <span class="post_edit" id="edited_by_{{ post.pid }}">
 			{% if post.editedmsg %}
 				<span class="edited_post">({{ post.editnote|raw }} {{ post.editedprofilelink|raw }}.{% if post.editreason %} <em>{{ lang.postbit_editreason }}: {{ post.editreason }}</em>{% endif %})</span>
 			{% endif %}

--- a/member.php
+++ b/member.php
@@ -2324,12 +2324,7 @@ if($mybb->input['action'] == "profile")
         }
     }
 
-    $memprofile['postnum'] = my_number_format($memprofile['postnum']);
-    $memprofile['ppd'] = my_number_format($ppd);
     $memprofile['post_percent'] = $post_percent;
-
-    $memprofile['threadnum'] = my_number_format($memprofile['threadnum']);
-    $memprofile['tpd'] = my_number_format($tpd);
     $memprofile['thread_percent'] = $thread_percent;
 
     $memprofile['formattedname'] = format_name($memprofile['username'], $memprofile['usergroup'], $memprofile['displaygroup']);


### PR DESCRIPTION
Part of #2976.

This PR adds the following:

- `my_date` filter:

```twig
{{ post.dateline|my_date('relative', 'offset', true) }}
```

This means that language strings are changed slightly, moving HTML into a partial template rather than a language string. Dates now also use the HTML 5 `<time>` element, with eh `datetime` attribute set and a `title` attribute that shows the date as a full string whether relative formatting is enabled or not.

I've tried to keep this functioning the same as the old `my_date`, but it was unclear to me what the different values of the `$ty` parameter to that function actually achieved...
- `my_number_format` filter:

```twig
{{ memprofile.threadnum|my_number_format }}
```

I plan to add other functions to this PR over this weekend.