### PR TITLE
Fixes #3580 Oversensitive Word Filter

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -707,7 +707,7 @@ class postParser
 			$trap .= '[^\s\n]{'.($plus-1).'}';
 		}
 		
-		return '[\b\B]{0}'.$trap.'[\b\B]{0}';
+		return '\b'.$trap.'\b';
 	}
 
 	/**


### PR DESCRIPTION
Attempt to fix #3580 

Reverting word boundary to original might be the best optimal solution for now.
With the following known issues, as word boundary acts invert to the non word characters:

With a word filter `monk` to `pon`: `Monkey` will remain as is but `{monk}ey` will be affected resulting to `{pon}ey`.
If we try to filter `\()` with `no`:
`Hello \() MyBB` will not be changed, but `Hell\()o MyBB` will be affected resulting `Hellnoo MyBB`.

If we can live with those rare incidents this PR is good to go for now. If anyone has a better idea feel free to comment or push commits (for members) to PR.