### PR TITLE
Fix #3656 - SQL Error on Post Update With Removed Attachment

### DIFF
--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -21,7 +21,7 @@ function remove_attachment($pid, $posthash, $aid)
 	global $db, $mybb, $plugins;
 	$aid = (int)$aid;
 	$posthash = $db->escape_string($posthash);
-	if($posthash != "")
+	if(!empty($posthash))
 	{
 		$query = $db->simple_select("attachments", "aid, attachname, thumbnail, visible", "aid='{$aid}' AND posthash='{$posthash}'");
 		$attachment = $db->fetch_array($query);
@@ -33,6 +33,12 @@ function remove_attachment($pid, $posthash, $aid)
 	}
 
 	$plugins->run_hooks("remove_attachment_do_delete", $attachment);
+
+	if($attachment === false)
+	{
+		// no attachment found with the given details
+		return;
+	}
 
 	$db->delete_query("attachments", "aid='{$attachment['aid']}'");
 


### PR DESCRIPTION
Fixes #3656 

There are some other issues with editing posts, especially when JS is disabled. I'll open another issue regarding these.