### PR TITLE
Resolve #3762 Purging guest sessions by IP address may invalidate anti-CSRF tokens between requests

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -287,7 +287,7 @@ if($mybb->settings['browsingthisforum'] != 0)
 		SELECT s.ip, s.uid, u.username, s.time, u.invisible, u.usergroup, u.usergroup, u.displaygroup
 		FROM ".TABLE_PREFIX."sessions s
 		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time > '$timecut' AND location1='$fid' AND nopermission != 1
+		WHERE s.isunique = 1 AND s.time > '$timecut' AND location1='$fid' AND nopermission != 1
 		ORDER BY u.username ASC, s.time DESC
 	");
 

--- a/inc/class_session.php
+++ b/inc/class_session.php
@@ -476,8 +476,16 @@ class session
 		
 		$onlinedata['location1'] = (int)$speciallocs['1'];
 		$onlinedata['location2'] = (int)$speciallocs['2'];
+		$onlinedata['isunique'] = 1;
 		$onlinedata['nopermission'] = 0;
 		$sid = $db->escape_string($sid);
+
+		if ($uid == 0)
+		{
+			$db->update_query("sessions", array(
+				'isunique' => 0,
+			), "ip=".$db->escape_binary($this->packedip)." AND uid=0 AND sid!='{$sid}'");
+		}
 
 		$db->update_query("sessions", $onlinedata, "sid='{$sid}'");
 	}
@@ -503,10 +511,13 @@ class session
 		{
 			$db->delete_query("sessions", "sid='{$this->sid}'");
 		}
-		// Else delete by ip.
+		// Else set other sessions as not unique by ip.
 		else
 		{
-			$db->delete_query("sessions", "ip=".$db->escape_binary($this->packedip));
+			$db->update_query("sessions", array(
+				'isunique' => 0,
+			), "ip=".$db->escape_binary($this->packedip));
+
 			$onlinedata['uid'] = 0;
 		}
 
@@ -527,6 +538,7 @@ class session
 		
 		$onlinedata['location1'] = (int)$speciallocs['1'];
 		$onlinedata['location2'] = (int)$speciallocs['2'];
+		$onlinedata['isunique'] = 1;
 		$onlinedata['nopermission'] = 0;
 		$db->replace_query("sessions", $onlinedata, "sid", false);
 		$this->sid = $onlinedata['sid'];

--- a/index.php
+++ b/index.php
@@ -61,7 +61,7 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 		SELECT s.sid, s.ip, s.uid, s.time, s.location, s.location1, u.username, u.invisible, u.usergroup, u.displaygroup
 		FROM ".TABLE_PREFIX."sessions s
 		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time > '".$timesearch."'
+		WHERE s.isunique = 1 AND s.time > '".$timesearch."'
 		ORDER BY {$order_by}, {$order_by2}
 	");
 

--- a/install/resources/mysql_db_tables.php
+++ b/install/resources/mysql_db_tables.php
@@ -724,9 +724,11 @@ $tables[] = "CREATE TABLE mybb_sessions (
   nopermission tinyint(1) NOT NULL default '0',
   location1 int(10) unsigned NOT NULL default '0',
   location2 int(10) unsigned NOT NULL default '0',
+  isunique tinyint(1) NOT NULL default '0',
   PRIMARY KEY(sid),
   KEY location (location1, location2),
   KEY time (time),
+  KEY isunique (isunique),
   KEY uid (uid),
   KEY ip (ip)
 ) ENGINE=MyISAM;";

--- a/install/resources/pgsql_db_tables.php
+++ b/install/resources/pgsql_db_tables.php
@@ -694,6 +694,7 @@ $tables[] = "CREATE TABLE mybb_sessions (
   nopermission smallint NOT NULL default '0',
   location1 int NOT NULL default '0',
   location2 int NOT NULL default '0',
+  isunique smallint NOT NULL DEFAULT '0',
   UNIQUE (sid)
 );";
 

--- a/install/resources/pgsql_db_tables.php
+++ b/install/resources/pgsql_db_tables.php
@@ -694,7 +694,7 @@ $tables[] = "CREATE TABLE mybb_sessions (
   nopermission smallint NOT NULL default '0',
   location1 int NOT NULL default '0',
   location2 int NOT NULL default '0',
-  isunique smallint NOT NULL DEFAULT '0',
+  isunique smallint NOT NULL default '0',
   UNIQUE (sid)
 );";
 

--- a/install/resources/sqlite_db_tables.php
+++ b/install/resources/sqlite_db_tables.php
@@ -645,7 +645,8 @@ $tables[] = "CREATE TABLE mybb_sessions (
 	anonymous tinyint(1) NOT NULL default '0',
 	nopermission tinyint(1) NOT NULL default '0',
 	location1 int(10) NOT NULL default '0',
-	location2 int(10) NOT NULL default '0'
+	location2 int(10) NOT NULL default '0',
+    isunique tinyint(1) NOT NULL DEFAULT '0'
 );";
 
 $tables[] = "CREATE TABLE mybb_settinggroups (

--- a/install/resources/sqlite_db_tables.php
+++ b/install/resources/sqlite_db_tables.php
@@ -646,7 +646,7 @@ $tables[] = "CREATE TABLE mybb_sessions (
 	nopermission tinyint(1) NOT NULL default '0',
 	location1 int(10) NOT NULL default '0',
 	location2 int(10) NOT NULL default '0',
