### PR TITLE
Fixes #3419 View Own Unapproved Threads / Posts

### DIFF
--- a/editpost.php
+++ b/editpost.php
@@ -71,7 +71,10 @@ $forum = get_forum($fid);
 
 if($thread['visible'] == 0 && !is_moderator($fid, "canviewunapprove") || $thread['visible'] == -1 && !is_moderator($fid, "canviewdeleted") || ($thread['visible'] < -1 && $thread['uid'] != $mybb->user['uid']))
 {
-	error($lang->error_invalidthread);
+	if($thread['visible'] == 0 && !($mybb->settings['showownunapproved'] && $thread['uid'] == $mybb->user['uid']))
+	{
+		error($lang->error_invalidthread);
+	}
 }
 if(!$forum || $forum['type'] != "f")
 {
@@ -131,8 +134,8 @@ if($mybb->input['action'] == "deletepost" && $mybb->request_method == "post")
 		{
 			error_no_permission();
 		}
-		// User can't delete unapproved post
-		if($post['visible'] == 0)
+		// User can't delete unapproved post unless allowed for own
+		if($post['visible'] == 0 && !($mybb->settings['showownunapproved'] && $post['uid'] == $mybb->user['uid']))
 		{
 			error_no_permission();
 		}
@@ -173,7 +176,7 @@ else
 			error($lang->edit_time_limit);
 		}
 		// User can't edit unapproved post
-		if($post['visible'] == 0 || $post['visible'] == -1)
+		if(($post['visible'] == 0 && !($mybb->settings['showownunapproved'] && $post['uid'] == $mybb->user['uid'])) || $post['visible'] == -1)
 		{
 			error_no_permission();
 		}

