### PR TITLE
Fix #3397 - Custom Profile Fields - Certain characters not escaped

### DIFF
--- a/usercp.php
+++ b/usercp.php
@@ -582,6 +582,7 @@ if($mybb->input['action'] == "profile")
 			}
 			elseif($type == "radio")
 			{
+				$userfield = htmlspecialchars_uni($userfield);
 				$expoptions = explode("\n", $options);
 				if(is_array($expoptions))
 				{
@@ -599,6 +600,7 @@ if($mybb->input['action'] == "profile")
 			}
 			elseif($type == "checkbox")
 			{
+				$userfield = htmlspecialchars_uni($userfield);
 				if($errors)
 				{
 					$useropts = $userfield;


### PR DESCRIPTION
Fixes #3397 Updated usercp.php on lines 585 and 603. Added htmlspecialchars_uni for $userfield to escape non-escaped options for checkboxes and radio buttons