### PR TITLE
Fix #3828 - Alter the [font] MyCode

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -368,7 +368,7 @@ class postParser
 
 		if($mybb->settings['allowfontmycode'] == 1)
 		{
-			$nestable_mycode['font']['regex'] = "#\[font=(\\\"?)([a-z0-9 ,\-_']+)\\1\](.*?)\[/font\]#si";
+			$nestable_mycode['font']['regex'] = "#\[font=(\"?)([a-z0-9 ,\-_']+)\\1\](.*?)\[/font\]#si";
 			$nestable_mycode['font']['replacement'] = "<span style=\"font-family: $2;\" class=\"mycode_font\">$3</span>";
 
 			++$nestable_count;

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -368,7 +368,7 @@ class postParser
 
 		if($mybb->settings['allowfontmycode'] == 1)
 		{
-			$nestable_mycode['font']['regex'] = "#\[font=([\\\"']?)([a-z0-9 ,\-_]+)\\1\](.*?)\[\/font\]#si";
+			$nestable_mycode['font']['regex'] = "#\[font=(\\\"?)([a-z0-9 ,\-_']+)\\1\](.*?)\[/font\]#si";
 			$nestable_mycode['font']['replacement'] = "<span style=\"font-family: $2;\" class=\"mycode_font\">$3</span>";
 
 			++$nestable_count;

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -368,8 +368,8 @@ class postParser
 
 		if($mybb->settings['allowfontmycode'] == 1)
 		{
-			$nestable_mycode['font']['regex'] = "#\[font=([a-z0-9 ,\-_'\"]+)\](.*?)\[/font\]#si";
-			$nestable_mycode['font']['replacement'] = "<span style=\"font-family: $1;\" class=\"mycode_font\">$2</span>";
+			$nestable_mycode['font']['regex'] = "#\[font=([\\\"']?)([a-z0-9 ,\-_]+)\\1\](.*?)\[\/font\]#si";
+			$nestable_mycode['font']['replacement'] = "<span style=\"font-family: $2;\" class=\"mycode_font\">$3</span>";
 
 			++$nestable_count;
 		}


### PR DESCRIPTION
Fixes #3828 by altering the `[font]` MyCode to only allow quotes at the start and end and to ensure the used quotes match each other.

Tested locally using the provided broken tag examples.
