### PR TITLE
Fix errors in pull #3740 calling undefined `Form` objects

### DIFF
--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -2662,6 +2662,7 @@ document.write('".str_replace("/", "\/", $field_select)."');
 
 /**
  * @param DefaultFormContainer $form_container
+ * @param DefaultForm $form
  * @param int $pid
  * @param int $depth
  */

--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -2289,7 +2289,7 @@ if(!$mybb->input['action'])
 	$form_container->output_row_header($lang->order, array("class" => "align_center", 'width' => '5%'));
 	$form_container->output_row_header($lang->controls, array("class" => "align_center", 'style' => 'width: 200px'));
 
-	build_admincp_forums_list($form_container, $fid);
+	build_admincp_forums_list($form_container, $form, $fid);
 
 	$submit_options = array();
 
@@ -2665,7 +2665,7 @@ document.write('".str_replace("/", "\/", $field_select)."');
  * @param int $pid
  * @param int $depth
  */
-function build_admincp_forums_list(&$form_container, $pid=0, $depth=1)
+function build_admincp_forums_list(&$form_container, &$form, $pid=0, $depth=1)
 {
 	global $mybb, $lang, $db, $sub_forums;
 	static $forums_by_parent;
@@ -2701,7 +2701,7 @@ function build_admincp_forums_list(&$form_container, $pid=0, $depth=1)
 				$sub_forums = '';
 				if(isset($forums_by_parent[$forum['fid']]) && $depth == 2)
 				{
-					build_admincp_forums_list($form_container, $forum['fid'], $depth+1);
+					build_admincp_forums_list($form_container, $form, $forum['fid'], $depth+1);
 				}
 				if($sub_forums)
 				{
@@ -2710,7 +2710,7 @@ function build_admincp_forums_list(&$form_container, $pid=0, $depth=1)
 
 				$form_container->output_cell("<div style=\"padding-left: ".(40*($depth-1))."px;\"><a href=\"index.php?module=forum-management&amp;fid={$forum['fid']}\"><strong>{$forum['name']}</strong></a>{$sub_forums}</div>");
 
-				$form_container->output_cell($form->generate_numeric_field("disporder[{$forum['fid']}]", "{$forum['disporder']}", array('class' => 'align_center', 'style' => 'width:80%; font-weight:bold')), array("class" => "align_center"));
+				$form_container->output_cell($form->generate_numeric_field("disporder[{$forum['fid']}]", "{$forum['disporder']}", array('min' => 0, 'class' => 'align_center', 'style' => 'width:80%; font-weight:bold')), array("class" => "align_center"));
 
 				$popup = new PopupMenu("forum_{$forum['fid']}", $lang->options);
 				$popup->add_item($lang->edit_forum, "index.php?module=forum-management&amp;action=edit&amp;fid={$forum['fid']}");
@@ -2728,7 +2728,7 @@ function build_admincp_forums_list(&$form_container, $pid=0, $depth=1)
 				// Does this category have any sub forums?
 				if($forums_by_parent[$forum['fid']])
 				{
-					build_admincp_forums_list($form_container, $forum['fid'], $depth+1);
+					build_admincp_forums_list($form_container, $form, $forum['fid'], $depth+1);
 				}
 			}
 			elseif($forum['type'] == "f" && ($depth == 1 || $depth == 2))
@@ -2742,7 +2742,7 @@ function build_admincp_forums_list(&$form_container, $pid=0, $depth=1)
 				$sub_forums = '';
 				if(isset($forums_by_parent[$forum['fid']]) && $depth == 2)
 				{
-					build_admincp_forums_list($form_container, $forum['fid'], $depth+1);
+					build_admincp_forums_list($form_container, $form, $forum['fid'], $depth+1);
 				}
 				if($sub_forums)
 				{
@@ -2751,7 +2751,7 @@ function build_admincp_forums_list(&$form_container, $pid=0, $depth=1)
 
 				$form_container->output_cell("<div style=\"padding-left: ".(40*($depth-1))."px;\"><a href=\"index.php?module=forum-management&amp;fid={$forum['fid']}\">{$forum['name']}</a>{$forum['description']}{$sub_forums}</div>");
 
-				$form_container->output_cell($form->generate_numeric_field("disporder[{$forum['fid']}]", "{$forum['disporder']}", array('class' => 'align_center', 'style' => 'width:80%')), array("class" => "align_center"));
+				$form_container->output_cell($form->generate_numeric_field("disporder[{$forum['fid']}]", "{$forum['disporder']}", array('min' => 0, 'class' => 'align_center', 'style' => 'width:80%')), array("class" => "align_center"));
 				$popup = new PopupMenu("forum_{$forum['fid']}", $lang->options);
 				$popup->add_item($lang->edit_forum, "index.php?module=forum-management&amp;action=edit&amp;fid={$forum['fid']}");
 				$popup->add_item($lang->subforums, "index.php?module=forum-management&amp;fid={$forum['fid']}");
@@ -2767,7 +2767,7 @@ function build_admincp_forums_list(&$form_container, $pid=0, $depth=1)
 
 				if(isset($forums_by_parent[$forum['fid']]) && $depth == 1)
 				{
-					build_admincp_forums_list($form_container, $forum['fid'], $depth+1);
+					build_admincp_forums_list($form_container, $form, $forum['fid'], $depth+1);
 				}
 			}
 			else if($depth == 3)


### PR DESCRIPTION
Fix errors of calling undefined `Form` objects in AdminCP > forum management since committed PR #3740 (fixes #3739).

Also add minimum values to those two numeric fields of `disporder`.