### PR TITLE
prevent array error message popping up

### DIFF
--- a/index.php
+++ b/index.php
@@ -360,7 +360,7 @@ if(($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0) |
 		$stats = $cache->read('stats');
 	}
 	
-	$expaltext = (in_array("boardstats", $collapse)) ? "[+]" : "[-]";
+	$expaltext = (in_array("boardstats", is_null($collapse) ? array() : $collapse)) ? "[+]" : "[-]";
 	eval('$boardstats = "'.$templates->get('index_boardstats').'";');
 }
 


### PR DESCRIPTION
$collapse can be null and then in_array will throw an error message. to prevent this, ensure a proper array is used at all times.

I came upon this issue after my host (forcefully) changed from PHP 5.8.2 to 7.2.7