### PR TITLE
Fix errors on showteam and usercp_forumsubscriptions

### DIFF
--- a/inc/views/base/showteam/showteam.twig
+++ b/inc/views/base/showteam/showteam.twig
@@ -38,6 +38,15 @@
                                             {% endfor %}
                                         </span>
                                     </li>
+                                 {% elseif usergroup.gid == 0 %}
+                                    <li class="list__item">
+                                        <span class="list__field">{{ lang.mod_groups }}</span>
+                                        <span class="list__value commas">
+                                            {% for group in user.grouplist %}
+                                                <span>{{ group|raw }}</span>
+                                            {% endfor %}
+                                        </span>
+                                    </li>
                                 {% endif %}
                             </ul>
                             <div class="user-list__buttons">

--- a/showteam.php
+++ b/showteam.php
@@ -119,7 +119,7 @@ if($mybb->settings['showgroupleaders'])
 
 		while($leaded_group = $db->fetch_array($query))
 		{
-			$leaded_groups[$leaded_group['gid']] = str_replace("{username}",$leaded_group['title'], $leaded_group['namestyle']);
+			$leaded_groups[$leaded_group['gid']] = str_replace("{username}", $leaded_group['title'], $leaded_group['namestyle']);
 		}
 
 		// Create virtual usergroup container for leaders
@@ -127,10 +127,8 @@ if($mybb->settings['showgroupleaders'])
 		foreach($leaderlist as $uid => $leaded)
 		{
 			foreach($leaded as $gid){
-				$leadlist[] = $leaded_groups[$gid];
+				$usergroups[0]['user_list'][$uid]['grouplist'][] = $leaded_groups[$gid];
 			}
-			$usergroups[0]['user_list'][$uid]['leaded'] = implode(", ",$leadlist);
-			unset($leadlist);
 		}
 
 		$users_in = implode(",", array_keys(array_flip(explode(",", implode(",", array_keys($leaderlist)).",".$users_in))));
@@ -156,6 +154,12 @@ while ($user = $db->fetch_array($query)) {
 
     if ($user['displaygroup'] == '6' || $user['usergroup'] == '6') {
         $usergroups[6]['user_list'][$user['uid']] = $user;
+    }
+
+    // Group leaders.
+    if (isset($usergroups[0]['user_list']) && array_key_exists($user['uid'], $usergroups[0]['user_list'])) {
+        $user['grouplist'] = $usergroups[0]['user_list'][$user['uid']]['grouplist'];
+        $usergroups[0]['user_list'][$user['uid']] = $user;
     }
 
     // Are they also in another group which is being shown on the list?

--- a/usercp.php
+++ b/usercp.php
@@ -1031,6 +1031,7 @@ if ($mybb->input['action'] == 'forumsubscriptions') {
                 'profile_link' => $lastpost_profilelink,
                 'last_poster_avatar_url' => $forum['last_poster_avatar'],
                 'lastposter' => $lastposter,
+                'lastposteruid' => $forum['lastposteruid'],
             ];
         }
 


### PR DESCRIPTION
Fix errors on `showteam` when there are group leaders to display.
Fix errors on Forum Subscriptions page in UserCP with adding a missing `lastposteruid` variable.

These problems have been tracked in #3785. I'll try to fix other issues in separated PRs.