### PR TITLE
Unique check for per_page on recount_rebuild.php

### DIFF
--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -30,10 +30,7 @@ function acp_rebuild_forum_counters()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('forumcounters', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 50;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -60,10 +57,7 @@ function acp_rebuild_thread_counters()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('threadcounters', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -88,10 +82,7 @@ function acp_rebuild_poll_counters()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('pollcounters', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -116,10 +107,7 @@ function acp_recount_user_posts()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('userposts', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -170,10 +158,7 @@ function acp_recount_user_threads()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('userthreads', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -223,10 +208,7 @@ function acp_recount_reputation()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('reputation', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -258,10 +240,7 @@ function acp_recount_warning()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('warning', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -293,10 +272,7 @@ function acp_recount_private_messages()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('privatemessages', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -354,10 +330,7 @@ function acp_recount_thread_ratings()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('threadrating', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 500;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -389,10 +362,7 @@ function acp_rebuild_attachment_thumbnails()
 
 	$page = $mybb->get_input('page', MyBB::INPUT_INT);
 	$per_page = $mybb->get_input('attachmentthumbs', MyBB::INPUT_INT);
-	if($per_page <= 0)
-	{
-		$per_page = 20;
-	}
+
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
@@ -488,7 +458,9 @@ if(!$mybb->input['action'])
 				// Log admin action
 				log_admin_action("forum");
 			}
-			if(!$mybb->get_input('forumcounters', MyBB::INPUT_INT))
+
+			$per_page = $mybb->get_input('forumcounters', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['forumcounters'] = 50;
 			}
@@ -504,7 +476,9 @@ if(!$mybb->input['action'])
 				// Log admin action
 				log_admin_action("thread");
 			}
-			if(!$mybb->get_input('threadcounters', MyBB::INPUT_INT))
+
+			$per_page = $mybb->get_input('threadcounters', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['threadcounters'] = 500;
 			}
@@ -520,7 +494,9 @@ if(!$mybb->input['action'])
 				// Log admin action
 				log_admin_action("userposts");
 			}
-			if(!$mybb->get_input('userposts', MyBB::INPUT_INT))
+
+			$per_page = $mybb->get_input('userposts', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['userposts'] = 500;
 			}
@@ -536,7 +512,9 @@ if(!$mybb->input['action'])
 				// Log admin action
 				log_admin_action("userthreads");
 			}
-			if(!$mybb->get_input('userthreads', MyBB::INPUT_INT))
+
+			$per_page = $mybb->get_input('userthreads', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['userthreads'] = 500;
 			}
@@ -553,7 +531,8 @@ if(!$mybb->input['action'])
 				log_admin_action("attachmentthumbs");
 			}
 
-			if(!$mybb->get_input('attachmentthumbs', MyBB::INPUT_INT))
+			$per_page = $mybb->get_input('attachmentthumbs', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['attachmentthumbs'] = 500;
 			}
@@ -570,7 +549,8 @@ if(!$mybb->input['action'])
 				log_admin_action("reputation");
 			}
 
-			if(!$mybb->get_input('reputation', MyBB::INPUT_INT))
+			$per_page = $mybb->get_input('reputation', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['reputation'] = 500;
 			}
@@ -587,7 +567,8 @@ if(!$mybb->input['action'])
 				log_admin_action("warning");
 			}
 
-			if(!$mybb->get_input('warning', MyBB::INPUT_INT))
+			$per_page = $mybb->get_input('warning', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['warning'] = 500;
 			}
@@ -604,7 +585,8 @@ if(!$mybb->input['action'])
 				log_admin_action("privatemessages");
 			}
 
-			if(!$mybb->get_input('privatemessages', MyBB::INPUT_INT))
+			$per_page = $mybb->get_input('privatemessages', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['privatemessages'] = 500;
 			}
@@ -621,7 +603,8 @@ if(!$mybb->input['action'])
 				log_admin_action("referral");
 			}
 
-			if(!$mybb->get_input('referral', MyBB::INPUT_INT))
+			$per_page = $mybb->get_input('referral', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['referral'] = 500;
 			}
@@ -638,7 +621,8 @@ if(!$mybb->input['action'])
 				log_admin_action("threadrating");
 			}
 
-			if(!$mybb->get_input('threadrating', MyBB::INPUT_INT))
+			$per_page = $mybb->get_input('threadrating', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['threadrating'] = 500;
 			}
@@ -655,7 +639,8 @@ if(!$mybb->input['action'])
 				log_admin_action("poll");
 			}
 
-			if(!$mybb->get_input('pollcounters', MyBB::INPUT_INT))
+			$per_page = $mybb->get_input('pollcounters', MyBB::INPUT_INT);
+			if(!$per_page || $per_page <= 0)
 			{
 				$mybb->input['pollcounters'] = 500;
 			}


### PR DESCRIPTION
Remove the double check of the per_page variable in order to set the default value one time.