### PR TITLE
fix check_thumbnail_memory to work with memory_limit in bytes without…

### DIFF
--- a/inc/functions_image.php
+++ b/inc/functions_image.php
@@ -178,7 +178,7 @@ function check_thumbnail_memory($width, $height, $type, $bitdepth, $channels)
 	}
 
 	$limit = preg_match("#^([0-9]+)\s?([kmg])b?$#i", trim(my_strtolower($memory_limit)), $matches);
-	$memory_limit = 0;
+	$memory_limit = (int)$memory_limit;
 	if($matches[1] && $matches[2])
 	{
 		switch($matches[2])


### PR DESCRIPTION
… k, m or g suffix

ini_get('memory_limit') can return limit in bytes (without suffix) or with k m or g suffix. check_thumbnail_memory() wrongly assumed that memory_limit without suffix is zero, thus leading to 500 internal server errors due to very low (negative!) value in ini_set("memory_limit").

Some hosting providers (beget.ru in my case) actually set memory_limit to number of bytes without suffix. I've found and fixed this bug on my local MyBB 1.6.10 install, but it seems to be present in current version as well, thus this pull request.

Fixes #3471 