### PR TITLE
Fix 3647 - add missing parameters to modify_column() and rename_column() in DB classes

### DIFF
--- a/inc/db_base.php
+++ b/inc/db_base.php
@@ -375,19 +375,25 @@ interface DB_Base
 	 *
 	 * @param string $table The table
 	 * @param string $column The column name
-	 * @param string $new_definition The new column definition
+	 * @param string $new_definition the new column definition
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
-	function modify_column($table, $column, $new_definition);
+	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false);
 
 	/**
 	 * Renames a column
 	 *
 	 * @param string $table The table
 	 * @param string $old_column The old column name
-	 * @param string $new_column The new column name
-	 * @param string $new_definition The new column definition
+	 * @param string $new_column the new column name
+	 * @param string $new_definition the new column definition
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully
 	 */
-	function rename_column($table, $old_column, $new_column, $new_definition);
+	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false);
 
 	/**
 	 * Sets the table prefix used by the simple select, insert, update and delete functions

--- a/inc/db_base.php
+++ b/inc/db_base.php
@@ -376,8 +376,8 @@ interface DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
 	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false);
@@ -389,8 +389,8 @@ interface DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully
 	 */
 	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false);

--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -1379,13 +1379,15 @@ class DB_MySQL implements DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
-	 * @return resource
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
-	function modify_column($table, $column, $new_definition)
+	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		$column = trim($column, '`');
 
-		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition}");
+		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition}");
 	}
 
 	/**
@@ -1395,14 +1397,16 @@ class DB_MySQL implements DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @return resource
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully
 	 */
-	function rename_column($table, $old_column, $new_column, $new_definition)
+	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		$old_column = trim($old_column, '`');
 		$new_column = trim($new_column, '`');
 
-		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition}");
+		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition}");
 	}
 
 	/**

--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -1379,15 +1379,40 @@ class DB_MySQL implements DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
 	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		$column = trim($column, '`');
 
-		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition}");
+		if($new_not_null !== false)
+		{
+			if(strtolower($new_not_null) == "set")
+			{
+				$not_null = "NOT NULL";
+			}
+			else
+			{
+				$not_null = "NULL";
+			}
+		}
+		else
+		{
+			$not_null = '';
+		}
+
+		if($new_default_value !== false)
+		{
+			$default = "DEFAULT ".$new_default_value;
+		}
+		else
+		{
+			$default = '';
+		}
+
+		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition} {$not_null}");
 	}
 
 	/**
@@ -1397,8 +1422,8 @@ class DB_MySQL implements DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully
 	 */
 	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false)
@@ -1406,7 +1431,32 @@ class DB_MySQL implements DB_Base
 		$old_column = trim($old_column, '`');
 		$new_column = trim($new_column, '`');
 
-		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition}");
+		if($new_not_null !== false)
+		{
+			if(strtolower($new_not_null) == "set")
+			{
+				$not_null = "NOT NULL";
+			}
+			else
+			{
+				$not_null = "NULL";
+			}
+		}
+		else
+		{
+			$not_null = '';
+		}
+
+		if($new_default_value !== false)
+		{
+			$default = "DEFAULT ".$new_default_value;
+		}
+		else
+		{
+			$default = '';
+		}
+
+		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition} {$not_null} {$default}");
 	}
 
 	/**

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -1360,15 +1360,40 @@ class DB_MySQLi implements DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
 	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		$column = trim($column, '`');
 
-		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition}");
+		if($new_not_null !== false)
+		{
+			if(strtolower($new_not_null) == "set")
+			{
+				$not_null = "NOT NULL";
+			}
+			else
+			{
+				$not_null = "NULL";
+			}
+		}
+		else
+		{
+			$not_null = '';
+		}
+
+		if($new_default_value !== null)
+		{
+			$default = "DEFAULT ".$new_default_value;
+		}
+		else
+		{
+			$default = '';
+		}
+
+		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition} {$not_null}");
 	}
 
 	/**
@@ -1378,8 +1403,8 @@ class DB_MySQLi implements DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully
 	 */
 	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false)
@@ -1387,7 +1412,32 @@ class DB_MySQLi implements DB_Base
 		$old_column = trim($old_column, '`');
 		$new_column = trim($new_column, '`');
 
