### PR TITLE
Fix #3123 - StopForumSpam confidence levels

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "illuminate/events": "5.7.*",
         "illuminate/hashing": "5.7.*",
         "illuminate/routing": "5.7.*",
-        "twig/twig": "^2.11"
+        "twig/twig": "^2.11",
+        "ext-json": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",

--- a/inc/src/AntiSpam/AntiSpamServiceInterface.php
+++ b/inc/src/AntiSpam/AntiSpamServiceInterface.php
@@ -18,5 +18,5 @@ interface AntiSpamServiceInterface
      *
      * @return \MyBB\AntiSpam\CheckResult The result of the check.
      */
-    function checkUser(string $username, string $emailAddress, string $ipAddress): CheckResult;
+    public function checkUser(string $username, string $emailAddress, string $ipAddress): CheckResult;
 }

--- a/inc/src/AntiSpam/AntiSpamServiceInterface.php
+++ b/inc/src/AntiSpam/AntiSpamServiceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\AntiSpam;
+
+/**
+ * Interface to check a user against an anti-spam service.
+ */
+interface AntiSpamServiceInterface
+{
+    /**
+     * Check whether a user is a spammer according to the anti-spam service.
+     *
+     * @param string $username The username of the user to check.
+     * @param string $emailAddress The email address of the user to check.
+     * @param string $ipAddress The IP address of the user to check.
+     *
+     * @return \MyBB\AntiSpam\CheckResult The result of the check.
+     */
+    function check(string $username, string $emailAddress, string $ipAddress): CheckResult;
+}

--- a/inc/src/AntiSpam/AntiSpamServiceInterface.php
+++ b/inc/src/AntiSpam/AntiSpamServiceInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MyBB\AntiSpam;
 
 /**
- * Interface to check a user against an anti-spam service.
+ * Interface to check content against an anti-spam service.
  */
 interface AntiSpamServiceInterface
 {
@@ -18,5 +18,5 @@ interface AntiSpamServiceInterface
      *
      * @return \MyBB\AntiSpam\CheckResult The result of the check.
      */
-    function check(string $username, string $emailAddress, string $ipAddress): CheckResult;
+    function checkUser(string $username, string $emailAddress, string $ipAddress): CheckResult;
 }

