### PR TITLE
Resolve #3762 Purging guest sessions by IP address may invalidate anti-CSRF tokens between requests

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -284,9 +284,15 @@ if($mybb->settings['browsingthisforum'] != 0)
 	$doneusers = array();
 
 	$query = $db->query("
-		SELECT s.ip, s.uid, u.username, s.time, u.invisible, u.usergroup, u.usergroup, u.displaygroup
-		FROM ".TABLE_PREFIX."sessions s
-		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
+		SELECT
+			s.ip, s.uid, u.username, s.time, u.invisible, u.usergroup, u.usergroup, u.displaygroup
+		FROM
+			".TABLE_PREFIX."sessions s
+			INNER JOIN (
+				SELECT uid, ip, MAX(time) AS time
+				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
+			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
+			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
 		WHERE s.time > '$timecut' AND location1='$fid' AND nopermission != 1
 		ORDER BY u.username ASC, s.time DESC
 	");

--- a/inc/class_session.php
+++ b/inc/class_session.php
@@ -503,10 +503,8 @@ class session
 		{
 			$db->delete_query("sessions", "sid='{$this->sid}'");
 		}
-		// Else delete by ip.
 		else
 		{
-			$db->delete_query("sessions", "ip=".$db->escape_binary($this->packedip));
 			$onlinedata['uid'] = 0;
 		}
 

--- a/inc/datahandlers/login.php
+++ b/inc/datahandlers/login.php
@@ -310,9 +310,6 @@ class LoginDataHandler extends DataHandler
 		my_setcookie('loginattempts', 1);
 		my_setcookie("sid", $session->sid, -1, true);
 
-		$ip_address = $db->escape_binary($session->packedip);
-		$db->delete_query("sessions", "ip = {$ip_address} AND sid != '{$session->sid}'");
-
 		$newsession = array(
 			"uid" => $user['uid'],
 		);

--- a/index.php
+++ b/index.php
@@ -58,9 +58,15 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 
 	$timesearch = TIME_NOW - (int)$mybb->settings['wolcutoff'];
 	$query = $db->query("
-		SELECT s.sid, s.ip, s.uid, s.time, s.location, s.location1, u.username, u.invisible, u.usergroup, u.displaygroup
-		FROM ".TABLE_PREFIX."sessions s
-		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
+		SELECT
+			s.sid, s.ip, s.uid, s.time, s.location, s.location1, u.username, u.invisible, u.usergroup, u.displaygroup
+		FROM
+			".TABLE_PREFIX."sessions s
+			INNER JOIN (
+				SELECT uid, ip, MAX(time) AS time
+				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
+			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
+			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
 		WHERE s.time > '".$timesearch."'
 		ORDER BY {$order_by}, {$order_by2}
 	");

--- a/online.php
+++ b/online.php
@@ -159,7 +159,9 @@ else
 	{
 		case "sqlite":
 			$sessions = array();
-			$query = $db->simple_select("sessions", "sid", "time > {$timesearch}");
+			$query = $db->simple_select("sessions", "MAX(sid)", "time > {$timesearch}", array(
+				'group_by' => 'uid, ip',
+			));
 			while($sid = $db->fetch_field($query, "sid"))
 			{
 				$sessions[$sid] = 1;
@@ -169,7 +171,9 @@ else
 			break;
 		case "pgsql":
 		default:
-			$query = $db->simple_select("sessions", "COUNT(sid) as online", "time > {$timesearch}");
+			$query = $db->simple_select("sessions", "COUNT(sid) as online", "time > {$timesearch}", array(
+				'group_by' => 'uid, ip',
+			));
 			$online_count = $db->fetch_field($query, "online");
 			break;
 	}
@@ -204,9 +208,15 @@ else
 
 	// Query for active sessions
 	$query = $db->query("
-		SELECT DISTINCT s.sid, s.ip, s.uid, s.time, s.location, u.username, s.nopermission, u.invisible, u.usergroup, u.displaygroup
-		FROM ".TABLE_PREFIX."sessions s
-		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
+		SELECT
+			s.sid, s.ip, s.uid, s.time, s.location, u.username, s.nopermission, u.invisible, u.usergroup, u.displaygroup
+		FROM
+			".TABLE_PREFIX."sessions s
+			INNER JOIN (
+				SELECT uid, ip, MAX(time) AS time
+				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
+			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
+			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
 		WHERE s.time>'$timesearch'
 		ORDER BY $sql
 		LIMIT {$start}, {$perpage}

--- a/portal.php
+++ b/portal.php
@@ -236,9 +236,15 @@ if($mybb->settings['portal_showwol'] != 0 && $mybb->usergroup['canviewonline'] !
 	$guestcount = $membercount = $botcount = $anoncount = 0;
 	$doneusers = $onlinemembers = $onlinebots = array();
 	$query = $db->query("
-		SELECT s.sid, s.ip, s.uid, s.time, s.location, u.username, u.invisible, u.usergroup, u.displaygroup
-		FROM ".TABLE_PREFIX."sessions s
-		LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
+		SELECT
+			s.sid, s.ip, s.uid, s.time, s.location, u.username, u.invisible, u.usergroup, u.displaygroup
+		FROM
+			".TABLE_PREFIX."sessions s
+			INNER JOIN (
+				SELECT uid, ip, MAX(time) AS time
+				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
+			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
+			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
 		WHERE s.time>'$timesearch'
 		ORDER BY {$order_by}, {$order_by2}
 	");

--- a/showthread.php
+++ b/showthread.php
@@ -1520,9 +1520,15 @@ if($mybb->input['action'] == "thread")
 		$doneusers = array();
 
 		$query = $db->query("
-			SELECT s.ip, s.uid, s.time, u.username, u.invisible, u.usergroup, u.displaygroup
-			FROM ".TABLE_PREFIX."sessions s
-			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
+			SELECT
+				s.ip, s.uid, s.time, u.username, u.invisible, u.usergroup, u.displaygroup
+			FROM
+				".TABLE_PREFIX."sessions s
+				INNER JOIN (
+					SELECT uid, ip, MAX(time) AS time
+					FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
+				) s2 ON (s.ip=s2.ip AND s.uid=s2.uid)
+				LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
 			WHERE s.time > '$timecut' AND location2='$tid' AND nopermission != 1
 			ORDER BY u.username ASC, s.time DESC
 		");


### PR DESCRIPTION
Resolves #3762 
Replaces #3769, #3833

This solution filters data from the `mybb_sessions` table in `SELECT` queries instead of relying on deleting sessions from same IP addresses on creation (MyBB 1.8.21) or updating rows (referenced PRs).

The `INNER JOIN` subquery groups records by `{uid, ip}` and provides the most recent timestamp (`MAX(time)`), which may result in returning more than 1 guest session with the same IP address if the `time` value is also the same. User sessions, however, should be unique, as duplicates are still deleted at https://github.com/mybb/mybb/blob/mybb_1821/inc/class_session.php#L498.