### PR TITLE
Add missing PM menu, fix fetch_remote_file(), remove thread rating, minor template fix, etc.

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -910,6 +910,11 @@ if ($foruminfo['type'] != "c") {
     $prefixselect = build_forum_prefix_select($fid, $tprefix);
 }
 
+// User posting has been suspended?
+if (isset($mybb->user['suspendposting']) && $mybb->user['suspendposting']) {
+    $fpermissions['canpostthreads'] = 0;
+}
+
 $plugins->run_hooks('forumdisplay_end');
 
 $foruminfo['name'] = strip_tags($foruminfo['name']);

--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -172,7 +172,7 @@ foreach ($parentlistexploded as $mfid) {
                     $moderator['profilelink'] = get_profile_link($moderator['id']);
                     $moderator['username'] = format_name(htmlspecialchars_uni($moderator['username']), $moderator['usergroup'], $moderator['displaygroup']);
 
-                    $moderator['users'][$moderator['id']] = $moderator;
+                    $moderators['users'][$moderator['id']] = $moderator;
                 }
             }
         }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -5784,7 +5784,7 @@ function fetch_remote_file($url, $post_data=array(), $max_redirects=20)
             $body = substr($response, $header_size);
 
             if (in_array(curl_getinfo($ch, CURLINFO_HTTP_CODE), array(301, 302))) {
-                preg_match('/Location:(.*?)(?:\n|$)/', $header, $matches);
+                preg_match('/^Location:(.*?)(?:\n|$)/im', $header, $matches);
 
                 if ($matches) {
                     $data = fetch_remote_file(trim(array_pop($matches)), $post_data, --$max_redirects);
@@ -5882,7 +5882,7 @@ function fetch_remote_file($url, $post_data=array(), $max_redirects=20)
         $body = $data[1];
 
         if ($max_redirects > 0 && (strstr($status_line, ' 301 ') || strstr($status_line, ' 302 '))) {
-            preg_match('/Location:(.*?)(?:\n|$)/', $header, $matches);
+            preg_match('/^Location:(.*?)(?:\n|$)/im', $header, $matches);
 
             if ($matches) {
                 $data = fetch_remote_file(trim(array_pop($matches)), $post_data, --$max_redirects);

--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -375,7 +375,6 @@ SQL;
 									}
 
 									$moderator['profilelink'] = get_profile_link($moderator['id']);
-									$moderator['username'] = format_name(htmlspecialchars_uni($moderator['username']), $moderator['usergroup'], $moderator['displaygroup']);
 									$moderator['type'] = 'user';
 									$moderators[] = $moderator;
 									$done_moderators['users'][] = $moderator['id'];

--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -375,6 +375,7 @@ SQL;
 									}
 
 									$moderator['profilelink'] = get_profile_link($moderator['id']);
+									$moderator['username'] = format_name(htmlspecialchars_uni($moderator['username']), $moderator['usergroup'], $moderator['displaygroup']);
 									$moderator['type'] = 'user';
 									$moderators[] = $moderator;
 									$done_moderators['users'][] = $moderator['id'];

--- a/inc/views/base/forumbit/depth_2/forum.twig
+++ b/inc/views/base/forumbit/depth_2/forum.twig
@@ -6,9 +6,9 @@
             {{ lang.forumbit_moderated_by }}
             {% for moderator in moderators %}
                 {% if moderator.type == 'group' %}
-                    {{ moderator.title|raw }}
+                    {{ moderator.title }}
                 {% elseif moderator.type == 'user' %}
-                    <a href="{{ moderator.profilelink }}">{{ moderator.username|raw }}</a>
+                    <a href="{{ moderator.profilelink }}">{{ moderator.username }}</a>
                 {% endif %}
                 {% if loop.last != true %}{{ lang.comma }} {% endif %}
             {% endfor %}

--- a/inc/views/base/forumbit/depth_2/forum.twig
+++ b/inc/views/base/forumbit/depth_2/forum.twig
@@ -5,12 +5,12 @@
         <p class="forum__moderators">
             {{ lang.forumbit_moderated_by }}
             {% for moderator in moderators %}
-                {% if loop.last != true %}{{ lang.comma }} {% endif %}
                 {% if moderator.type == 'group' %}
                     {{ moderator.title }}
                 {% elseif moderator.type == 'user' %}
                     <a href="{{ moderator.profilelink }}">{{ moderator.username }}</a>
                 {% endif %}
+                {% if loop.last != true %}{{ lang.comma }} {% endif %}
             {% endfor %}
         </p>
     {% endif %}

--- a/inc/views/base/forumbit/depth_2/forum.twig
+++ b/inc/views/base/forumbit/depth_2/forum.twig
@@ -6,9 +6,9 @@
             {{ lang.forumbit_moderated_by }}
             {% for moderator in moderators %}
                 {% if moderator.type == 'group' %}
-                    {{ moderator.title }}
+                    {{ moderator.title|raw }}
                 {% elseif moderator.type == 'user' %}
-                    <a href="{{ moderator.profilelink }}">{{ moderator.username }}</a>
+                    <a href="{{ moderator.profilelink }}">{{ moderator.username|raw }}</a>
                 {% endif %}
                 {% if loop.last != true %}{{ lang.comma }} {% endif %}
             {% endfor %}

--- a/inc/views/base/forumdisplay/forumdisplay.twig
+++ b/inc/views/base/forumdisplay/forumdisplay.twig
@@ -39,11 +39,10 @@
             <p>{{ lang.moderated_by }}
                 <strong>
                     {% for moderator in moderators.users %}
-                        <a href="{{ moderator.profilelink }}">{{ moderator.username }}</a>{% if loop.last == false %}{{ lang.comma }} {% endif %}
+                        <a href="{{ moderator.profilelink }}">{{ moderator.username|raw }}</a>{% if loop.last == false or moderators.groups is not empty %}{{ lang.comma }} {% endif %}
                     {% endfor %}
-                    {% if moderators.groups %}{{ lang.comma }} {% endif %}
                     {% for moderator in moderators.groups %}
-                        {{ moderator.title }}{% if loop.last == false %}{{ lang.comma }} {% endif %}
+                        {{ moderator.title|raw }}{% if loop.last == false %}{{ lang.comma }} {% endif %}
                     {% endfor %}
                 </strong>
             </p>

--- a/inc/views/base/forumdisplay/forumdisplay.twig
+++ b/inc/views/base/forumdisplay/forumdisplay.twig
@@ -71,7 +71,7 @@
             </section>
         {% endif %}
 
-        {% if foruminfo.type == 'f' and foruminfo.open and fpermissions.canpostthreads and mybb.user.suspendposting is not empty %}
+        {% if foruminfo.type == 'f' and foruminfo.open and fpermissions.canpostthreads %}
             {% set newthread %}
                 <a href="newthread.php?fid={{ foruminfo.fid }}" class="button button--medium button--full-width">
                     {{ include('partials/icon.twig', {icon: 'pencil-alt', class: 'button__icon'}, with_context = false) }}

--- a/inc/views/base/forumdisplay/forumdisplay.twig
+++ b/inc/views/base/forumdisplay/forumdisplay.twig
@@ -241,7 +241,7 @@
                                 <option value="{{ field }}"{% if mybb.input[field] %} selected{% endif %}>{{ attribute(lang, 'sort_by_' ~ field) }}</option>
                             {% endfor %}
                             {% if displayRating %}
-                                <option value="rating"{% if mybb.input.rating %} selected{% endif %}>{{ lang.sort_by_rating }}</option>
+                                {#<option value="rating"{% if mybb.input.rating %} selected{% endif %}>{{ lang.sort_by_rating }}</option>#}
                             {% endif %}
                         </select>
                     </div>

--- a/inc/views/base/layouts/messenger.twig
+++ b/inc/views/base/layouts/messenger.twig
@@ -10,7 +10,7 @@
             <li class="section-menu__item section-menu__item--messenger-compose{% if mybb.input.action == 'send' %} section-menu__item--active{% endif %}">
                 <a href="private.php?action=send" class="section-menu__link">
                     {{ include('partials/icon.twig', {icon: 'edit', class: 'section-menu__icon fa-fw'}, with_context = false) }}
-                    <span class="section-menu__text">{{ lang.ucp_nav_compose }}</span>
+                    <span class="section-menu__text">{{ lang.nav_send }}</span>
                 </a>
             </li>
         {% endif %}
@@ -37,14 +37,26 @@
             <li class="section-menu__item section-menu__item--messenger-tracking{% if mybb.input.action == 'tracking' %} section-menu__item--active{% endif %}">
                 <a href="private.php?action=tracking" class="section-menu__link">
                     {{ include('partials/icon.twig', {icon: 'bell', class: 'section-menu__icon fa-fw'}, with_context = false) }}
-                    <span class="section-menu__text">{{ lang.ucp_nav_tracking }}</span>
+                    <span class="section-menu__text">{{ lang.nav_tracking }}</span>
                 </a>
             </li>
         {% endif %}
         <li class="section-menu__item section-menu__item--messenger-edit-folders{% if mybb.input.action == 'folders' %} section-menu__item--active{% endif %}">
             <a href="private.php?action=folders" class="section-menu__link">
                 {{ include('partials/icon.twig', {icon: 'folder-open', class: 'section-menu__icon fa-fw'}, with_context = false) }}
-                <span class="section-menu__text">{{ lang.ucp_nav_edit_folders }}</span>
+                <span class="section-menu__text">{{ lang.nav_folders }}</span>
+            </a>
+        </li>
+        <li class="section-menu__item section-menu__item--messenger-empty-folders{% if mybb.input.action == 'empty' %} section-menu__item--active{% endif %}">
+            <a href="private.php?action=empty" class="section-menu__link">
+                {{ include('partials/icon.twig', {icon: 'folder-minus', class: 'section-menu__icon fa-fw'}, with_context = false) }}
+                <span class="section-menu__text">{{ lang.nav_empty }}</span>
+            </a>
+        </li>
+        <li class="section-menu__item section-menu__item--messenger-export-messenges{% if mybb.input.action == 'export' %} section-menu__item--active{% endif %}">
+            <a href="private.php?action=export" class="section-menu__link">
+                {{ include('partials/icon.twig', {icon: 'file-export', class: 'section-menu__icon fa-fw'}, with_context = false) }}
+                <span class="section-menu__text">{{ lang.nav_export }}</span>
             </a>
         </li>
     </ul>

--- a/inc/views/base/showthread/showthread.twig
+++ b/inc/views/base/showthread/showthread.twig
@@ -205,7 +205,7 @@
         </div>
 
         {% if mybb.settings.allowthreadratings and forum.allowtratings %}
-            <div style="margin-top: 6px; padding-right: 10px;" class="float_right">
+            {#<div style="margin-top: 6px; padding-right: 10px;" class="float_right">
                 <script type="text/javascript">
                 <!--
                     lang.ratings_update_error = "{{ lang.ratings_update_error }}";
@@ -223,7 +223,7 @@
                         <li><a class="five_stars" title="{{ lang.five_stars }}" href="./ratethread.php?tid={{ thread.tid }}&amp;rating=5&amp;my_post_key={{ mybb.post_code }}">5</a></li>
                     </ul>
                 </div>
-            </div>
+            </div> #}
         {% endif %}
 
         <section class="post-list" id="posts">


### PR DESCRIPTION
- Add Empty Folders & Export Messages back on PM menu. I'm not sure they're missing for an intentional reason. Icons might need replacement, ping @justinsoltesz here.
- Fix wrong `,` (comma) position in displaying moderators in forum listing.
- Fix post thread button showing on `forumdisplay` page for guest uses. Let Twig do less PHP job.
- Fix #3786 enforced case sensitivity check in `fetch_remote_file()`.
- Fix moderators not showing on forumdisplay page and minor tweak on using `,`(comma).
- #3498 code clean up, remove thread rating by commenting them in templates `showthread` and `forumdisplay`. (PHP scripts including `forumdisplay.php`, `showthread` and ratethread.php` and JavaScript `./jscripts/ratings.js` are left as what they were, where codes of thread rating are not touched.)


These problems have been tracked in #3785. I'll try to fix other issues in separated PRs.