### PR TITLE
Nav template conversion

### DIFF
--- a/archive/global.php
+++ b/archive/global.php
@@ -175,10 +175,6 @@ $lang->load("global");
 $lang->load("messages");
 $lang->load("archive");
 
-// Draw up the basic part of our naviagation
-$navbits[0]['name'] = $mybb->settings['bbname_orig'];
-$navbits[0]['url'] = $mybb->settings['bburl']."/archive/index.php";
-
 // Check banned ip addresses
 if(is_banned_ip($session->ipaddress))
 {

--- a/archive/index.php
+++ b/archive/index.php
@@ -112,7 +112,7 @@ switch($action)
 		check_forum_password_archive($forum['fid']);
 
 		// Build the navigation
-		build_forum_breadcrumb($forum['fid'], 1);
+		build_forum_breadcrumb($forum['fid']);
 		add_breadcrumb($thread['subject']);
 
 		archive_header($thread['subject'], $thread['subject'], $mybb->settings['bburl']."/".get_thread_link($thread['tid'], $page));
@@ -253,7 +253,7 @@ switch($action)
 		$threadcount = $db->fetch_field($query, "threads");
 
 		// Build the navigation
-		build_forum_breadcrumb($forum['fid'], 1);
+		build_forum_breadcrumb($forum['fid']);
 
 		// No threads and not a category? Error!
 		if($forum['type'] != 'c')

--- a/global.php
+++ b/global.php
@@ -674,11 +674,6 @@ if ($mybb->user['uid'] > 0 && $mybb->user['dstcorrection'] == 2) {
     ]);
 }
 
-// Add our main parts to the navigation
-$navbits = array();
-$navbits[0]['name'] = $mybb->settings['bbname_orig'];
-$navbits[0]['url'] = $mybb->settings['bburl'].'/index.php';
-
 // Set the link to the archive.
 $archive_url = build_archive_link();
 

--- a/global.php
+++ b/global.php
@@ -15,7 +15,6 @@ if (!$working_dir) {
 
 // Load main MyBB core file which begins all of the magic
 require_once $working_dir.'/inc/init.php';
-require_once $working_dir.'/inc/src/bootstrap.php';
 
 $shutdown_queries = $shutdown_functions = array();
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3494,38 +3494,6 @@ function fix_mktime($format, $year)
 }
 
 /**
- * Build the breadcrumb navigation trail from the specified items
- *
- * @return string The formatted breadcrumb navigation trail
- */
-function build_breadcrumb()
-{
-    global $nav, $navbits, $theme, $lang, $mybb;
-
-    /** @var \MyBB\Utilities\BreadcrumbManager $breadcrumbManager */
-    $breadcrumbManager = \MyBB\app(\MyBB\Utilities\BreadcrumbManager::class);
-
-    foreach ($breadcrumbManager as $key => $navbit) {
-        if (!empty($navbit['multipage'])) {
-            if (!$mybb->settings['threadsperpage'] || (int)$mybb->settings['threadsperpage'] < 1) {
-                $mybb->settings['threadsperpage'] = 20;
-            }
-
-            $navbit['pagination'] = multipage($navbit['multipage']['num_threads'], $mybb->settings['threadsperpage'], $navbit['multipage']['current_page'], $navbit['multipage']['url'], true);
-        }
-
-        // Replace page 1 URLs
-        $navbit['url'] = str_replace("-page-1.html", ".html", $navbit['url']);
-        $navbit['url'] = preg_replace("/&amp;page=1$/", "", $navbit['url']);
-        $navbits[$key] = $navbit;
-    }
-
-    return \MyBB\template('partials/breadcrumb.twig', [
-        'navbits' => $breadcrumbManager,
-    ]);
-}
-
-/**
  * Add a breadcrumb menu item to the list.
  *
  * @param string $name The name of the item to add
@@ -3539,7 +3507,7 @@ function add_breadcrumb($name, $url="")
 }
 
 /**
- * Build the forum breadcrumb nagiation (the navigation to a specific forum including all parent forums)
+ * Build the forum breadcrumb navigation (the navigation to a specific forum including all parent forums)
  *
  * @param int $fid The forum ID to build the navigation for
  * @param array $multipage The multipage drop down array of information

--- a/inc/functions_archive.php
+++ b/inc/functions_archive.php
@@ -84,38 +84,25 @@ function archive_header($title="", $fulltitle="", $fullurl="")
  */
 function archive_navigation()
 {
-	global $navbits, $mybb, $lang;
+    /** @var \MyBB\Utilities\BreadcrumbManager $breadcrumbManager */
+    $breadcrumbManager = \MyBB\app(\MyBB\Utilities\BreadcrumbManager::class);
 
-	$navsep = " &gt; ";
-	$nav = $activesep = '';
-	if(is_array($navbits))
-	{
-		reset($navbits);
-		foreach($navbits as $key => $navbit)
-		{
-			if(!empty($navbits[$key+1]))
-			{
-				if(!empty($navbits[$key+2]))
-				{
-					$sep = $navsep;
-				}
-				else
-				{
-					$sep = "";
-				}
-				$nav .= "<a href=\"".$navbit['url']."\">".$navbit['name']."</a>$sep";
-			}
-		}
-	}
-	$navsize = count($navbits);
-	$navbit = $navbits[$navsize-1];
-	if(!empty($nav))
-	{
-		$activesep = $navsep;
-	}
-	$nav .= $activesep.$navbit['name'];
+    $nav = '';
+    $sep = '';
 
-	return $nav;
+    for ($i = 0; $i < $breadcrumbManager->count(); $i++) {
+        $nav .= $sep;
+
+        if ($i < $breadcrumbManager->count() - 1) {
+            $nav .= '<a href="'. $breadcrumbManager[$i]['url'] .'">'. $breadcrumbManager[$i]['name'] .'</a>';
+        } else {
+            $nav .= $breadcrumbManager[$i]['name'];
+        }
+
+        $sep = ' &gt; ';
+    }
+
+    return $nav;
 }
 
 /**

--- a/inc/init.php
+++ b/inc/init.php
@@ -300,3 +300,4 @@ $time_formats = array(
 	3 => "H:i"
 );
 
+require_once __DIR__.'/src/bootstrap.php';

--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -365,7 +365,7 @@ class CoreExtension extends \Twig_Extension
     public function removePageOne(string $url): string
     {
         $url = str_replace('-page-1.html', '.html', $url);
-        $url = str_replace('/&amp;page=1$/', '', $url);
+        $url = preg_replace('/&amp;page=1$/', '', $url);
 
         return $url;
     }

--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -26,9 +26,12 @@ class CoreExtension extends \Twig_Extension
      */
     protected $breadcrumbManager;
 
