### PR TITLE
Fix #3241 .prop('checked') doesn't trigger change events

### DIFF
--- a/admin/inc/class_page.php
+++ b/admin/inc/class_page.php
@@ -108,7 +108,7 @@ class DefaultPage
 
 		echo "	<script type=\"text/javascript\" src=\"../jscripts/jquery.js?ver=1813\"></script>\n";
 		echo "	<script type=\"text/javascript\" src=\"../jscripts/jquery.plugins.min.js?ver=1813\"></script>\n";
-		echo "	<script type=\"text/javascript\" src=\"../jscripts/general.js?ver=1813\"></script>\n";
+		echo "	<script type=\"text/javascript\" src=\"../jscripts/general.js?ver=1820\"></script>\n";
 		echo "	<script type=\"text/javascript\" src=\"./jscripts/admincp.js\"></script>\n";
 		echo "	<script type=\"text/javascript\" src=\"./jscripts/tabs.js\"></script>\n";
 
@@ -392,7 +392,7 @@ lang.saved = \"{$lang->saved}\";
 <meta name="copyright" content="Copyright {$copy_year} MyBB Group." />
 <link rel="stylesheet" href="./styles/{$cp_style}/login.css" type="text/css" />
 <script type="text/javascript" src="../jscripts/jquery.js?ver=1813"></script>
-<script type="text/javascript" src="../jscripts/general.js?ver=1813"></script>
+<script type="text/javascript" src="../jscripts/general.js?ver=1820"></script>
 <script type="text/javascript" src="./jscripts/admincp.js"></script>
 <script type="text/javascript">
 //<![CDATA[
@@ -524,7 +524,7 @@ EOF;
 <meta name="copyright" content="Copyright {$copy_year} MyBB Group." />
 <link rel="stylesheet" href="./styles/{$cp_style}/login.css" type="text/css" />
 <script type="text/javascript" src="../jscripts/jquery.js?ver=1813"></script>
-<script type="text/javascript" src="../jscripts/general.js?ver=1813"></script>
+<script type="text/javascript" src="../jscripts/general.js?ver=1820"></script>
 <script type="text/javascript" src="./jscripts/admincp.js"></script>
 <script type="text/javascript">
 //<![CDATA[

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -14035,13 +14035,13 @@ $(function() {
 </html>]]></template>
 		<template name="debug_summary" version="1800"><![CDATA[<div id="debug">{$generated_in} {$debug_weight} <br />{$sql_queries} / {$server_load} / {$memory_usage}<br />[<a href="{$debuglink}" target="_blank">{$lang->debug_advanced_details}</a>]<br /></div>]]></template>
 		<template name="gobutton" version="120"><![CDATA[<input type="submit" class="button" value="{$lang->go}" />]]></template>
-		<template name="headerinclude" version="1817"><![CDATA[<link rel="alternate" type="application/rss+xml" title="{$lang->latest_threads} (RSS 2.0)" href="{$mybb->settings['bburl']}/syndication.php" />
+		<template name="headerinclude" version="1820"><![CDATA[<link rel="alternate" type="application/rss+xml" title="{$lang->latest_threads} (RSS 2.0)" href="{$mybb->settings['bburl']}/syndication.php" />
 <link rel="alternate" type="application/atom+xml" title="{$lang->latest_threads} (Atom 1.0)" href="{$mybb->settings['bburl']}/syndication.php?type=atom1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset={$charset}" />
 <meta http-equiv="Content-Script-Type" content="text/javascript" />
 <script type="text/javascript" src="{$mybb->asset_url}/jscripts/jquery.js?ver=1813"></script>
 <script type="text/javascript" src="{$mybb->asset_url}/jscripts/jquery.plugins.min.js?ver=1813"></script>
-<script type="text/javascript" src="{$mybb->asset_url}/jscripts/general.js?ver=1817"></script>
+<script type="text/javascript" src="{$mybb->asset_url}/jscripts/general.js?ver=1820"></script>
 
 {$stylesheets}
 <script type="text/javascript">

--- a/install/resources/output.php
+++ b/install/resources/output.php
@@ -66,7 +66,7 @@ class installerOutput {
 	<title>{$this->title} &gt; {$title}</title>
 	<link rel="stylesheet" href="stylesheet.css" type="text/css" />
 	<script type="text/javascript" src="../jscripts/jquery.js?ver=1813"></script>
-	<script type="text/javascript" src="../jscripts/general.js?ver=1813"></script>
+	<script type="text/javascript" src="../jscripts/general.js?ver=1820"></script>
 	{$dbconfig_add}
 </head>
 <body>

--- a/jscripts/general.js
+++ b/jscripts/general.js
@@ -17,17 +17,28 @@ var MyBB = {
 		$('[name="allbox"]').each(function(key, value) {
 			var allbox = this;
 			var checked = $(this).is(':checked');
-			var checkboxes = $(this).closest('form').find(':checkbox');
+			var checkboxes = $(this).closest('form').find(':checkbox').not('[name="allbox"]');
+
 			checkboxes.change(function() {
 				if(checked && !$(this).prop('checked'))
 				{
 					checked = false;
-					$(allbox).prop('checked', checked);
+					$(allbox).trigger('change', ['item']);
 				}
 			});
-			$(this).change(function() {
+
+			$(this).on('change', function(event, origin) {
 				checked = $(this).is(':checked');
-				checkboxes.prop('checked', checked);
+
+				if(typeof(origin) == "undefined")
+				{
+					checkboxes.each(function() {
+						if(checked != $(this).is(':checked'))
+						{
+							$(this).prop('checked', checked).change();
+						}
+					});
+				}
 			});
 		});
 


### PR DESCRIPTION
Fix #3241 

Changes to non-moderator functionality.

If "all" checkbox is used, item checkboxes are synchronized; after that it's unchecked when an item checkbox is unchecked (using `.trigger()` with extra parameter to distinguish the origin of this action).