### PR TITLE
Fix potential security issue in class_session.php

### DIFF
--- a/inc/class_session.php
+++ b/inc/class_session.php
@@ -323,6 +323,7 @@ class session
 		// Set up some defaults
 		$time = TIME_NOW;
 		$mybb->user['usergroup'] = 1;
+		$mybb->user['additionalgroups'] = '';
 		$mybb->user['username'] = '';
 		$mybb->user['uid'] = 0;
 		$mybbgroups = 1;


### PR DESCRIPTION
Setting additional groups to empty can prevent the wrong users from potentially seeing privileged things, especially when using plugins that hook into the login process ([Mybb2fa](https://community.mybb.com/mods.php?action=view&pid=941) is affected by this).

Apologies if this isn't the correct format-- I'm new around these parts.