### PR TITLE
Fixes #3359 Settings `gid` is blank in ACP settings search page

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1158,10 +1158,6 @@ if($mybb->input['action'] == "change")
 			$page->add_breadcrumb_item($lang->settings_search);
 			$page->output_header($lang->board_settings." - {$lang->settings_search}");
 		}
-
-		$form = new Form("index.php?module=config-settings&amp;action=change", "post", "change");
-
-		echo $form->generate_hidden_field("gid", $group['gid']);
 	}
 	elseif($mybb->input['gid'])
 	{
@@ -1198,10 +1194,6 @@ if($mybb->input['action'] == "change")
 		// Page header
 		$page->add_breadcrumb_item($groupinfo['title']);
 		$page->output_header($lang->board_settings." - {$groupinfo['title']}");
-
-		$form = new Form("index.php?module=config-settings&amp;action=change", "post", "change");
-
-		echo $form->generate_hidden_field("gid", $groupinfo['gid']);
 	}
 	else
 	{
@@ -1228,14 +1220,14 @@ if($mybb->input['action'] == "change")
 		// Page header
 		$page->add_breadcrumb_item($lang->show_all_settings);
 		$page->output_header($lang->board_settings." - {$lang->show_all_settings}");
-
-		$form = new Form("index.php?module=config-settings&amp;action=change", "post", "change");
 	}
 
-	// Build rest of page
-	$buttons[] = $form->generate_submit_button($lang->save_settings);
+	// Build individual forms as per settings group
 	foreach($cache_groups as $groupinfo)
 	{
+		$form = new Form("index.php?module=config-settings&amp;action=change", "post", "change");
+		echo $form->generate_hidden_field("gid", $groupinfo['gid']);
+		$buttons = array($form->generate_submit_button($lang->save_settings));
 		$group_lang_var = "setting_group_{$groupinfo['name']}";
 		if(isset($lang->$group_lang_var))
 		{
@@ -1522,9 +1514,9 @@ if($mybb->input['action'] == "change")
 		$form_container->end();
 
 		$form->output_submit_wrapper($buttons);
+		$form->end();
 		echo '<br />';
 	}
-	$form->end();
 
 	print_setting_peekers();
 


### PR DESCRIPTION
Attempt to fix #3359 

- Individual form generation per settings group against search
- Enabling form-wise settings `gid` value.