### PR TITLE
Moved cookie clearing out to guests

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -6441,9 +6441,10 @@ function login_attempt_check($uid = 0, $fatal = true)
 					"loginattempts" => 0,
 					"loginlockoutexpiry" => 0
 				), "uid='{$uid}'");
-
-				my_unsetcookie('lockoutexpiry');
 			}
+
+			// Wipe the cookie, no matter if a guest or a member
+			my_unsetcookie('lockoutexpiry');
 
 			return 0;
 		}


### PR DESCRIPTION
This PR fixes a little bug which prevents the loginlockout cookie to be cleared for guests.