### PR TITLE
Revert get_users behaviour to starts with instead of contains

### DIFF
--- a/xmlhttp.php
+++ b/xmlhttp.php
@@ -222,7 +222,7 @@ if($mybb->settings['boardclosed'] == 1 && $mybb->usergroup['canviewboardclosed']
 if($mybb->input['action'] == "get_users")
 {
 	$mybb->input['query'] = ltrim($mybb->get_input('query'));
-	$search_type = $mybb->get_input('search_type', MyBB::INPUT_INT); // 0: contains, 1: starts with, 2: ends with
+	$search_type = $mybb->get_input('search_type', MyBB::INPUT_INT); // 0: starts with, 1: ends with, 2: contains
 
 	// If the string is less than 2 characters, quit.
 	if(my_strlen($mybb->input['query']) < 2)
@@ -255,15 +255,15 @@ if($mybb->input['action'] == "get_users")
 	$likestring = $db->escape_string_like($mybb->input['query']);
 	if($search_type == 1)
 	{
-		$likestring .= '%';
+		$likestring = '%'.$likestring;
 	}
 	elseif($search_type == 2)
 	{
-		$likestring = '%'.$likestring;
+		$likestring = '%'.$likestring.'%';
 	}
 	else
 	{
-		$likestring = '%'.$likestring.'%';
+		$likestring .= '%';
 	}
 
 	$query = $db->simple_select("users", "uid, username", "username LIKE '{$likestring}'", $query_options);


### PR DESCRIPTION
In https://github.com/mybb/mybb/commit/87f833ecd93a037c6a4c3904b692f93baec57380 the default behaviour of the XMLHTTP function `get_users` was changed from _starts with_ to _contains_ without any convincing reason or retrospective changes to core code to prevent regressions where this function is used.

The function is primarily used for autocompleting usernames in select boxes. The change to _contains_ would not normally be an issue as a selection of users are returned based on the search query, however, on forums with large numbers of members and common terms in usernames, it leads to users not being able to select a member from an user autocomplete box even when entering an exact username (as the results are returned A-Z).

A quick search reveals there is no core code that takes advantage of _ends with_ or _contains_, and given that the nature of this function is to return a list of users for autocompleting, the default behaviour of this function should be _starts with_.

This PR reverts `get_users` to the previous default of _starts with_, while keeping the option to query `get_users` with _ends with_ (1: ends with) and  _contains_ (2: contains) via `search_type` input.

**Possible regressions**
If a plugin is utilising `get_users` and including `search_type` input, the output of the function has changed and so plugin functionality may not be as expected.