-    isunique tinyint(1) NOT NULL default '0'
+	isunique tinyint(1) NOT NULL default '0'
 );";
 
 $tables[] = "CREATE TABLE mybb_settinggroups (

--- a/install/resources/sqlite_db_tables.php
+++ b/install/resources/sqlite_db_tables.php
@@ -646,7 +646,7 @@ $tables[] = "CREATE TABLE mybb_sessions (
 	nopermission tinyint(1) NOT NULL default '0',
 	location1 int(10) NOT NULL default '0',
 	location2 int(10) NOT NULL default '0',
-    isunique tinyint(1) NOT NULL DEFAULT '0'
+    isunique tinyint(1) NOT NULL default '0'
 );";
 
 $tables[] = "CREATE TABLE mybb_settinggroups (

--- a/install/resources/upgrade49.php
+++ b/install/resources/upgrade49.php
@@ -41,6 +41,7 @@ function upgrade49_dbchanges()
 				break;
 			default:
 				$db->add_column("sessions", "isunique", "tinyint(1) NOT NULL default '0'");
+				$db->write_query("ALTER TABLE ".TABLE_PREFIX."sessions ADD INDEX isunique (isunique)");
 				break;
 		}
 	}

--- a/install/resources/upgrade49.php
+++ b/install/resources/upgrade49.php
@@ -31,6 +31,20 @@ function upgrade49_dbchanges()
 
 	$db->delete_query("settings", "name='allowyahoofield'");
 
+	if (!$db->field_exists("isunique", "sessions"))
+	{
+		switch ($db->type)
+		{
+			case "pgsql":
+			case "sqlite":
+				$db->add_column("sessions", "isunique", "smallint NOT NULL default '0'");
+				break;
+			default:
+				$db->add_column("sessions", "isunique", "tinyint(1) NOT NULL default '0'");
+				break;
+		}
+	}
+
 	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
 	$output->print_footer("49_done");
 }

--- a/online.php
+++ b/online.php
@@ -159,7 +159,7 @@ else
 	{
 		case "sqlite":
 			$sessions = array();
-			$query = $db->simple_select("sessions", "sid", "time > {$timesearch}");
+			$query = $db->simple_select("sessions", "sid", "isunique = 1 AND time > {$timesearch}");
 			while($sid = $db->fetch_field($query, "sid"))
 			{
 				$sessions[$sid] = 1;
@@ -169,7 +169,7 @@ else
 			break;
 		case "pgsql":
 		default:
-			$query = $db->simple_select("sessions", "COUNT(sid) as online", "time > {$timesearch}");
+			$query = $db->simple_select("sessions", "COUNT(sid) as online", "isunique = 1 AND time > {$timesearch}");
 			$online_count = $db->fetch_field($query, "online");
 			break;
 	}
@@ -207,7 +207,7 @@ else
 		SELECT DISTINCT s.sid, s.ip, s.uid, s.time, s.location, u.username, s.nopermission, u.invisible, u.usergroup, u.displaygroup
 		FROM ".TABLE_PREFIX."sessions s
 		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time>'$timesearch'
+		WHERE s.isunique = 1 AND s.time>'$timesearch'
 		ORDER BY $sql
 		LIMIT {$start}, {$perpage}
 	");

--- a/portal.php
+++ b/portal.php
@@ -239,7 +239,7 @@ if($mybb->settings['portal_showwol'] != 0 && $mybb->usergroup['canviewonline'] !
 		SELECT s.sid, s.ip, s.uid, s.time, s.location, u.username, u.invisible, u.usergroup, u.displaygroup
 		FROM ".TABLE_PREFIX."sessions s
 		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time>'$timesearch'
+		WHERE s.isunique = 1 AND s.time>'$timesearch'
 		ORDER BY {$order_by}, {$order_by2}
 	");
 

--- a/showthread.php
+++ b/showthread.php
@@ -1521,7 +1521,7 @@ if($mybb->input['action'] == "thread")
 			SELECT s.ip, s.uid, s.time, u.username, u.invisible, u.usergroup, u.displaygroup
 			FROM ".TABLE_PREFIX."sessions s
 			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-			WHERE s.time > '$timecut' AND location2='$tid' AND nopermission != 1
+			WHERE s.isunique = 1 AND s.time > '$timecut' AND location2='$tid' AND nopermission != 1
 			ORDER BY u.username ASC, s.time DESC
 		");
 


### PR DESCRIPTION
Resolves #3762.

To continue using the `mybb_sessions` table / `session` class for CSRF prevention tokens for guest users:
- a `mybb_sessions.isunique` column is created to indicate whether the session should be representative of a unique user and included in online counts/lists,
- the session system logic is modified to set old, conflicting sessions as not unique instead of having them deleted (resulting in additional `UPDATE` query for guest users in `session::update_session()`, which is called instead of `session::create_session()` as sessions continue with no disruption),
- online statistics sections are limited to unique sessions by extending general `SELECT` queries of `mybb_sessions` with a `isunique = 1` condition.

Alternatively to `isunique`-like column, `SELECT` queries could be extended to return most recent rows by IP; this approach would need to be compatible with database engine versions [supported by MyBB 1.8](https://docs.mybb.com/1.8/install/requirements/).

These changes are not intended to modify the original behavior of the session system in relation to numbers and listings of active users.