-		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition}");
+		if($new_not_null !== false)
+		{
+			if(strtolower($new_not_null) == "set")
+			{
+				$not_null = "NOT NULL";
+			}
+			else
+			{
+				$not_null = "NULL";
+			}
+		}
+		else
+		{
+			$not_null = '';
+		}
+
+		if($new_default_value !== false)
+		{
+			$default = "DEFAULT ".$new_default_value;
+		}
+		else
+		{
+			$default = '';
+		}
+
+		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition} {$not_null} {$default}");
 	}
 
 	/**

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -1360,13 +1360,15 @@ class DB_MySQLi implements DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
-	 * @return mysqli_result
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
-	function modify_column($table, $column, $new_definition)
+	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		$column = trim($column, '`');
 
-		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition}");
+		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition}");
 	}
 
 	/**
@@ -1376,14 +1378,16 @@ class DB_MySQLi implements DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @return mysqli_result
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully
 	 */
-	function rename_column($table, $old_column, $new_column, $new_definition)
+	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		$old_column = trim($old_column, '`');
 		$new_column = trim($new_column, '`');
 
-		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition}");
+		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE `{$old_column}` `{$new_column}` {$new_definition}");
 	}
 
 	/**

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1418,8 +1418,8 @@ class DB_PgSQL implements DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
 	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false)
@@ -1443,13 +1443,16 @@ class DB_PgSQL implements DB_Base
 			$result2 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} {$set_drop} NOT NULL");
 		}
 
-		if($new_default_value !== false)
+		if($new_default_value !== null)
 		{
-			$result3 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} SET DEFAULT {$new_default_value}");
-		}
-		else
-		{
-			$result3 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} DROP DEFAULT");
+			if($new_default_value !== false)
+			{
+				$result3 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} SET DEFAULT {$new_default_value}");
+			}
+			else
+			{
+				$result3 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} DROP DEFAULT");
+			}
 		}
 
 		return $result1 && $result2 && $result3;
@@ -1462,8 +1465,8 @@ class DB_PgSQL implements DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully
 	 */
 	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false)

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -1446,14 +1446,14 @@ class DB_SQLite implements DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
 	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		// We use a rename query as both need to duplicate the table etc...
-		return $this->rename_column($table, $column, $column, $new_definition);
+		return $this->rename_column($table, $column, $column, $new_definition, $new_not_null, $new_default_value);
 	}
 
 	/**
@@ -1463,14 +1463,39 @@ class DB_SQLite implements DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @param boolean $new_not_null Whether to drop or set a column
-	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @param boolean|string $new_not_null Whether to "drop" or "set" the NOT NULL attribute (no change if false)
+	 * @param boolean|string $new_default_value The new default value, or false to drop the attribute
 	 * @return bool Returns true if all queries are executed successfully
 	 */
 	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
+		if($new_not_null !== false)
+		{
+			if(strtolower($new_not_null) == "set")
+			{
+				$not_null = "NOT NULL";
+			}
+			else
+			{
+				$not_null = "NULL";
+			}
+		}
+		else
+		{
+			$not_null = '';
+		}
+
+		if($new_default_value !== false)
+		{
+			$default = "DEFAULT ".$new_default_value;
+		}
+		else
+		{
+			$default = '';
+		}
+
 		// This will trigger the "alter_table_parse" function which will copy the table and rename the column
-		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE {$old_column} {$new_column} {$new_definition}");
+		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE {$old_column} {$new_column} {$new_definition} {$not_null} {$default}");
 	}
 
 	/**

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -1446,11 +1446,14 @@ class DB_SQLite implements DB_Base
 	 * @param string $table The table
 	 * @param string $column The column name
 	 * @param string $new_definition the new column definition
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully or false if one of them failed
 	 */
-	function modify_column($table, $column, $new_definition)
+	function modify_column($table, $column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		// We use a rename query as both need to duplicate the table etc...
-		$this->rename_column($table, $column, $column, $new_definition);
+		return $this->rename_column($table, $column, $column, $new_definition);
 	}
 
 	/**
@@ -1460,12 +1463,14 @@ class DB_SQLite implements DB_Base
 	 * @param string $old_column The old column name
 	 * @param string $new_column the new column name
 	 * @param string $new_definition the new column definition
-	 * @return PDOStatement
+	 * @param boolean $new_not_null Whether to drop or set a column
+	 * @param boolean $new_default_value The new default value (if one is to be set)
+	 * @return bool Returns true if all queries are executed successfully
 	 */
-	function rename_column($table, $old_column, $new_column, $new_definition)
+	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null=false, $new_default_value=false)
 	{
 		// This will trigger the "alter_table_parse" function which will copy the table and rename the column
-		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE {$old_column} {$new_column} {$new_definition}");
+		return (bool) $this->write_query("ALTER TABLE {$this->table_prefix}{$table} CHANGE {$old_column} {$new_column} {$new_definition}");
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3647 - Incompatible arguments of DB_Base::modify_column() and DB_Base::rename_column() implementations