### PR TITLE
README: fix URL for MyBB logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![MyBB](https://raw.github.com/mybb/mybb/feature/images/logo.png "MyBB")](https://mybb.com "MyBB")
+[![MyBB](https://raw.githubusercontent.com/mybb/mybb/feature/images/logo.png "MyBB")](https://mybb.com "MyBB")
 
 [![Backers on Open Collective](https://opencollective.com/mybb/backers/badge.svg)](#backers)
  [![Sponsors on Open Collective](https://opencollective.com/mybb/sponsors/badge.svg)](#sponsors)


### PR DESCRIPTION
Currently, the MyBB logo in the readme is not displayed, because it seems like the URL was changed from raw.github.com to raw.githubusercontent.com