### PR TITLE
Fix #3476 - version check failing with blank lines in content

### DIFF
--- a/admin/modules/config/plugins.php
+++ b/admin/modules/config/plugins.php
@@ -253,6 +253,8 @@ if($mybb->input['action'] == "check")
 		admin_redirect("index.php?module=config-plugins");
 	}
 
+	$contents = trim($contents);
+
 	$parser = new XMLParser($contents);
 	$tree = $parser->get_tree();
 

--- a/admin/modules/home/index.php
+++ b/admin/modules/home/index.php
@@ -53,18 +53,7 @@ if($mybb->input['action'] == "version_check")
 	$page->output_header($lang->version_check);
 	$page->output_nav_tabs($sub_tabs, 'version_check');
 
-	// We do this because there is some weird symbols that show up in the xml file for unknown reasons
-	$pos = strpos($contents, "<");
-	if($pos > 1)
-	{
-		$contents = substr($contents, $pos);
-	}
-
-	$pos = strpos(strrev($contents), ">");
-	if($pos > 1)
-	{
-		$contents = substr($contents, 0, (-1) * ($pos-1));
-	}
+	$contents = trim($contents);
 
 	$parser = new XMLParser($contents);
 	$tree = $parser->get_tree();

--- a/inc/tasks/versioncheck.php
+++ b/inc/tasks/versioncheck.php
@@ -28,17 +28,7 @@ function task_versioncheck($task)
 		return false;
 	}
 
-	$pos = strpos($contents, "<");
-	if($pos > 1)
-	{
-		$contents = substr($contents, $pos);
-	}
-
-	$pos = strpos(strrev($contents), ">");
-	if($pos > 1)
-	{
-		$contents = substr($contents, 0, (-1) * ($pos-1));
-	}
+	$contents = trim($contents);
 
 	$parser = new XMLParser($contents);
 	$tree = $parser->get_tree();


### PR DESCRIPTION
Fixes #3476 in the simplest way possible by just using `trim` on the returned contents.

As the plan is to rewrite the ACP in future versions (1.10+), I just wanted to take the easy route for now and we'll add better error management and logging for future releases.