### PR TITLE
Pass debuglink to template

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -60,7 +60,8 @@ function output_page($contents)
                 'sql_queries' => $sql_queries,
                 'serverload' => $serverload,
                 'totaltime' => $totaltime,
-                'memory_usage' => get_friendly_size($memory_usage)
+                'memory_usage' => get_friendly_size($memory_usage),
+                'debuglink' => $debuglink,
             ]);
             $contents = str_replace("<debugstuff>", $debugstuff, $contents);
         }


### PR DESCRIPTION
The `debuglink` variable was missed in #3256 when the `debugsummary` template was converted to twig.