### PR TITLE
fixes #3430 : ACP settings search option - hardcoded only for english language

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1145,18 +1145,41 @@ if($mybb->input['action'] == "change")
 		// Search for settings
 		$search = $db->escape_string_like($mybb->input['search']);
 		$query = $db->query("
-			SELECT s.*
+			SELECT s.* , g.name as gname, g.title as gtitle, g.description as gdescription
 			FROM ".TABLE_PREFIX."settings s
 			LEFT JOIN ".TABLE_PREFIX."settinggroups g ON(s.gid=g.gid)
-			WHERE s.name LIKE '%{$search}%' OR s.title LIKE '%{$search}%' OR s.description LIKE '%{$search}%' OR g.name LIKE '%{$search}%' OR g.title LIKE '%{$search}%' OR g.description LIKE '%{$search}%'
 			ORDER BY s.disporder
 		");
 		while($setting = $db->fetch_array($query))
 		{
-			$cache_settings[$setting['gid']][$setting['sid']] = $setting;
+			$lang_var = "setting_{$setting['name']}";
+			if(isset($lang->$lang_var))
+			{
+				$setting["title"] = $lang->$lang_var;
+			}
+			$lang_var = "setting_{$setting['name']}_desc";
+			if(isset($lang->$lang_var))
+			{
+				$setting["description"] = $lang->$lang_var;
+			}
+			$lang_var = "setting_group_{$setting['gname']}";
+			if(isset($lang->$lang_var))
+			{
+				$setting["gtitle"] = $lang->$lang_var;
+			}
+			$lang_var = "setting_group_{$setting['gname']}_desc";
+			if(isset($lang->$lang_var))
+			{
+				$setting["gdescription"] = $lang->$lang_var;
+			}
+			$lang_var = $setting["title"] . " " . $setting["description"] . " " . $setting["gtitle"] . " " . $setting["gdescription"];
+			$search = mb_convert_encoding($search, mb_detect_encoding($setting["title"], "auto"));
+			if (mb_stripos($lang_var, $search))
+			{
+				$cache_settings[$setting['gid']][$setting['sid']] = $setting;
+			}
 		}
-
-		if(!$db->num_rows($query))
+		if(!count($cache_settings))
 		{
 			if(isset($mybb->input['ajax_search']))
 			{


### PR DESCRIPTION
Fixes issue where ACP settings search option, has searched directly DB data (which is in english) without considering translation. Because of this, ACP options search feature didnt worked for any other language
than english.