### PR TITLE
Fixes #3192 Avatar dimension separator consistency

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -940,9 +940,9 @@ if($mybb->input['action'] == "change")
 		{
 			foreach($dimfields[$gid] as $field)
 			{
-				if(trim($mybb->input['upsetting'][$field]) != "")
+				if(isset($mybb->input['upsetting'][$field]))
 				{
-					if(preg_match("/\b\d+[|x]{1}\d+\b/i", $mybb->input['upsetting'][$field]))
+					if(preg_match("/\b\d+[|x]{1}\d+\b/i", $mybb->input['upsetting'][$field]) || ($field == 'maxavatardims' && trim($mybb->input['upsetting'][$field]) == ""))
 					{
 						// If pipe (|) is used normalize to 'x'
 						$mybb->input['upsetting'][$field] = str_replace('|', 'x', my_strtolower($mybb->input['upsetting'][$field]));

--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -940,15 +940,18 @@ if($mybb->input['action'] == "change")
 		{
 			foreach($dimfields[$gid] as $field)
 			{
-				if(preg_match("/\b\d+[|x]{1}\d+\b/i", $mybb->input['upsetting'][$field]) || ($field == 'maxavatardims' && trim($mybb->input['upsetting'][$field]) == ""))
+				if(trim($mybb->input['upsetting'][$field]) != "")
 				{
-					// If pipe (|) is used normalize to 'x'
-					$mybb->input['upsetting'][$field] = str_replace('|', 'x', my_strtolower($mybb->input['upsetting'][$field]));
-				}
-				else
-				{
-					flash_message($lang->sprintf($lang->error_format_dimension, $lang->{'error_field_'.$field}), 'error');
-					admin_redirect("index.php?module=config-settings&action=change&gid=".$gid);
+					if(preg_match("/\b\d+[|x]{1}\d+\b/i", $mybb->input['upsetting'][$field]))
+					{
+						// If pipe (|) is used normalize to 'x'
+						$mybb->input['upsetting'][$field] = str_replace('|', 'x', my_strtolower($mybb->input['upsetting'][$field]));
+					}
+					else
+					{
+						flash_message($lang->sprintf($lang->error_format_dimension, $lang->{'error_field_'.$field}), 'error');
+						admin_redirect("index.php?module=config-settings&action=change&gid=".$gid);
+					}
 				}
 			}
 		}

--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -929,6 +929,30 @@ if($mybb->input['action'] == "change")
 			$lang->success_settings_updated .= $lang->sprintf($lang->success_settings_updated_hiddencaptchaimage, htmlspecialchars_uni($mybb->input['upsetting']['hiddencaptchaimagefield']), htmlspecialchars_uni($wrong_value));
 		}
 
+		// Validate avatar dimension inputs
+		$gid = (int)$mybb->input['gid'];
+		$dimfields = array(
+			8 => array('postmaxavatarsize'),
+			10 => array('useravatardims', 'maxavatardims'),
+			13 => array('memberlistmaxavatarsize')
+		);
+		if(in_array($gid, array_keys($dimfields)))
+		{
+			foreach($dimfields[$gid] as $field)
+			{
+				if(preg_match("/\b\d+[|x]{1}\d+\b/i", $mybb->input['upsetting'][$field]) || ($field == 'maxavatardims' && trim($mybb->input['upsetting'][$field]) == ""))
+				{
+					// If pipe (|) is used normalize to 'x'
+					$mybb->input['upsetting'][$field] = str_replace('|', 'x', my_strtolower($mybb->input['upsetting'][$field]));
+				}
+				else
+				{
+					flash_message($lang->sprintf($lang->error_format_dimension, $lang->{'error_field_'.$field}), 'error');
+					admin_redirect("index.php?module=config-settings&action=change&gid=".$gid);
+				}
+			}
+		}
+
 		// Have we opted for a reCAPTCHA and not set a public/private key?
 		if((isset($mybb->input['upsetting']['captchaimage']) && in_array($mybb->input['upsetting']['captchaimage'], array(4, 5)) && (!$mybb->input['upsetting']['captchaprivatekey'] || !$mybb->input['upsetting']['captchapublickey']))
 		   || (in_array($mybb->settings['captchaimage'], array(4, 5)) && (!$mybb->settings['captchaprivatekey'] || !$mybb->settings['captchapublickey'])))

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -645,7 +645,7 @@ if($mybb->input['action'] == "edit")
 						}
 
 						// Because Gravatars are square, hijack the width
-						list($maxwidth, $maxheight) = explode("x", my_strtolower($mybb->settings['maxavatardims']));
+						list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
 
 						$s = "?s={$maxwidth}";
 						$maxheight = (int)$maxwidth;
@@ -693,7 +693,7 @@ if($mybb->input['action'] == "edit")
 						{
 							if($width && $height && $mybb->settings['maxavatardims'] != "")
 							{
-								list($maxwidth, $maxheight) = explode("x", my_strtolower($mybb->settings['maxavatardims']));
+								list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
 								if(($maxwidth && $width > $maxwidth) || ($maxheight && $height > $maxheight))
 								{
 									$lang->error_avatartoobig = $lang->sprintf($lang->error_avatartoobig, $maxwidth, $maxheight);
@@ -977,13 +977,13 @@ EOF;
 	$table->construct_header($lang->general_account_stats, array('colspan' => '2', 'class' => 'align_center'));
 
 	// Avatar
-	$avatar_dimensions = explode("|", $user['avatardimensions']);
+	$avatar_dimensions = preg_split('/[|x]/', $user['avatardimensions']);
 	if($user['avatar'] && (my_strpos($user['avatar'], '://') === false || $mybb->settings['allowremoteavatars']))
 	{
 		if($user['avatardimensions'])
 		{
 			require_once MYBB_ROOT."inc/functions_image.php";
-			list($width, $height) = explode("|", $user['avatardimensions']);
+			list($width, $height) = preg_split('/[|x]/', $user['avatardimensions']);
 			$scaled_dimensions = scale_image($width, $height, 120, 120);
 		}
 		else
@@ -1513,7 +1513,7 @@ EOF;
 
 	if($mybb->settings['maxavatardims'] != "")
 	{
-		list($max_width, $max_height) = explode("x", my_strtolower($mybb->settings['maxavatardims']));
+		list($max_width, $max_height) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
 		$max_size = "<br />{$lang->max_dimensions_are} {$max_width}x{$max_height}";
 	}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3174,11 +3174,11 @@ function format_avatar($avatar, $dimensions = '', $max_dimensions = '')
 
 	if($dimensions)
 	{
-		$dimensions = explode("|", $dimensions);
+		$dimensions = preg_split('/[|x]/', $dimensions);
 
 		if($dimensions[0] && $dimensions[1])
 		{
-			list($max_width, $max_height) = explode('x', $max_dimensions);
+			list($max_width, $max_height) = preg_split('/[|x]/', $max_dimensions);
 
 			if(!empty($max_dimensions) && ($dimensions[0] > $max_width || $dimensions[1] > $max_height))
 			{

--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -250,7 +250,7 @@ function upload_avatar($avatar=array(), $uid=0)
 	// Check avatar dimensions
 	if($mybb->settings['maxavatardims'] != '')
 	{
-		list($maxwidth, $maxheight) = @explode("x", $mybb->settings['maxavatardims']);
+		list($maxwidth, $maxheight) = @preg_split('/[|x]/', $mybb->settings['maxavatardims']);
 		if(($maxwidth && $img_dimensions[0] > $maxwidth) || ($maxheight && $img_dimensions[1] > $maxheight))
 		{
 			// Automatic resizing enabled?

--- a/inc/languages/english/admin/config_settings.lang.php
+++ b/inc/languages/english/admin/config_settings.lang.php
@@ -68,6 +68,11 @@ $l['settings_search'] = "Search For Settings";
 $l['confirm_setting_group_deletion'] = "Are you sure you wish to delete this setting group?";
 $l['confirm_setting_deletion'] = "Are you sure you wish to delete this setting?";
 
+$l['error_format_dimension'] = "Defined {1} format is invalid.";
+$l['error_field_postmaxavatarsize'] = "Maximum Avatar Dimensions";
+$l['error_field_useravatardims'] = "Default Avatar Dimensions";
+$l['error_field_maxavatardims'] = "Maximum Avatar Dimensions";
+$l['error_field_memberlistmaxavatarsize'] = "Maximum Display Avatar Dimensions";
 $l['error_missing_title'] = "You did not enter a title for this setting";
 $l['error_missing_group_title'] = "You did not enter a title for this setting group";
 $l['error_invalid_gid'] = "You did not select a valid group to place this setting in";

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -737,7 +737,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="postmaxavatarsize">
 			<title>Maximum Avatar Dimensions in Posts</title>
-			<description><![CDATA[The maximum dimensions for avatars when being displayed in a post. If an avatar is too large, it will automatically be scaled down.]]></description>
+			<description><![CDATA[The maximum dimensions for avatars when being displayed in a post (width and height separated by 'x' or '|') . If an avatar is too large, it will automatically be scaled down.]]></description>
 			<disporder>4</disporder>
 			<optionscode><![CDATA[text]]></optionscode>
 			<settingvalue><![CDATA[55x55]]></settingvalue>
@@ -1128,7 +1128,7 @@ min=0]]></optionscode>
 		</setting>
 		<setting name="useravatardims">
 			<title>Default Avatar Dimensions</title>
-			<description><![CDATA[The dimensions of the default avatar; width by height (e.g. 40|40).]]></description>
+			<description><![CDATA[The dimensions of the default avatar; width and height separated by 'x' or '|' (e.g. 40|40 or 40x40).]]></description>
 			<disporder>11</disporder>
 			<optionscode><![CDATA[text]]></optionscode>
 			<settingvalue><![CDATA[100|100]]></settingvalue>
@@ -1155,7 +1155,7 @@ x=X]]></optionscode>
 		</setting>
 		<setting name="maxavatardims">
 			<title>Maximum Avatar Dimensions</title>
-			<description><![CDATA[The maximum dimensions that an avatar can be, in the format of width<b>x</b>height. If this is left blank then there will be no dimension restriction.]]></description>
+			<description><![CDATA[The maximum dimensions that an avatar can be, width and height separated by 'x' or '|'. If this is left blank then there will be no dimension restriction.]]></description>
 			<disporder>13</disporder>
 			<optionscode><![CDATA[text]]></optionscode>
 			<settingvalue><![CDATA[100x100]]></settingvalue>
@@ -1514,7 +1514,7 @@ descending=Descending]]></optionscode>
 		</setting>
 		<setting name="memberlistmaxavatarsize">
 			<title>Maximum Display Avatar Dimensions</title>
-			<description><![CDATA[The maximum dimensions for avatars when being displayed in the member list. If an avatar is too large, it will automatically be scaled down.]]></description>
+			<description><![CDATA[The maximum dimensions for avatars when being displayed in the member list, width & height separated by 'x' or '|'. If an avatar is too large, it will automatically be scaled down.]]></description>
 			<disporder>5</disporder>
 			<optionscode><![CDATA[text]]></optionscode>
 			<settingvalue><![CDATA[70x70]]></settingvalue>

--- a/install/resources/upgrade12.php
+++ b/install/resources/upgrade12.php
@@ -1280,8 +1280,6 @@ function upgrade12_dbchanges5()
 		$view_count++;
 	}
 
-	//$avatardimensions = str_replace('x', '|', my_strtolower($mybb->settings['postmaxavatarsize']));
-
 	$db->simple_select("users", "uid", "avatar != '' AND avatardimensions = ''");
 	while($user = $db->fetch_array($query))
 	{

--- a/install/resources/upgrade12.php
+++ b/install/resources/upgrade12.php
@@ -1280,7 +1280,7 @@ function upgrade12_dbchanges5()
 		$view_count++;
 	}
 
-	$avatardimensions = str_replace('x', '|', my_strtolower($mybb->settings['postmaxavatarsize']));
+	//$avatardimensions = str_replace('x', '|', my_strtolower($mybb->settings['postmaxavatarsize']));
 
 	$db->simple_select("users", "uid", "avatar != '' AND avatardimensions = ''");
 	while($user = $db->fetch_array($query))

--- a/usercp.php
+++ b/usercp.php
@@ -2333,7 +2333,7 @@ if($mybb->input['action'] == "do_avatar" && $mybb->request_method == "post")
 			}
 
 			// Because Gravatars are square, hijack the width
-			list($maxwidth, $maxheight) = explode("x", my_strtolower($mybb->settings['maxavatardims']));
+			list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
 			$maxheight = (int)$maxwidth;
 
 			// Rating?
@@ -2391,7 +2391,7 @@ if($mybb->input['action'] == "do_avatar" && $mybb->request_method == "post")
 			{
 				if($width && $height && $mybb->settings['maxavatardims'] != "")
 				{
-					list($maxwidth, $maxheight) = explode("x", my_strtolower($mybb->settings['maxavatardims']));
+					list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
 					if(($maxwidth && $width > $maxwidth) || ($maxheight && $height > $maxheight))
 					{
 						$lang->error_avatartoobig = $lang->sprintf($lang->error_avatartoobig, $maxwidth, $maxheight);
@@ -2454,7 +2454,7 @@ if($mybb->input['action'] == "avatar")
 
 	if($mybb->settings['maxavatardims'] != "")
 	{
-		list($maxwidth, $maxheight) = explode("x", my_strtolower($mybb->settings['maxavatardims']));
+		list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
 		$lang->avatar_note .= "<br />".$lang->sprintf($lang->avatar_note_dimensions, $maxwidth, $maxheight);
 	}
 


### PR DESCRIPTION
Attempt to fix #3192 

Added flexibility in defining and usage of avatar dimensions:
- Added validation while setting dimensions through ACP
- Modified ACP settings description to define both separator usage is acceptable.
- Modified width - height separation process (used `preg_split()` in place of `explode()`) to generate values when any of the two separators is used.