### PR TITLE
Fix #3467 - load all css.php stylesheets at once

### DIFF
--- a/css.php
+++ b/css.php
@@ -60,14 +60,14 @@ SQL;
 	{
 		$stylesheet = $row['stylesheet'];
 
-		$plugins->run_hooks('css_start');
+		$plugins->run_hooks('css_start', $stylesheet);
 
 		if(!empty($mybb->settings['minifycss']))
 		{
 			$stylesheet = minify_stylesheet($stylesheet);
 		}
 
-		$plugins->run_hooks('css_end');
+		$plugins->run_hooks('css_end', $stylesheet);
 
 		$content .= $stylesheet;
 	}

--- a/css.php
+++ b/css.php
@@ -22,13 +22,14 @@ if(!empty($stylesheets))
 	$stylesheet_list = implode(', ', array_map('intval', $stylesheets));
 
 	$content = '';
+	$prefix = TABLE_PREFIX;
 
 	switch($db->type)
 	{
 		case 'pgsql':
 		case 'sqlite':
 			$sql = <<<SQL
-SELECT stylesheet FROM themestylesheets
+SELECT stylesheet FROM {$prefix}themestylesheets
   WHERE sid IN ({$stylesheet_list})
   ORDER BY CASE sid
 SQL;
@@ -46,7 +47,7 @@ SQL;
 			break;
 		default:
 			$sql = <<<SQL
-SELECT stylesheet FROM themestylesheets
+SELECT stylesheet FROM {$prefix}themestylesheets
   WHERE sid IN ({$stylesheet_list})
   ORDER BY FIELD(sid, {$stylesheet_list});
 SQL;

--- a/css.php
+++ b/css.php
@@ -19,21 +19,41 @@ $stylesheets = $mybb->get_input('stylesheet', MyBB::INPUT_ARRAY);
 
 if(!empty($stylesheets))
 {
-	$stylesheet_list = '';
-	$sep = '';
-
-	foreach($stylesheets as $stylesheet)
-	{
-		$stylesheet_list .= $sep . (int) $stylesheet;
-		$sep = ', ';
-	}
+	$stylesheet_list = implode(', ', array_map('intval', $stylesheets));
 
 	$content = '';
 
-	$query = $db->simple_select('themestylesheets', 'stylesheet', "sid IN ({$stylesheet_list})", array(
-		'order_by' => 'sid',
-		'order_dir' => 'ASC',
-	));
+	switch($db->type)
+	{
+		case 'pgsql':
+		case 'sqlite':
+			$sql = <<<SQL
+SELECT stylesheet FROM themestylesheets
+  WHERE sid IN ({$stylesheet_list})
+  ORDER BY CASE sid
+SQL;
+
+			$i = 0;
+			foreach($stylesheets as $sid)
+			{
+				$sid = (int) $sid;
+
+				$sql .= "WHEN {$sid} THEN {$i}\n";
+				$i++;
+			}
+
+			$sql .= 'END;';
+			break;
+		default:
+			$sql = <<<SQL
+SELECT stylesheet FROM themestylesheets
+  WHERE sid IN ({$stylesheet_list})
+  ORDER BY FIELD(sid, {$stylesheet_list});
+SQL;
+			break;
+	}
+
+	$query = $db->query($sql);
 
 	while($row = $db->fetch_array($query))
 	{

--- a/css.php
+++ b/css.php
@@ -15,26 +15,43 @@ define('THIS_SCRIPT', 'css.php');
 require_once "./inc/init.php";
 require_once MYBB_ROOT . $config['admin_dir'] . '/inc/functions_themes.php';
 
-$stylesheet = $mybb->get_input('stylesheet', MyBB::INPUT_INT);
+$stylesheets = $mybb->get_input('stylesheet', MyBB::INPUT_ARRAY);
 
-if($stylesheet)
+if(!empty($stylesheets))
 {
-	$options = array(
-		"limit" => 1
-	);
-	$query = $db->simple_select("themestylesheets", "stylesheet", "sid=".$stylesheet, $options);
-	$stylesheet = $db->fetch_field($query, "stylesheet");
+	$stylesheet_list = '';
+	$sep = '';
 
-	$plugins->run_hooks("css_start");
-
-	if(!empty($mybb->settings['minifycss']))
+	foreach($stylesheets as $stylesheet)
 	{
-		$stylesheet = minify_stylesheet($stylesheet);
+		$stylesheet_list .= $sep . (int) $stylesheet;
+		$sep = ', ';
 	}
 
-	$plugins->run_hooks("css_end");
+	$content = '';
 
-	header("Content-type: text/css");
-	echo $stylesheet;
+	$query = $db->simple_select('themestylesheets', 'stylesheet', "sid IN ({$stylesheet_list})", array(
+		'order_by' => 'sid',
+		'order_dir' => 'ASC',
+	));
+
+	while($row = $db->fetch_array($query))
+	{
+		$stylesheet = $row['stylesheet'];
+
+		$plugins->run_hooks('css_start');
+
+		if(!empty($mybb->settings['minifycss']))
+		{
+			$stylesheet = minify_stylesheet($stylesheet);
+		}
+
+		$plugins->run_hooks('css_end');
+
+		$content .= $stylesheet;
+	}
+
+	header('Content-type: text/css');
+	echo $content;
 }
 exit;

--- a/global.php
+++ b/global.php
@@ -386,14 +386,7 @@ if(!empty($theme_stylesheets) && is_array($theme['disporder']))
 
 if(!empty($css_php_script_stylesheets))
 {
-	$sheet = $mybb->settings['bburl'] . '/css.php?';
-
-	$sep = '';
-	foreach($css_php_script_stylesheets as $sid)
-	{
-		$sheet .= $sep . 'stylesheet[]=' . (int) $sid;
-		$sep = '&amp;';
-	}
+	$sheet = $mybb->settings['bburl'] . '/css.php?' . http_build_query(['stylesheet' => $css_php_script_stylesheets]);
 
 	$stylesheets .= "<link type=\"text/css\" rel=\"stylesheet\" href=\"{$sheet}\" />\n";
 }

--- a/global.php
+++ b/global.php
@@ -350,7 +350,7 @@ foreach($stylesheet_scripts as $stylesheet_script)
 					$id = (int) my_substr($query_string, 11);
 					$query = $db->simple_select("themestylesheets", "name", "sid={$id}");
 					$real_name = $db->fetch_field($query, "name");
-					$theme_stylesheets[$real_name] = "<link type=\"text/css\" rel=\"stylesheet\" href=\"{$stylesheet_url}\" />\n";
+					$theme_stylesheets[$real_name] = $id;
 				}
 				else
 				{
@@ -364,15 +364,38 @@ foreach($stylesheet_scripts as $stylesheet_script)
 }
 unset($actions);
 
+$css_php_script_stylesheets = array();
+
 if(!empty($theme_stylesheets) && is_array($theme['disporder']))
 {
 	foreach($theme['disporder'] as $style_name => $order)
 	{
 		if(!empty($theme_stylesheets[$style_name]))
 		{
-			$stylesheets .= $theme_stylesheets[$style_name];
+			if(is_int($theme_stylesheets[$style_name]))
+			{
+				$css_php_script_stylesheets[] = $theme_stylesheets[$style_name];
+			}
+			else
+			{
+				$stylesheets .= $theme_stylesheets[$style_name];
+			}
 		}
 	}
+}
+
+if(!empty($css_php_script_stylesheets))
+{
+	$sheet = $mybb->settings['bburl'] . '/css.php?';
+
+	$sep = '';
+	foreach($css_php_script_stylesheets as $sid)
+	{
+		$sheet .= $sep . 'stylesheet[]=' . (int) $sid;
+		$sep = '&amp;';
+	}
+
+	$stylesheets .= "<link type=\"text/css\" rel=\"stylesheet\" href=\"{$sheet}\" />\n";
 }
 
 // Are we linking to a remote theme server?

--- a/global.php
+++ b/global.php
@@ -386,7 +386,9 @@ if(!empty($theme_stylesheets) && is_array($theme['disporder']))
 
 if(!empty($css_php_script_stylesheets))
 {
-	$sheet = $mybb->settings['bburl'] . '/css.php?' . http_build_query(['stylesheet' => $css_php_script_stylesheets]);
+	$sheet = $mybb->settings['bburl'] . '/css.php?' . http_build_query(array(
+		'stylesheet' => $css_php_script_stylesheets
+		));
 
 	$stylesheets .= "<link type=\"text/css\" rel=\"stylesheet\" href=\"{$sheet}\" />\n";
 }


### PR DESCRIPTION
Fixes #3467 by loading all stylesheets loaded through `css.php` at once.

This does cause some issues with the stylesheet display order options, unfortunately. It could be possible to have the display order set in the following style:

- Sheet from `css.php`
- Sheet from cache
- Another sheet from cache
- ...

With this patch, the above would become:

- Sheet from cache
- Another sheet from cache
- All sheets from `css.php`, in order according to display order

We may also want to add some extra hooks into `css.php`, but I just wanted to whip up a first draft implementation to get more thoughts on the proposal.