### PR TITLE
Fix #3409 by moving my_hash_equals

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8896,3 +8896,37 @@ if(!function_exists('array_column'))
  		return $values;
 	}
 }
+
+/**
+ * Performs a timing attack safe string comparison.
+ *
+ * @param string $known_string The first string to be compared.
+ * @param string $user_string The second, user-supplied string to be compared.
+ * @return bool Result of the comparison.
+ */
+function my_hash_equals($known_string, $user_string)
+{
+	if(version_compare(PHP_VERSION, '5.6.0', '>='))
+	{
+		return hash_equals($known_string, $user_string);
+	}
+	else
+	{
+		$known_string_length = my_strlen($known_string);
+		$user_string_length = my_strlen($user_string);
+
+		if($user_string_length != $known_string_length)
+		{
+			return false;
+		}
+
+		$result = 0;
+
+		for($i = 0; $i < $known_string_length; $i++)
+		{
+			$result |= ord($known_string[$i]) ^ ord($user_string[$i]);
+		}
+
+		return $result === 0;
+	}
+}

--- a/inc/functions_archive.php
+++ b/inc/functions_archive.php
@@ -261,7 +261,7 @@ function check_forum_password_archive($fid, $pid=0)
 	$password = $forum_cache[$fid]['password'];
 	if($password)
 	{
-		if(!$mybb->cookies['forumpass'][$fid] || ($mybb->cookies['forumpass'][$fid] && !my_hash_equals(md5($mybb->user['uid'].$password), $mybb->cookies['forumpass'][$fid])))
+		if(!isset($mybb->cookies['forumpass'][$fid]) || !my_hash_equals(md5($mybb->user['uid'].$password), $mybb->cookies['forumpass'][$fid]))
 		{
 			archive_error_no_permission();
 		}

--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -145,7 +145,7 @@ function build_forumbits($pid=0, $depth=1)
 			if($forum['password'])
 			{
 				if(!isset($mybb->cookies['forumpass'][$forum['fid']]) || !my_hash_equals($mybb->cookies['forumpass'][$forum['fid']], md5($mybb->user['uid'].$forum['password'])))
-                {
+				{
 					$hideinfo = true;
 					$showlockicon = 1;
 				}

--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -142,10 +142,13 @@ function build_forumbits($pid=0, $depth=1)
 				);
 			}
 
-			if($forum['password'] != '' && !my_hash_equals($mybb->cookies['forumpass'][$forum['fid']], md5($mybb->user['uid'].$forum['password'])))
+			if($forum['password'])
 			{
-			    $hideinfo = true;
-			    $showlockicon = 1;
+				if(!isset($mybb->cookies['forumpass'][$forum['fid']]) || !my_hash_equals($mybb->cookies['forumpass'][$forum['fid']], md5($mybb->user['uid'].$forum['password'])))
+                {
+					$hideinfo = true;
+					$showlockicon = 1;
+				}
 			}
 
 			// Fetch subforums of this forum

--- a/inc/functions_search.php
+++ b/inc/functions_search.php
@@ -125,7 +125,7 @@ function get_unsearchable_forums($pid=0, $first=1)
 		$pwverified = 1;
 		if($forum['password'] != '')
 		{
-			if(!my_hash_equals($mybb->cookies['forumpass'][$forum['fid']], md5($mybb->user['uid'].$forum['password'])))
+			if(!isset($mybb->cookies['forumpass'][$forum['fid']]) || !my_hash_equals($mybb->cookies['forumpass'][$forum['fid']], md5($mybb->user['uid'].$forum['password'])))
 			{
 				$pwverified = 0;
 			}

--- a/inc/functions_user.php
+++ b/inc/functions_user.php
@@ -250,40 +250,6 @@ function verify_user_password($user, $password)
 }
 
 /**
- * Performs a timing attack safe string comparison.
- *
- * @param string $known_string The first string to be compared.
- * @param string $user_string The second, user-supplied string to be compared.
- * @return bool Result of the comparison.
- */
-function my_hash_equals($known_string, $user_string)
-{
-	if(version_compare(PHP_VERSION, '5.6.0', '>='))
-	{
-		return hash_equals($known_string, $user_string);
-	}
-	else
-	{
-		$known_string_length = my_strlen($known_string);
-		$user_string_length = my_strlen($user_string);
-
-		if($user_string_length != $known_string_length)
-		{
-			return false;
-		}
-
-		$result = 0;
-
-		for($i = 0; $i < $known_string_length; $i++)
-		{
-			$result |= ord($known_string[$i]) ^ ord($user_string[$i]);
-		}
-
-		return $result === 0;
-	}
-}
-
-/**
  * Generates a random salt
  *
  * @return string The salt.


### PR DESCRIPTION
Fixes #3409 and fixes #3410.

Moves `my_hash_equals` to `inc/functions.php` and checks that `$mybb->cookies['forumpass'][$forum['fid']]` is set. I haven't tested this, but it should work.