--- a/inc/src/AntiSpam/CheckResult.php
+++ b/inc/src/AntiSpam/CheckResult.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\AntiSpam;
+
+use InvalidArgumentException;
+
+class CheckResult
+{
+    /**
+     * The check passed, the service doesn't believe the user is a spammer.
+     */
+    const PASS = 0;
+
+    /**
+     * The check failed, the service believes the user is a spammer.
+     */
+    const FAIL = 1;
+
+    /**
+     * The check errored out when contacting the service.
+     */
+    const ERROR = 2;
+
+    /**
+     * One of {@see \MyBB\AntiSpam\CheckResult::PASS}, {@see \MyBB\AntiSpam\CheckResult::FAIL},
+     * {@see \MyBB\AntiSpam\CheckResult::ERROR}.
+     *
+     * @var int
+     */
+    private $result;
+
+    /**
+     * @var string
+     */
+    private $error;
+
+    /**
+     * @var float
+     */
+    private $totalConfidence;
+
+    /**
+     * @var int
+     */
+    private $numberOfChecks;
+
+    /**
+     * @var float
+     */
+    private $usernameConfidence;
+
+    /**
+     * @var float
+     */
+    private $emailAddressConfidence;
+
+    /**
+     * @var float
+     */
+    private $ipAddressConfidence;
+
+    public function __construct()
+    {
+        $this->result = static::PASS;
+        $this->error = '';
+        $this->totalConfidence = 0.0;
+        $this->numberOfChecks = 0;
+        $this->usernameConfidence = 0.0;
+        $this->emailAddressConfidence = 0.0;
+        $this->ipAddressConfidence = 0.0;
+    }
+
+    /**
+     * @return float
+     */
+    public function getAverageConfidence(): float
+    {
+        return $this->totalConfidence / $this->numberOfChecks;
+    }
+
+    /**
+     * @return int
+     */
+    public function getResult(): int
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param int $result
+     *
+     * @return self
+     *
+     * @throws \InvalidArgumentException Thrown if {@see $result} is not one of {@see \MyBB\AntiSpam\CheckResult::PASS},
+     * {@see \MyBB\AntiSpam\CheckResult::FAIL}, {@see \MyBB\AntiSpam\CheckResult::ERROR}.
+     */
+    public function setResult(int $result): self
+    {
+        if (!in_array($result, [static::PASS, static::FAIL, static::ERROR])) {
+            throw new InvalidArgumentException('Result must be one of pass, fail or error');
+        }
+
+        $this->result = $result;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    /**
+     * @param string $error
+     *
+     * @return self
+     */
+    public function setError(string $error): self
+    {
+        $this->error = $error;
+
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getTotalConfidence(): float
+    {
+        return $this->totalConfidence;
+    }
+
+    /**
+     * @param float $totalConfidence
+     *
+     * @return self
+     */
+    public function setTotalConfidence(float $totalConfidence): self
+    {
+        $this->totalConfidence = $totalConfidence;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumberOfChecks(): int
+    {
+        return $this->numberOfChecks;
+    }
+
+    /**
+     * @param int $numberOfChecks
+     *
+     * @return self
+     */
+    public function setNumberOfChecks(int $numberOfChecks): self
+    {
+        $this->numberOfChecks = $numberOfChecks;
+
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getUsernameConfidence(): float
+    {
+        return $this->usernameConfidence;
+    }
+
+    /**
+     * @param float $usernameConfidence
+     *
+     * @return self
+     */
+    public function setUsernameConfidence(float $usernameConfidence): self
+    {
+        $this->usernameConfidence = $usernameConfidence;
+
+        $this->totalConfidence += $usernameConfidence;
+        $this->numberOfChecks++;
+
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getEmailAddressConfidence(): float
+    {
+        return $this->emailAddressConfidence;
+    }
+
+    /**
+     * @param float $emailAddressConfidence
+     *
+     * @return self
+     */
+    public function setEmailAddressConfidence(float $emailAddressConfidence): self
+    {
+        $this->emailAddressConfidence = $emailAddressConfidence;
+
+        $this->totalConfidence += $emailAddressConfidence;
+        $this->numberOfChecks++;
+
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getIpAddressConfidence(): float
+    {
+        return $this->ipAddressConfidence;
+    }
+
+    /**
+     * @param float $ipAddressConfidence
+     *
+     * @return self
+     */
+    public function setIpAddressConfidence(float $ipAddressConfidence): self
+    {
+        $this->ipAddressConfidence = $ipAddressConfidence;
+
+        $this->totalConfidence += $ipAddressConfidence;
+        $this->numberOfChecks++;
+
+        return $this;
+    }
+}

--- a/inc/src/AntiSpam/CheckResult.php
+++ b/inc/src/AntiSpam/CheckResult.php
@@ -9,12 +9,12 @@ use InvalidArgumentException;
 class CheckResult
 {
     /**
-     * The check passed, the service doesn't believe the user is a spammer.
+     * The check passed, the service doesn't believe the content is spam.
      */
     const PASS = 0;
 
     /**
-     * The check failed, the service believes the user is a spammer.
+     * The check failed, the service believes the content is spam.
      */
     const FAIL = 1;
 

--- a/inc/src/AntiSpam/Services/StopForumSpam.php
+++ b/inc/src/AntiSpam/Services/StopForumSpam.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\AntiSpam\Services;
+
+use MyBB;
+use MyBB\AntiSpam\AntiSpamServiceInterface;
+use MyBB\AntiSpam\CheckResult;
+use MyBB\Plugins\HookManager;
+
+class StopForumSpam implements AntiSpamServiceInterface
+{
+    private const URL = 'http://api.stopforumspam.org/api?confidence&json';
+
+    /**
+     * @var \MyBB
+     */
+    private $mybb;
+
+    /**
+     * @var \MyBB\Plugins\HookManager
+     */
+    private $plugins;
+
+    public function __construct(MyBB $mybb, HookManager $plugins)
+    {
+        $this->mybb = $mybb;
+        $this->plugins = $plugins;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    function check(string $username, string $emailAddress, string $ipAddress): CheckResult
+    {
+        $data = [];
+
+        $result = new CheckResult();
+
+        if ($this->mybb->settings['stopforumspam_min_username_weighting_before_spam'] > 0 &&
+            !is_null($username) && $username !== '') {
+            $data['username'] = urlencode($username);
+        }
+
+        if ($this->mybb->settings['stopforumspam_min_email_weighting_before_spam'] > 0 &&
+            !is_null($emailAddress) && $emailAddress !== '') {
+            $data['email'] = urlencode($emailAddress);
+        }
+
+        if ($this->mybb->settings['stopforumspam_min_ip_address_weighting_before_spam'] > 0 &&
+            !is_null($ipAddress) && $ipAddress !== '') {
+            $isInternalIpAddress = !filter_var(
+                $ipAddress,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE |  FILTER_FLAG_NO_RES_RANGE
+            );
+
+            if($isInternalIpAddress)
+            {
+                $result->setResult(CheckResult::PASS);
+
+                return $result;
+            }
+
+            $data['ip'] = urlencode($ipAddress);
+        }
+
+        if (empty($data)) {
+            $result->setResult(CheckResult::PASS);
+
+            return $result;
+        }
+
+        $url = static::URL . '&' . http_build_query($data);
+
+        $response = fetch_remote_file($url);
+
+        if ($response === null) {
+            $result->setResult(CheckResult::ERROR);
+            $result->setError('no_response');
+
+            return $result;
+        }
+
+        $responseJson = @json_decode($response);
+
+        if (is_null($responseJson)) {
+            $result->setResult(CheckResult::ERROR);
+            $result->setError(@json_last_error_msg());
+
+            return $result;
+        }
+
+        if (isset($responseJson->error)) {
+            $result->setResult(CheckResult::ERROR);
+            $result->setError($responseJson->error);
+
+            return $result;
+        }
+
+        if (isset($data['username']) && $responseJson->username->appears) {
+            $usernameConfidence = (float) $responseJson->username->confidence;
+
+            if ($usernameConfidence >= $this->mybb->settings['stopforumspam_min_username_weighting_before_spam']) {
+                $result->setResult(CheckResult::FAIL);
+            }
+
+            $result->setUsernameConfidence($usernameConfidence);
+        }
+
+        if (isset($data['email']) && $responseJson->email->appears) {
+            $emailConfidence = (float) $responseJson->email->confidence;
+
+            if ($emailConfidence >= $this->mybb->settings['stopforumspam_min_email_weighting_before_spam']) {
+                $result->setResult(CheckResult::FAIL);
+            }
+
+            $result->setEmailAddressConfidence($emailConfidence);
+        }
+
+        if (isset($data['ip']) && $responseJson->ip->appears) {
+            $ipConfidence = (float) $responseJson->ip->confidence;
+
+            if ($ipConfidence >= $this->mybb->settings['stopforumspam_min_ip_address_weighting_before_spam']) {
+                $result->setResult(CheckResult::FAIL);
+            }
+
+            $result->setIpAddressConfidence($ipConfidence);
+        }
+
+        $averageConfidence = $result->getAverageConfidence();
+
+        if ($averageConfidence >= $this->mybb->settings['stopforumspam_min_weighting_before_spam']) {
+            $result->setResult(CheckResult::FAIL);
+        }
+
+        $this->plugins->runHooks('stopforumspam_check_pre_return', $result);
+
+        return $result;
+    }
+}

--- a/inc/src/AntiSpam/Services/StopForumSpam.php
+++ b/inc/src/AntiSpam/Services/StopForumSpam.php
@@ -11,7 +11,7 @@ use MyBB\Plugins\HookManager;
 
 class StopForumSpam implements AntiSpamServiceInterface
 {
-    private const URL = 'http://api.stopforumspam.org/api?confidence&json';
+    private const URL = 'https://api.stopforumspam.org/api?confidence&json';
 
     /**
      * @var \MyBB
@@ -32,7 +32,7 @@ class StopForumSpam implements AntiSpamServiceInterface
     /**
      * @inheritDoc
      */
-    function check(string $username, string $emailAddress, string $ipAddress): CheckResult
+    function checkUser(string $username, string $emailAddress, string $ipAddress): CheckResult
     {
         $data = [];
 

--- a/inc/src/AntiSpam/Services/StopForumSpam.php
+++ b/inc/src/AntiSpam/Services/StopForumSpam.php
@@ -32,7 +32,7 @@ class StopForumSpam implements AntiSpamServiceInterface
     /**
      * @inheritDoc
      */
-    function checkUser(string $username, string $emailAddress, string $ipAddress): CheckResult
+    public function checkUser(string $username, string $emailAddress, string $ipAddress): CheckResult
     {
         $data = [];
 
@@ -56,8 +56,7 @@ class StopForumSpam implements AntiSpamServiceInterface
                 FILTER_FLAG_NO_PRIV_RANGE |  FILTER_FLAG_NO_RES_RANGE
             );
 
-            if($isInternalIpAddress)
-            {
+            if ($isInternalIpAddress) {
                 $result->setResult(CheckResult::PASS);
 
                 return $result;

--- a/tests/Unit/AntiSpam/CheckResultTest.php
+++ b/tests/Unit/AntiSpam/CheckResultTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Tests\Unit\AntiSpam;
+
+use InvalidArgumentException;
+use MyBB\AntiSpam\CheckResult;
+use MyBB\Tests\Unit\TestCase;
+
+class CheckResultTest extends TestCase
+{
+    public function testGetAverageConfidenceWithNoIndividualConfidences()
+    {
+        $checkResult = new CheckResult();
+
+        $this->assertEquals('0.00', number_format($checkResult->getTotalConfidence(), 2));
+        $this->assertEquals('0.00', number_format($checkResult->getResult(), 2));
+        $this->assertEquals(0, $checkResult->getNumberOfChecks());
+    }
+
+    public function testGetAverageConfidenceWithAllIndividualConfidences()
+    {
+        $checkResult = (new CheckResult())
+            ->setUsernameConfidence(99.95)
+            ->setEmailAddressConfidence(31.64)
+            ->setIpAddressConfidence(0.0);
+
+        $this->assertEquals('131.59', number_format($checkResult->getTotalConfidence(), 2));
+        $this->assertEquals('43.86', number_format($checkResult->getAverageConfidence(), 2));
+        $this->assertEquals(3, $checkResult->getNumberOfChecks());
+    }
+
+    public function testGetAverageConfidenceWithSomeConfidences()
+    {
+        $checkResult = (new CheckResult())
+            ->setUsernameConfidence(99.95)
+            ->setEmailAddressConfidence(31.64);
+
+        $this->assertEquals('131.59', number_format($checkResult->getTotalConfidence(), 2));
+        $this->assertEquals('65.80', number_format($checkResult->getAverageConfidence(), 2));
+        $this->assertEquals(2, $checkResult->getNumberOfChecks());
+    }
+
+    public function testSetResultWithInvalidValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Result must be one of pass, fail or error');
+
+        (new CheckResult())
+            ->setResult(10);
+    }
+}

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyBB\Tests\Unit;
 
 use MyBB\Tests\Unit\Traits\LegacyCoreAwareTest;

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyBB\Tests\Unit;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/tests/Unit/Traits/LegacyCoreAwareTest.php
+++ b/tests/Unit/Traits/LegacyCoreAwareTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace MyBB\Tests\Unit\Traits;
+declare(strict_types=1);
 
-use Mockery\Mock;
+namespace MyBB\Tests\Unit\Traits;
 
 /**
  * This trait can be used by any unit tests that is testing a legacy MyBB component.

--- a/tests/Unit/Utilities/BreadcrumbManagerTest.php
+++ b/tests/Unit/Utilities/BreadcrumbManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyBB\Tests\Unit\Utilities;
 
 use MyBB\Tests\Unit\TestCase;


### PR DESCRIPTION
Resolves #3123 

This is still a work in progress.

**TODO**

- [X] Add a new interface for classes to check against anti-spam interfaces
- [X] Better handling for errors when checking anti-spam services
- [X] Ability to check against individual confidence levels (username, email, IP address)
- [ ] New settings for the above
- [ ] Testing the new implementation
- [ ] Updating usages of the old implementation