-    public function __construct(\MyBB $mybb, \MyLanguage $lang, ?\pluginSystem $plugins,
-        BreadcrumbManager $breadcrumbManager)
-    {
+    public function __construct(
+        \MyBB $mybb,
+        \MyLanguage $lang,
+        ?\pluginSystem $plugins,
+        BreadcrumbManager $breadcrumbManager
+    ) {
         $this->mybb = $mybb;
         $this->lang = $lang;
         $this->plugins = $plugins;

--- a/inc/src/Utilities/BreadcrumbManager.php
+++ b/inc/src/Utilities/BreadcrumbManager.php
@@ -7,7 +7,7 @@ use Traversable;
 /**
  * The breadcrumb manager manages breadcrumb navigation.
  */
-class BreadcrumbManager implements \IteratorAggregate
+class BreadcrumbManager implements \IteratorAggregate, \ArrayAccess
 {
     /**
      * The root URL to the site.
@@ -140,6 +140,16 @@ class BreadcrumbManager implements \IteratorAggregate
     }
 
     /**
+     * Get the number of items in the breadcrumb list.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return count($this->breadcrumbs);
+    }
+
+    /**
      * Retrieve an external iterator
      *
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
@@ -150,5 +160,83 @@ class BreadcrumbManager implements \IteratorAggregate
     public function getIterator()
     {
         return new \ArrayIterator($this->breadcrumbs);
+    }
+
+    /**
+     * Whether a offset exists
+     *
+     * @link https://php.net/manual/en/arrayaccess.offsetexists.php
+     *
+     * @param mixed $offset <p>
+     * An offset to check for.
+     * </p>
+     *
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->breadcrumbs[$offset]);
+    }
+
+    /**
+     * Offset to retrieve
+     *
+     * @link https://php.net/manual/en/arrayaccess.offsetget.php
+     *
+     * @param mixed $offset <p>
+     * The offset to retrieve.
+     * </p>
+     *
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->breadcrumbs[$offset]) ? $this->breadcrumbs[$offset] : null;
+    }
+
+    /**
+     * Offset to set
+     *
+     * @link https://php.net/manual/en/arrayaccess.offsetset.php
+     *
+     * @param mixed $offset <p>
+     * The offset to assign the value to.
+     * </p>
+     * @param mixed $value <p>
+     * The value to set.
+     * </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->breadcrumbs[] = $value;
+        } else {
+            $this->breadcrumbs[$offset] = $value;
+        }
+    }
+
+    /**
+     * Offset to unset
+     *
+     * @link https://php.net/manual/en/arrayaccess.offsetunset.php
+     *
+     * @param mixed $offset <p>
+     * The offset to unset.
+     * </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->breadcrumbs[$offset]);
     }
 }

--- a/inc/src/Utilities/BreadcrumbManager.php
+++ b/inc/src/Utilities/BreadcrumbManager.php
@@ -95,11 +95,9 @@ class BreadcrumbManager implements \IteratorAggregate, \ArrayAccess
     public function buildForumBreadcrumb(int $fid, array $multiPage = [])
     {
         if (empty($this->forumCache)) {
-            // TODO: We want to eradicate globals eventually, but for now this is the best way to do this
             // NOTE: The below call to `cache_forums` will not rebuild the cache if it already exists -
             //  it is simply used here to ensure it exists.
-            cache_forums();
-            $forumCache = $GLOBALS['forum_cache'];
+            $forumCache = cache_forums();
 
             foreach ($forumCache as $key => $val) {
                 $this->forumCache[$val['fid']][$val['pid']] = $val;
@@ -110,7 +108,7 @@ class BreadcrumbManager implements \IteratorAggregate, \ArrayAccess
             foreach ($this->forumCache[$fid] as $key => $forumNav) {
                 if ($fid == $forumNav['fid']) {
                     if (!empty($this->forumCache[$forumNav['pid']])) {
-                        build_forum_breadcrumb($forumNav['pid']);
+                        $this->buildForumBreadcrumb((int) $forumNav['pid']);
                     }
 
                     $newEntry = [

--- a/inc/src/Utilities/BreadcrumbManager.php
+++ b/inc/src/Utilities/BreadcrumbManager.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace MyBB\Utilities;
+
+use Traversable;
+
+/**
+ * The breadcrumb manager manages breadcrumb navigation.
+ */
+class BreadcrumbManager implements \IteratorAggregate
+{
+    /**
+     * The root URL to the site.
+     *
+     * @var string $boardUrl
+     */
+    protected $boardUrl;
+
+    /**
+     * The current trail of breadcrumbs.
+     *
+     * @var array $breadcrumbs
+     */
+    protected $breadcrumbs;
+
+    /**
+     * A cache of forum details.
+     *
+     * @var array $forumCache
+     */
+    protected $forumCache;
+
+    /**
+     * Create a new breadcrumb manager with the given site name and index URL.
+     *
+     * The site name and index URL will be used as the first elements in the breadcrumb trail.
+     *
+     * @param string $boardName The name of the site.
+     * @param string $boardUrl The URL to the index of the site.
+     */
+    public function __construct(string $boardName, string $boardUrl)
+    {
+        $this->boardUrl = $boardUrl;
+
+        $this->breadcrumbs = [
+            [
+                'name' => $boardName,
+                'url' => $boardUrl .'/index.php',
+            ],
+        ];
+
+        $this->forumCache = [];
+    }
+
+    /**
+     * Add a breadcrumb menu item to the list.
+     *
+     * @param string $name The name of the item to add.
+     * @param string $url The URL of the item to add.
+     */
+    public function addBreadcrumb(string $name, string $url = '')
+    {
+        $this->breadcrumbs[] = [
+            'name' => $name,
+            'url' => $url,
+        ];
+    }
+
+    /**
+     * Reset the breadcrumb navigation to the first item, and clear all other entries.
+     */
+    public function reset()
+    {
+        $this->breadcrumbs = array_slice($this->breadcrumbs, 0, 1);
+    }
+
+    /**
+     * Build the forum breadcrumb navigation (the navigation to a specific forum including all parent forums).
+     *
+     * @param int $fid The forum ID to build the navigation for.
+     * @param array $multiPage The multi-page drop down array of information.
+     */
+    public function buildForumBreadcrumb(int $fid, array $multiPage = [])
+    {
+        if (empty($this->forumCache)) {
+            // TODO: We want to eradicate globals eventually, but for now this is the best way to do this
+            // NOTE: The below call to `cache_forums` will not rebuild the cache if it already exists -
+            //  it is simply used here to ensure it exists.
+            cache_forums();
+            $forumCache = $GLOBALS['forum_cache'];
+
+            foreach ($forumCache as $key => $val) {
+                $this->forumCache[$val['fid']][$val['pid']] = $val;
+            }
+        }
+
+        if (is_array($this->forumCache[$fid])) {
+            foreach ($this->forumCache[$fid] as $key => $forumNav) {
+                if ($fid == $forumNav['fid']) {
+                    if (!empty($this->forumCache[$forumNav['pid']])) {
+                        build_forum_breadcrumb($forumNav['pid']);
+                    }
+
+                    $newEntry = [
+                        'name' => preg_replace("#&(?!\#[0-9]+;)#si", "&amp;", $forumNav['name']),
+                    ];
+
+                    if (defined("IN_ARCHIVE")) {
+                        // Set up link to forum in breadcrumb.
+                        if ($this->forumCache[$fid][$forumNav['pid']]['type'] == 'f' ||
+                            $this->forumCache[$fid][$forumNav['pid']]['type'] == 'c') {
+                            $newEntry['url'] = "forum-{$forumNav['fid']}.html";
+                        } else {
+                            $newEntry['url'] = $this->boardUrl.'/archive/index.php';
+                        }
+                    } elseif (!empty($multiPage)) {
+                        $newEntry['url'] = get_forum_link($forumNav['fid'], $multiPage['current_page']);
+                        $newEntry['multipage'] = $multiPage;
+                        $newEntry['multipage']['url'] = str_replace('{fid}', $forumNav['fid'], FORUM_URL_PAGED);
+                    } else {
+                        $newEntry['url'] = get_forum_link($forumNav['fid']);
+                    }
+
+                    $this->breadcrumbs[] = $newEntry;
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieve an external iterator
+     *
+     * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
+     * @return Traversable An instance of an object implementing <b>Iterator</b> or
+     * <b>Traversable</b>
+     * @since 5.0.0
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->breadcrumbs);
+    }
+}

--- a/inc/src/Utilities/BreadcrumbManager.php
+++ b/inc/src/Utilities/BreadcrumbManager.php
@@ -7,7 +7,7 @@ use Traversable;
 /**
  * The breadcrumb manager manages breadcrumb navigation.
  */
-class BreadcrumbManager implements \IteratorAggregate, \ArrayAccess
+class BreadcrumbManager implements \IteratorAggregate, \ArrayAccess, \Countable
 {
     /**
      * The root URL to the site.

--- a/inc/src/Utilities/BreadcrumbManager.php
+++ b/inc/src/Utilities/BreadcrumbManager.php
@@ -53,6 +53,18 @@ class BreadcrumbManager implements \IteratorAggregate
     }
 
     /**
+     * Get the raw breadcrumb items.
+     *
+     * The breadcrumbs are returned by reference, allowing them to be manually edited by plugins and elsewhere.
+     *
+     * @return array
+     */
+    public function &getBreadcrumbs(): array
+    {
+        return $this->breadcrumbs;
+    }
+
+    /**
      * Add a breadcrumb menu item to the list.
      *
      * @param string $name The name of the item to add.

--- a/inc/src/bootstrap.php
+++ b/inc/src/bootstrap.php
@@ -50,7 +50,7 @@ $container->singleton(BreadcrumbManager::class, function (ContainerInterface $co
     $mybb = $container[\MyBB::class];
 
     return new BreadcrumbManager(
-        $mybb->settings['bbname_orig'],
+        $mybb->settings['bbname'],
         $mybb->settings['bburl']
     );
 });

--- a/inc/src/bootstrap.php
+++ b/inc/src/bootstrap.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Router;
 use MyBB\Twig\Extensions\CoreExtension;
 use MyBB\Twig\Extensions\LangExtension;
 use MyBB\Twig\Extensions\ThemeExtension;
+use MyBB\Utilities\BreadcrumbManager;
 use Psr\Container\ContainerInterface;
 
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -43,6 +44,19 @@ $container->singleton(\MyLanguage::class, function () {
 
 $container->alias(\MyLanguage::class, 'lang');
 
+// Breadcrumb
+$container->singleton(BreadcrumbManager::class, function (ContainerInterface $container) {
+    /** @var \MyBB $mybb */
+    $mybb = $container[\MyBB::class];
+
+    return new BreadcrumbManager(
+        $mybb->settings['bbname_orig'],
+        $mybb->settings['bburl']
+    );
+});
+
+$container->alias(BreadcrumbManager::class, 'breadcrumbs');
+
 // Twig
 $container->singleton(\Twig_Environment::class, function (ContainerInterface $container) {
     if (defined('IN_ADMINCP')) {
@@ -77,7 +91,14 @@ $container->singleton(\Twig_Environment::class, function (ContainerInterface $co
     /** @var \MyLanguage $lang */
     $lang = $container->get(\MyLanguage::class);
 
-    $env->addExtension(new CoreExtension($mybb, $lang, $container->get(\pluginSystem::class)));
+    $env->addExtension(
+        new CoreExtension(
+            $mybb,
+            $lang,
+            $container[\pluginSystem::class],
+            $container[BreadcrumbManager::class]
+        )
+    );
     $env->addExtension(new ThemeExtension($mybb, $container->get(\DB_Base::class)));
     $env->addExtension(new LangExtension($lang));
 

--- a/inc/views/base/partials/breadcrumb.twig
+++ b/inc/views/base/partials/breadcrumb.twig
@@ -14,7 +14,7 @@
         {# Separator #}
         {% if loop.first != true and loop.last != true %}
             &rsaquo;
-        {% elseif loop.last %}
+        {% elseif loop.last and loop.length > 1 %}
             <br /><img src="{{ theme.imgdir }}/nav_bit.png" alt="" />
         {% endif %}
 

--- a/inc/views/base/partials/breadcrumb.twig
+++ b/inc/views/base/partials/breadcrumb.twig
@@ -1,20 +1,27 @@
 <div class="navigation">
-    {% for bit in navbits %}
-    	{# Pagination #}
-        {% if bit.pagination %}
-            <img src="{{ theme.imgdir }}/arrow_down.png" alt="v" title="" class="pagination_breadcrumb_link" id="breadcrumb_multipage" />{{ bit.pagination|raw }}
+    {% for crumb in breadcrumbs %}
+        {% if crumb.multipage is not empty %}
+            {% if not mybb.settings.threadsperpage or mybb.settings.threadsperpage < 1 %}
+                {% set perPage = 20 %}
+            {% else %}
+                {% set perPage = mybb.settings.threadsperpage %}
+            {% endif %}
+
+            {# TODO: multipage() function once it is implemented in Twig... #}
         {% endif %}
+
         {# Separator #}
         {% if loop.first != true and loop.last != true %}
             &rsaquo;
         {% elseif loop.last %}
             <br /><img src="{{ theme.imgdir }}/nav_bit.png" alt="" />
         {% endif %}
+
         {# Breadcrumb bit #}
         {% if loop.last %}
-            <span class="active">{{ bit.name }}</span>
+            <span class="active">{{ crumb.name }}</span>
         {% else %}
-            <a href="{{ bit.url }}">{{ bit.name }}</a>
+            <a href="{{ crumb.url|remove_page_one }}">{{ crumb.name }}</a>
         {% endif %}
     {% endfor %}
 </div>

--- a/inc/views/base/partials/breadcrumb.twig
+++ b/inc/views/base/partials/breadcrumb.twig
@@ -7,7 +7,8 @@
                 {% set perPage = mybb.settings.threadsperpage %}
             {% endif %}
 
-            {# TODO: multipage() function once it is implemented in Twig... #}
+            {{ multi_page(crumb.multipage.num_threads, mybb.settings.threadsperpage,
+                crumb.multipage.current_page, crumb.multipage.url, true) }}
         {% endif %}
 
         {# Separator #}

--- a/inc/views/base/partials/breadcrumb.twig
+++ b/inc/views/base/partials/breadcrumb.twig
@@ -22,7 +22,7 @@
         {% if loop.last %}
             <span class="active">{{ crumb.name }}</span>
         {% else %}
-            <a href="{{ crumb.url|remove_page_one }}">{{ crumb.name }}</a>
+            <a href="{{ crumb.url|remove_page_one|raw }}">{{ crumb.name }}</a>
         {% endif %}
     {% endfor %}
 </div>

--- a/inc/views/base/partials/header.twig
+++ b/inc/views/base/partials/header.twig
@@ -69,4 +69,4 @@
                         {% include 'messages/' ~ template ~ '.twig' %}
                     {% endif %}
                 {% endfor %}
-                <navigation>
+                {{ build_breadcrumb_navigation() }}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true">
     <testsuites>
         <testsuite name="unit">

--- a/tests/Unit/Traits/LegacyCoreAwareTest.php
+++ b/tests/Unit/Traits/LegacyCoreAwareTest.php
@@ -36,6 +36,7 @@ trait LegacyCoreAwareTest
 
         $GLOBALS['mybb']->settings = [
             'bburl' => 'http://example.com',
+            'bbname' => 'Test Board',
         ];
 
         $cacheHandler = \Mockery::mock('CacheHandlerInterface');


### PR DESCRIPTION
For #2972, adaptation of #3386.

This uses a Twig function to render the breadcrumb, and adds a new `BreadcrumbManager` class to manage breadcrumbs.

This isn't yet complete, as I plan to add a `multipage` Twig function as part of this PR to use in the breadcrumb template. It also doesn't do anything with the nav on the archive pages, which will need some work.

Pinging @Shade- since he worked on the original nav template conversion.