### PR TITLE
Fixes #3345 – Cookies not wiped if using the modal to log in

### DIFF
--- a/global.php
+++ b/global.php
@@ -90,6 +90,12 @@ $lang->set_language($mybb->settings['bblanguage']);
 $lang->load('global');
 $lang->load('messages');
 
+// Wipe lockout cookie if enough time has passed
+if($mybb->cookies['lockoutexpiry'] && $mybb->cookies['lockoutexpiry'] < TIME_NOW)
+{
+	my_unsetcookie('lockoutexpiry');
+}
+
 // Run global_start plugin hook now that the basics are set up
 $plugins->run_hooks('global_start');
 


### PR DESCRIPTION
Fixed #3345 by checking for cookies upon every page load in order to get rid of soft lockout cookies if using the modal to login.