### PR TITLE
Fixes #3461 Badword Filter Enhancement (2)

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -679,9 +679,9 @@ class postParser
 			return;
 		}
 
-		// Neutralize multiple adjacent wildcards and generate pattern
-		$ptrn = array('/\*\++/', '/\++\*/', '/\*+/');
-		$rplc = array('*', '*', '[^\s\n]*');
+		// Neutralize escape character, regex operators, multiple adjacent wildcards and generate pattern
+		$ptrn = array('/\\\\/', '/([\[\^\$\.\|\?\(\)\{\}]{1})/', '/\*\++/', '/\++\*/', '/\*+/');
+		$rplc = array('\\\\\\\\','\\\\${1}', '*', '*', '[^\s\n]*');
 		$bad_word = preg_replace($ptrn, $rplc, $bad_word);
 		
 		// Count + and generate pattern
@@ -707,7 +707,7 @@ class postParser
 			$trap .= '[^\s\n]{'.($plus-1).'}';
 		}
 		
-		return '\b'.$trap.'\b';
+		return '[\b\B]{0}'.$trap.'[\b\B]{0}';
 	}
 
 	/**


### PR DESCRIPTION
Attempt to fix #3461 
- Neutralized escape character (`\`).
- Neutralized regex operators (other than `*` & `+`, since they are being used for special purposes).
- Modified word boundary to capture words starting and ending with non-alphanumeric characters (`^$.|?(){}`).