### PR TITLE
Fix #3651 - use button's parent form

### DIFF
--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -453,7 +453,23 @@ function check_proceed($current, $finish, $next_page, $per_page, $name, $name2, 
 		echo "<div class=\"confirm_action\">\n";
 		echo "<p>{$lang->confirm_proceed_rebuild}</p>\n";
 		echo "<br />\n";
-		echo "<script type=\"text/javascript\">$(function() { var button = $(\"#proceed_button\"); if(button.length > 0) { button.val(\"{$lang->automatically_redirecting}\"); button.attr(\"disabled\", true); button.css(\"color\", \"#aaa\"); button.css(\"borderColor\", \"#aaa\"); document.forms[0].trigger('submit'); }})</script>";
+		echo "<script type=\"text/javascript\">
+			$(function() { 
+				var button = $(\"#proceed_button\"); 
+				if(button.length > 0) {
+					button.val(\"{$lang->automatically_redirecting}\");
+					button.attr(\"disabled\", true);
+					button.css(\"color\", \"#aaa\");
+					button.css(\"borderColor\", \"#aaa\");
+                    
+					var parent_form = button.closest('form');
+
+					if (parent_form.length > 0) {
+						parent_form.submit();
+					}
+				}
+			});
+		</script>";
 		echo "<p class=\"buttons\">\n";
 		echo $form->generate_submit_button($lang->proceed, array('class' => 'button_yes', 'id' => 'proceed_button'));
 		echo "</p>\n";


### PR DESCRIPTION
Fixes #3651 - get the button's parent form rather than using the document's first form.