### PR TITLE
Add the new `funding.yml` file to show a sponsor button on GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: mybb


### PR DESCRIPTION
See the [documentation available here](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository). This will show a sponsor button on this repository to direct users towards OpenCollective.