### PR TITLE
Fixes #3058 File Verification can wrongly parse mybb.com responses

### DIFF
--- a/admin/modules/tools/file_verification.php
+++ b/admin/modules/tools/file_verification.php
@@ -36,7 +36,7 @@ if(!$mybb->input['action'])
 
 		$page->output_header($lang->file_verification." - ".$lang->checking);
 
-		$file = explode("\n", fetch_remote_file("https://mybb.com/checksums/release_mybb_{$mybb->version_code}.txt"));
+		$file = explode("\n", @file_get_contents("https://mybb.com/checksums/release_mybb_{$mybb->version_code}.txt"));
 
 		if(strstr($file[0], "<?xml") !== false || empty($file[0]))
 		{


### PR DESCRIPTION
Attempt to fix #3058

Using `file_get_contents( )` in place of `fetch_remote_file( )` to avoid accumulating unwanted garbage error page codes resulting to trigger the condition check `empty($file[0])` properly.

_Test result with 1.8.18 pre-release (where checksum file is missing remotely)_

Using `fetch_remote_file( )`:

![snap](https://image.ibb.co/dCped9/Untitled_3.png)

Using `file_get_contents( )`:

![snap](https://image.ibb.co/hKVD5p/Untitled_2.png)