### PR TITLE
Fixes #3262 Bad word filter

### DIFF
--- a/admin/modules/config/badwords.php
+++ b/admin/modules/config/badwords.php
@@ -47,16 +47,29 @@ if($mybb->input['action'] == "add" && $mybb->request_method == "post")
 		}
 	}
 
-	// Check validity of defined regular expression
-	if($mybb->get_input('regex', MyBB::INPUT_INT) && (@preg_match('#'.trim($mybb->input['badword']).'#is', null) === false))
+	$badword = trim($mybb->input['badword']);
+
+	if($mybb->get_input('regex', MyBB::INPUT_INT))
 	{
-		$errors[] = $lang->error_invalid_regex;
+		// Check validity of defined regular expression
+		if((@preg_match('#'.trim($mybb->input['badword']).'#is', null) === false))
+		{
+			$errors[] = $lang->error_invalid_regex;
+		}
+	}
+	else
+	{
+		if(!is_object($parser))
+		{
+			require_once MYBB_ROOT."inc/class_parser.php";
+			$parser = new postParser;
+		}
+	
+		$badword = $parser->generate_regex($mybb->input['badword']);
 	}
 
-	$badword = str_replace('\*', '([a-zA-Z0-9_]{1})', preg_quote($mybb->input['badword'], "#"));
-
 	// Don't allow certain badword replacements to be added if it would cause an infinite recursive loop.
-	if(strlen($mybb->input['badword']) == strlen($mybb->input['replacement']) && preg_match("#(^|\W)".$badword."(\W|$)#i", $mybb->input['replacement']))
+	if(@preg_match('#'.$badword.'#is', $mybb->input['replacement']))
 	{
 		$errors[] = $lang->error_replacement_word_invalid;
 	}

--- a/admin/modules/config/badwords.php
+++ b/admin/modules/config/badwords.php
@@ -77,7 +77,7 @@ if($mybb->input['action'] == "add" && $mybb->request_method == "post")
 	if(!$errors)
 	{
 		$new_badword = array(
-			"badword" => $db->escape_string($badword),
+			"badword" => $db->escape_string($mybb->input['badword']),
 			"regex" => $mybb->get_input('regex', MyBB::INPUT_INT),
 			"replacement" => $db->escape_string($mybb->input['replacement'])
 		);
@@ -87,7 +87,7 @@ if($mybb->input['action'] == "add" && $mybb->request_method == "post")
 		$plugins->run_hooks("admin_config_badwords_add_commit");
 
 		// Log admin action
-		log_admin_action($bid, $badword);
+		log_admin_action($bid, $mybb->input['badword']);
 
 		$cache->update_badwords();
 		flash_message($lang->success_added_bad_word, 'success');

--- a/admin/modules/config/badwords.php
+++ b/admin/modules/config/badwords.php
@@ -52,7 +52,7 @@ if($mybb->input['action'] == "add" && $mybb->request_method == "post")
 	if($mybb->get_input('regex', MyBB::INPUT_INT))
 	{
 		// Check validity of defined regular expression
-		if((@preg_match('#'.trim($mybb->input['badword']).'#is', null) === false))
+		if((@preg_match('#'.$badword.'#is', null) === false))
 		{
 			$errors[] = $lang->error_invalid_regex;
 		}
@@ -65,7 +65,7 @@ if($mybb->input['action'] == "add" && $mybb->request_method == "post")
 			$parser = new postParser;
 		}
 	
-		$badword = $parser->generate_regex($mybb->input['badword']);
+		$badword = $parser->generate_regex($badword);
 	}
 
 	// Don't allow certain badword replacements to be added if it would cause an infinite recursive loop.
@@ -77,7 +77,7 @@ if($mybb->input['action'] == "add" && $mybb->request_method == "post")
 	if(!$errors)
 	{
 		$new_badword = array(
-			"badword" => $db->escape_string($mybb->input['badword']),
+			"badword" => $db->escape_string($badword),
 			"regex" => $mybb->get_input('regex', MyBB::INPUT_INT),
 			"replacement" => $db->escape_string($mybb->input['replacement'])
 		);
@@ -87,7 +87,7 @@ if($mybb->input['action'] == "add" && $mybb->request_method == "post")
 		$plugins->run_hooks("admin_config_badwords_add_commit");
 
 		// Log admin action
-		log_admin_action($bid, $mybb->input['badword']);
+		log_admin_action($bid, $badword);
 
 		$cache->update_badwords();
 		flash_message($lang->success_added_bad_word, 'success');

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -649,7 +649,7 @@ class postParser
 				{
 					$badword['replacement'] = "*****";
 				}
-				
+
 				if(!$badword['regex'])
 				{
 					$badword['badword'] = $this->generate_regex($badword['badword']);

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -654,7 +654,7 @@ class postParser
 				{
 					$bad_word = $badword['badword'];
 
-					// Neutralize multiple adjascent wildcards and generate pattern
+					// Neutralize multiple adjacent wildcards and generate pattern
 					$ptrn = array('/[\*]{1}[\+]+/', '/[\+]+[\*]{1}/', '/[\*]+/');
 					$rplc = array('*', '*', '[^\s\n]*');
 					$bad_word = preg_replace($ptrn, $rplc, $bad_word);

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -650,18 +650,42 @@ class postParser
 					$badword['replacement'] = "*****";
 				}
 
-				if($badword['regex'])
+				if(!$badword['regex'])
 				{
-					$message = preg_replace('#'.$badword['badword'].'#is', $badword['replacement'], $message);
-				}
-				else
-				{
-					// Take into account the position offset for our last replacement.
-					$badword['badword'] = str_replace('\*', '([a-zA-Z0-9_\*]{1})', preg_quote($badword['badword'], "#"));
+					$bad_word = $badword['badword'];
 
-					// Ensure we run the replacement enough times but not recursively (i.e. not while(preg_match..))
-					$message = preg_replace("#(^|\W)".$badword['badword']."(?=\W|$)#i", '\1'.$badword['replacement'], $message);
+					// Neutralize multiple adjascent wildcards and generate pattern
+					$ptrn = array('/[\*]{1}[\+]+/', '/[\+]+[\*]{1}/', '/[\*]+/');
+					$rplc = array('*', '*', '[^\s\n]*');
+					$bad_word = preg_replace($ptrn, $rplc, $bad_word);
+					
+					// Count + and generate pattern
+					$bad_word = explode('+', $bad_word);
+					$trap = "";
+					$plus = 0;
+					foreach($bad_word as $bad_piece)
+					{
+						if($bad_piece)
+						{
+							$trap .= $plus ? '[^\s\n]{'.$plus.'}'.$bad_piece : $bad_piece;
+							$plus = 1;
+						}
+						else
+						{
+							$plus++;
+						}
+					}
+					
+					// Handle trailing +
+					if($plus > 1)
+					{
+						$trap .= '[^\s\n]{'.($plus-1).'}';
+					}
+					
+					$badword['badword'] = $trap;
 				}
+
+				$message = preg_replace('#'.$badword['badword'].'#is', $badword['replacement'], $message);
 			}
 		}
 		if(!empty($this->options['strip_tags']))

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -649,40 +649,10 @@ class postParser
 				{
 					$badword['replacement'] = "*****";
 				}
