### PR TITLE
New hook on recount_rebuild.php

### DIFF
--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -479,6 +479,8 @@ if(!$mybb->input['action'])
 			$mybb->input['page'] = 1;
 		}
 
+		$plugins->run_hooks("admin_tools_do_recount_rebuild");
+
 		if(isset($mybb->input['do_rebuildforumcounters']))
 		{
 			$plugins->run_hooks("admin_tools_recount_rebuild_forum_counters");


### PR DESCRIPTION
May be useful add a do_recount_rebuild hook in order to have directly included the post request check and the input page check, avoiding to rewrite them in the development of the plugin.