### PR TITLE
Improve language of bans ending soon in ModCP homepage

### DIFF
--- a/inc/languages/english/modcp.lang.php
+++ b/inc/languages/english/modcp.lang.php
@@ -182,6 +182,7 @@ $l['ban_bannedby'] = "Banned By";
 $l['ban_movegroup'] = "Move to Banned Group:";
 $l['ban_liftafter'] = "Lift Ban After:";
 $l['no_banned'] = "There are currently no banned users.";
+$l['no_banned_soon'] = "There are no bans expiring soon.";
 $l['no_banned_group'] = "There are currently no banned groups.";
 $l['redirect_banuser'] = "The user has successfully been banned.";
 $l['redirect_banuser_updated'] = "The user's ban has successfully been updated.";

--- a/inc/views/base/modcp/home.twig
+++ b/inc/views/base/modcp/home.twig
@@ -139,7 +139,7 @@
                         </tr>
                     {% else %}
                         <tr>
-                            <td align="center" colspan="4">{{ lang.no_banned }}</td>
+                            <td align="center" colspan="4">{{ lang.no_banned_soon }}</td>
                         </tr>
                     {% endfor %}
                 </table>


### PR DESCRIPTION
The index page of the ModCP includes a 'Bans Ending Soon' section. If there are no bans ending soon this will incorrectly read **'There are currently no banned users.'** (when there _are_ users banned, just not any that have bans ending soon), I've added a language variable **$l['no_banned_soon']** and replaced the existing one in the template to add some clarity to this page.