-
+				
 				if(!$badword['regex'])
 				{
-					$bad_word = $badword['badword'];
-
-					// Neutralize multiple adjacent wildcards and generate pattern
-					$ptrn = array('/[\*]{1}[\+]+/', '/[\+]+[\*]{1}/', '/[\*]+/');
-					$rplc = array('*', '*', '[^\s\n]*');
-					$bad_word = preg_replace($ptrn, $rplc, $bad_word);
-					
-					// Count + and generate pattern
-					$bad_word = explode('+', $bad_word);
-					$trap = "";
-					$plus = 0;
-					foreach($bad_word as $bad_piece)
-					{
-						if($bad_piece)
-						{
-							$trap .= $plus ? '[^\s\n]{'.$plus.'}'.$bad_piece : $bad_piece;
-							$plus = 1;
-						}
-						else
-						{
-							$plus++;
-						}
-					}
-					
-					// Handle trailing +
-					if($plus > 1)
-					{
-						$trap .= '[^\s\n]{'.($plus-1).'}';
-					}
-					
-					$badword['badword'] = $trap;
+					$badword['badword'] = $this->generate_regex($badword['badword']);
 				}
 
 				$message = preg_replace('#'.$badword['badword'].'#is', $badword['replacement'], $message);
@@ -693,6 +663,50 @@ class postParser
 			$message = strip_tags($message);
 		}
 		return $message;
+	}
+
+	/**
+	 * Generates REGEX patterns based on user defined badword string.
+	 *
+	 * @param string $badword The word defined to replace.
+	 * @return string The regex pattern to match the word or null on error.
+	 */
+	function generate_regex($bad_word = "")
+	{
+		if($bad_word == "")
+		{
+			return;
+		}
+
+		// Neutralize multiple adjacent wildcards and generate pattern
+		$ptrn = array('/[\*]{1}[\+]+/', '/[\+]+[\*]{1}/', '/[\*]+/');
+		$rplc = array('*', '*', '[^\s\n]*');
+		$bad_word = preg_replace($ptrn, $rplc, $bad_word);
+		
+		// Count + and generate pattern
+		$bad_word = explode('+', $bad_word);
+		$trap = "";
+		$plus = 0;
+		foreach($bad_word as $bad_piece)
+		{
+			if($bad_piece)
+			{
+				$trap .= $plus ? '[^\s\n]{'.$plus.'}'.$bad_piece : $bad_piece;
+				$plus = 1;
+			}
+			else
+			{
+				$plus++;
+			}
+		}
+		
+		// Handle trailing +
+		if($plus > 1)
+		{
+			$trap .= '[^\s\n]{'.($plus-1).'}';
+		}
+		
+		return $trap;
 	}
 
 	/**

--- a/inc/languages/english/admin/config_badwords.lang.php
+++ b/inc/languages/english/admin/config_badwords.lang.php
@@ -12,10 +12,10 @@ $l['bad_word_filters'] = "Word Filters";
 $l['bad_word_filters_desc'] = "This feature allows you to manage a listing of words or phrases which are automatically replaced in posts on your forum. It is useful for replacing swear words and such.";
 
 $l['bad_word'] = "Word";
-$l['bad_word_desc'] = "Enter the word which you wish to be filtered. The '*' character represents any single character (a-zA-Z0-9_).";
+$l['bad_word_desc'] = "Enter the word which you wish to be filtered. The '*' symbol represents any number of characters and the '+' symbol represents any single character (other than space and new line).";
 $l['bad_word_max'] = "A filtered word can't be longer than 100 characters.";
 $l['replacement'] = "Replacement";
-$l['replacement_desc'] = "Enter the string which will replace the filtered word (If this is blank, asterisks will be shown)";
+$l['replacement_desc'] = "Enter the string which will replace the filtered word (If this is blank, asterisks will be shown).";
 $l['regex'] = "Regular Expression";
 $l['regex_desc'] = "Treat the \"Word\" field as a regular expression.";
 $l['replacement_word_max'] = "A replacement word can't be longer than 100 characters.";


### PR DESCRIPTION
Attempt to fix #3262 
Implemented effective usage of `*` and `+`

**Note: This is gonna break all the pre-defined bad word filters. Its is required to describe in release note to redefine bad word filters as per the new rule after applying this patch.**