--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -845,6 +845,12 @@ if($fpermissions['canviewthreads'] != 0)
 {
 	$plugins->run_hooks("forumdisplay_get_threads");
 
+	// Allow viewing unapproved threads for logged in users
+	if($mybb->user['uid'] && $mybb->settings['showselfunapproved'])
+	{
+		$tvisibleonly .= " OR (t.fid='$fid' AND t.uid=".$mybb->user['uid'].")";
+	}
+
 	// Start Getting Threads
 	$query = $db->query("
 		SELECT t.*, {$ratingadd}t.username AS threadusername, u.username

--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -846,7 +846,7 @@ if($fpermissions['canviewthreads'] != 0)
 	$plugins->run_hooks("forumdisplay_get_threads");
 
 	// Allow viewing unapproved threads for logged in users
-	if($mybb->user['uid'] && $mybb->settings['showselfunapproved'])
+	if($mybb->user['uid'] && $mybb->settings['showownunapproved'])
 	{
 		$tvisibleonly .= " OR (t.fid='$fid' AND t.uid=".$mybb->user['uid'].")";
 	}

--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -862,6 +862,14 @@ function build_postbit($post, $post_type=0)
 				$post_visibility = "display: none;";
 			}
 
+			// Is the user (not moderator) logged in and have unapproved posts?
+			if($mybb->user['uid'] && $post['visible'] == 0 && $post['uid'] == $mybb->user['uid'] && !is_moderator($fid, "canviewunapprove"))
+			{
+				$ignored_message = $lang->sprintf($lang->postbit_post_under_moderation, $post['username']);
+				eval("\$ignore_bit = \"".$templates->get("postbit_ignored")."\";");
+				$post_visibility = "display: none;";
+			}
+
 			// Is this author on the ignore list of the current user? Hide this post
 			if(is_array($ignored_users) && $post['uid'] != 0 && isset($ignored_users[$post['uid']]) && $ignored_users[$post['uid']] == 1 && empty($deleted_bit))
 			{

--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -271,6 +271,7 @@ $l['postbit_quick_edit'] = "Quick Edit";
 $l['postbit_full_edit'] = "Full Edit";
 $l['postbit_show_ignored_post'] = "Show this Post";
 $l['postbit_currently_ignoring_user'] = "The contents of this message are hidden because {1} is on your <a href=\"usercp.php?action=editlists\">ignore list</a>.";
+$l['postbit_post_under_moderation'] = "The post made by you is under moderation and currently not visible publicly. The post will be visible to everyone once a moderator approves it.";
 $l['postbit_warning_level'] = "Warning Level:";
 $l['postbit_warn'] = "Warn the author for this post";
 $l['postbit_purgespammer'] = "Purge Spammer";

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -1431,6 +1431,14 @@ min=0]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
+		<setting name="showownunapproved">
+			<title>Access Own Unapproved Threads / Posts</title>
+			<description><![CDATA[Allow general users to access their own unapproved threads and posts.]]></description>
+			<disporder>24</disporder>
+			<optionscode><![CDATA[yesno]]></optionscode>
+			<settingvalue><![CDATA[0]]></settingvalue>
+			<isdefault>1</isdefault>
+		</setting>
 	</settinggroup>
 	<settinggroup name="attachments" title="Attachments" description="Various options related to the attachment system can be managed and set here." disporder="12" isdefault="1">
 		<setting name="enableattachments">

--- a/newreply.php
+++ b/newreply.php
@@ -88,11 +88,17 @@ $forumpermissions = forum_permissions($fid);
 // See if everything is valid up to here.
 if(isset($post) && (($post['visible'] == 0 && !is_moderator($fid, "canviewunapprove")) || ($post['visible'] < 0 && $post['uid'] != $mybb->user['uid'])))
 {
-	error($lang->error_invalidpost);
+	if($post['visible'] == 0 && !($mybb->settings['showownunapproved'] && $post['uid'] == $mybb->user['uid']))
+	{
+		error($lang->error_invalidpost);
+	}
 }
 if(($thread['visible'] == 0 && !is_moderator($fid, "canviewunapprove")) || $thread['visible'] < 0)
 {
-	error($lang->error_invalidthread);
+	if($thread['visible'] == 0 && !($mybb->settings['showownunapproved'] && $thread['uid'] == $mybb->user['uid']))
+	{
+		error($lang->error_invalidthread);
+	}
 }
 if($forum['open'] == 0 || $forum['type'] != "f")
 {
@@ -1186,7 +1192,7 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 			$mybb->settings['postsperpage'] = 20;
 		}
 
-		if(is_moderator($fid, "canviewunapprove"))
+		if(is_moderator($fid, "canviewunapprove") || $mybb->settings['showownunapproved'])
 		{
 			$visibility = "(visible='1' OR visible='0')";
 		}

--- a/showthread.php
+++ b/showthread.php
@@ -146,7 +146,7 @@ else
 if(($thread['visible'] != 1 && $ismod == false) || ($thread['visible'] == 0 && !is_moderator($fid, "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($fid, "canviewdeleted")))
 {
 	// Allow viewing own unapproved thread
-	if (!($mybb->user['uid'] && $mybb->settings['showselfunapproved'] && $thread['visible'] == 0 && ($thread['uid'] == $mybb->user['uid'])))
+	if (!($mybb->user['uid'] && $mybb->settings['showownunapproved'] && $thread['visible'] == 0 && ($thread['uid'] == $mybb->user['uid'])))
 	{
 		error($lang->error_invalidthread);
 	}
@@ -1061,7 +1061,7 @@ if($mybb->input['action'] == "thread")
         $multipage = multipage($postcount, $perpage, $page, str_replace("{tid}", $tid, THREAD_URL_PAGED.$highlight.$threadmode));
 		
 		// Allow originator to see own unapproved posts
-		if($mybb->user['uid'] && $mybb->settings['showselfunapproved'])
+		if($mybb->user['uid'] && $mybb->settings['showownunapproved'])
 		{
 			$visible .= " OR (p.tid='$tid' AND p.visible='0' AND p.uid=".$mybb->user['uid'].")";
 		}

--- a/showthread.php
+++ b/showthread.php
@@ -145,7 +145,11 @@ else
 // Make sure we are looking at a real thread here.
 if(($thread['visible'] != 1 && $ismod == false) || ($thread['visible'] == 0 && !is_moderator($fid, "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($fid, "canviewdeleted")))
 {
-	error($lang->error_invalidthread);
+	// Allow viewing own unapproved thread
+	if (!($mybb->user['uid'] && $mybb->settings['showselfunapproved'] && $thread['visible'] == 0 && ($thread['uid'] == $mybb->user['uid'])))
+	{
+		error($lang->error_invalidthread);
+	}
 }
 
 // Does the user have permission to view this thread?
@@ -1055,6 +1059,12 @@ if($mybb->input['action'] == "thread")
         }
 
         $multipage = multipage($postcount, $perpage, $page, str_replace("{tid}", $tid, THREAD_URL_PAGED.$highlight.$threadmode));
+		
+		// Allow originator to see own unapproved posts
+		if($mybb->user['uid'] && $mybb->settings['showselfunapproved'])
+		{
+			$visible .= " OR (p.tid='$tid' AND p.visible='0' AND p.uid=".$mybb->user['uid'].")";
+		}
 
 		// Lets get the pids of the posts on this page.
 		$pids = "";

--- a/xmlhttp.php
+++ b/xmlhttp.php
@@ -483,8 +483,8 @@ else if($mybb->input['action'] == "edit_post")
 			$lang->edit_time_limit = $lang->sprintf($lang->edit_time_limit, $mybb->usergroup['edittimelimit']);
 			xmlhttp_error($lang->edit_time_limit);
 		}
-		// User can't edit unapproved post
-		if($post['visible'] == 0)
+		// User can't edit unapproved post unless permitted for own
+		if($post['visible'] == 0 && !($mybb->settings['showownunapproved'] && $post['uid'] == $mybb->user['uid']))
 		{
 			xmlhttp_error($lang->post_moderation);
 		}
@@ -745,7 +745,11 @@ else if($mybb->input['action'] == "get_multiquoted")
 			(in_array($quoted_post['fid'], $onlyusfids) && (!$mybb->user['uid'] || $quoted_post['thread_uid'] != $mybb->user['uid']))
 		)
 		{
-			continue;
+			// Allow quoting from own unapproved post
+			if($quoted_post['visible'] == 0 && !($mybb->settings['showownunapproved'] && $quoted_post['uid'] == $mybb->user['uid']))
+			{
+				continue;
+			}
 		}
 
 		$message .= parse_quoted_message($quoted_post, false);


### PR DESCRIPTION
Attempt to fix #3419 

- [x] Allow viewing unapproved threads - forumdisplay
- [x] Allow viewing unapproved threads - showthread
- [x] Allow viewing unapproved posts - showthread
- [x] Allow operating postbit buttons
- [x] Add ACP setting