### PR TITLE
Poll Voting Efficiency Fix

### DIFF
--- a/global.php
+++ b/global.php
@@ -206,7 +206,7 @@ if(in_array($current_page, $valid))
 	// If we're accessing poll results, fetch the forum theme for it and if we're overriding it
 	else if(isset($mybb->input['pid']) && THIS_SCRIPT == "polls.php")
 	{
-		$query = $db->simple_select('threads', 'fid', "poll = '{$mybb->input['pid']}'", array('limit' => 1));
+		$query = $db->query("SELECT t.fid FROM ".TABLE_PREFIX."polls p LEFT JOIN ".TABLE_PREFIX."threads t ON (t.tid=p.tid) WHERE p.pid = '{$mybb->input['pid']}' LIMIT 1");
 		$fid = $db->fetch_field($query, 'fid');
 
 		if($fid)

--- a/polls.php
+++ b/polls.php
@@ -917,8 +917,7 @@ if($mybb->input['action'] == "vote" && $mybb->request_method == "post")
 
 	$poll['timeout'] = $poll['timeout']*60*60*24;
 
-	$query = $db->simple_select("threads", "*", "poll='".(int)$poll['pid']."'");
-	$thread = $db->fetch_array($query);
+	$thread = get_thread($poll['tid']);
 
 	if(!$thread || ($thread['visible'] != 1 && ($thread['visible'] == 0 && !is_moderator($thread['fid'], "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($thread['fid'], "canviewdeleted"))))
 	{


### PR DESCRIPTION
Removes a query against the non-indexed `poll` column in the `threads` table in favor of get_thread() using the poll tid.