### PR TITLE
Display username before bbname on profiles

### DIFF
--- a/inc/views/base/member/profile.twig
+++ b/inc/views/base/member/profile.twig
@@ -1,7 +1,7 @@
 {% extends 'layouts/master.twig' %}
 
 {% block head %}
-    <title>{{ mybb.settings.bbname }} - {{ trans('profile', memprofile.username) }}</title>
+    <title>{{ trans('profile', memprofile.username) }} - {{ mybb.settings.bbname }}</title>
     <script type="text/javascript" src="{{ asset_url('jscripts/report.js') }}"></script>
 {% endblock head %}
 


### PR DESCRIPTION
This is something that has irked me since I started using MyBB, and is a change I always made in all of my custom templates.

It simply reverses the order of the `{{ trans('profile', memprofile.username) }}` and `{{ mybb.settings.bbname }}` variables so that the browser tab displays the text as;
```
Profile of andrewjs18 - MyBB 1.9 Demo
```
Instead of;
```
MyBB 1.9 Demo - Profile of andrewjs18
```
Why exactly? Because when you have more than one tab open the title text is truncated which leaves you with;
```
MyBB 1.9 Demo -  Profile o...
```
Which is entirely useless. As far as I'm aware this issue exists across MyBB in many places - so consider this a "concept PR" or a very small quality of life improvement at the slightest. Input from @justinsoltesz and @euantorano would be appreciated. :)