### PR TITLE
Extend #3774 quoting post from other threads not working

### DIFF
--- a/jscripts/post.js
+++ b/jscripts/post.js
@@ -69,7 +69,7 @@ var Post = {
 		}
 
 		var id = 'message';
-		if(typeof MyBBEditor != 'undefined')
+		if(typeof MyBBEditor !== 'undefined' && MyBBEditor !== null)
 		{
 			MyBBEditor.insert(json.message);
 		}

--- a/jscripts/thread.js
+++ b/jscripts/thread.js
@@ -133,7 +133,7 @@ var Thread = {
 			}
 		}
 
-		if(typeof MyBBEditor != 'undefined')
+		if(typeof MyBBEditor !== 'undefined' && MyBBEditor !== null)
 		{
 			MyBBEditor.insert(json.message);
 		}


### PR DESCRIPTION
Original issue: #3773.
Community thread: https://community.mybb.com/thread-224271.html

Fix multi-quoting when MyBBEditor is set to `null` for plain textarea input box pulled in https://github.com/mybb/mybb/pull/3774#issuecomment-561544068

Post the note here also, for quick reference:
> - `showthread` template includes `thread.js` only.
> - `newthread` & `newreply` templates include `post.js` only.

> In a default MyBB installation, the built-in SCEditor can only be enabled on full posting pages, i.e., `newthread` & `newreply` pages. Quick reply and vanilla text input box in newthread & newreply use `#message` as the input box's id. But it should be possible to enable quick reply to also use a WYSIWYG editor, and therefore `thread.js` & `post.js` should be able to both support where the WYSIWYG editor is not configured.
