### PR TITLE
Fix & optimize Who's Online queries

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -283,49 +283,41 @@ if($mybb->settings['browsingthisforum'] != 0)
 	$onlinemembers = '';
 	$doneusers = array();
 
+	$query = $db->simple_select("sessions", "COUNT(DISTINCT ip) AS guestcount", "uid = 0 AND time > $timecut AND location1 = $fid AND nopermission != 1");
+	$guestcount = $db->fetch_field($query, 'guestcount');
+
 	$query = $db->query("
 		SELECT
 			s.ip, s.uid, u.username, s.time, u.invisible, u.usergroup, u.usergroup, u.displaygroup
 		FROM
 			".TABLE_PREFIX."sessions s
-			INNER JOIN (
-				SELECT uid, ip, MAX(time) AS time
-				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
-			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
 			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time > '$timecut' AND location1='$fid' AND nopermission != 1
+		WHERE s.uid != 0 AND s.time > $timecut AND location1 = $fid AND nopermission != 1
 		ORDER BY u.username ASC, s.time DESC
 	");
 
 	while($user = $db->fetch_array($query))
 	{
-		if($user['uid'] == 0)
+		if(empty($doneusers[$user['uid']]) || $doneusers[$user['uid']] < $user['time'])
 		{
-			++$guestcount;
-		}
-		else
-		{
-			if(empty($doneusers[$user['uid']]) || $doneusers[$user['uid']] < $user['time'])
+			$doneusers[$user['uid']] = $user['time'];
+			++$membercount;
+			if($user['invisible'] == 1)
 			{
-				$doneusers[$user['uid']] = $user['time'];
-				++$membercount;
-				if($user['invisible'] == 1)
-				{
-					$invisiblemark = "*";
-					++$inviscount;
-				}
-				else
-				{
-					$invisiblemark = '';
-				}
+				$invisiblemark = "*";
+				++$inviscount;
+			}
+			else
+			{
+				$invisiblemark = '';
+			}
 
-				if($user['invisible'] != 1 || $mybb->usergroup['canviewwolinvis'] == 1 || $user['uid'] == $mybb->user['uid'])
-				{
-					$user['username'] = format_name(htmlspecialchars_uni($user['username']), $user['usergroup'], $user['displaygroup']);
-					$user['profilelink'] = build_profile_link($user['username'], $user['uid']);
-					eval("\$onlinemembers .= \"".$templates->get("forumdisplay_usersbrowsing_user", 1, 0)."\";");
-					$comma = $lang->comma;
-				}
+			if($user['invisible'] != 1 || $mybb->usergroup['canviewwolinvis'] == 1 || $user['uid'] == $mybb->user['uid'])
+			{
+				$user['username'] = format_name(htmlspecialchars_uni($user['username']), $user['usergroup'], $user['displaygroup']);
+				$user['profilelink'] = build_profile_link($user['username'], $user['uid']);
+				eval("\$onlinemembers .= \"".$templates->get("forumdisplay_usersbrowsing_user", 1, 0)."\";");
+				$comma = $lang->comma;
 			}
 		}
 	}

--- a/index.php
+++ b/index.php
@@ -57,22 +57,46 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 	}
 
 	$timesearch = TIME_NOW - (int)$mybb->settings['wolcutoff'];
+
+	$membercount = $guestcount = $anoncount = $botcount = 0;
+	$forum_viewers = $doneusers = $onlinemembers = $onlinebots = array();
+
+	if($mybb->settings['showforumviewing'] != 0)
+	{
+		$query = $db->query("
+			SELECT
+				location1, COUNT(DISTINCT ip) AS guestcount
+			FROM
+				".TABLE_PREFIX."sessions
+			WHERE uid = 0 AND time > $timesearch
+			GROUP BY location1
+		");
+
+		while($location = $db->fetch_array($query))
+		{
+			$guestcount += $location['guestcount'];
+
+			if($location['location1'])
+			{
+				$forum_viewers[$location['location1']] += $location['guestcount'];
+			}
+		}
+	}
+	else
+	{
+		$query = $db->simple_select("sessions", "COUNT(DISTINCT ip) AS guestcount", "uid = 0 AND time > $timesearch");
+		$guestcount = $db->fetch_field($query, "guestcount");
+	}
+
 	$query = $db->query("
 		SELECT
 			s.sid, s.ip, s.uid, s.time, s.location, s.location1, u.username, u.invisible, u.usergroup, u.displaygroup
 		FROM
 			".TABLE_PREFIX."sessions s
-			INNER JOIN (
-				SELECT uid, ip, MAX(time) AS time
-				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
-			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
 			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time > '".$timesearch."'
+		WHERE (s.uid != 0 OR SUBSTR(s.sid,4,1) = '=') AND s.time > $timesearch
 		ORDER BY {$order_by}, {$order_by2}
 	");
-
-	$forum_viewers = $doneusers = $onlinemembers = $onlinebots = array();
-	$membercount = $guestcount = $anoncount = $botcount = 0;
 
 	// Fetch spiders
 	$spiders = $cache->read('spiders');
@@ -130,11 +154,6 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 			// The user is a search bot.
 			$onlinebots[$key] = format_name($spiders[$botkey]['name'], $spiders[$botkey]['usergroup']);
 			++$botcount;
-		}
-		else
-		{
-			// The user is a guest.
-			++$guestcount;
 		}
 
 		if($user['location1'])

--- a/online.php
+++ b/online.php
@@ -154,30 +154,17 @@ else
 
 	$timesearch = TIME_NOW - $mybb->settings['wolcutoffmins']*60;
 
-	// Exactly how many users are currently online?
-	switch($db->type)
-	{
-		case "sqlite":
-			$sessions = array();
-			$query = $db->simple_select("sessions", "MAX(sid)", "time > {$timesearch}", array(
-				'group_by' => 'uid, ip',
-			));
-			while($sid = $db->fetch_field($query, "sid"))
-			{
-				$sessions[$sid] = 1;
-			}
-			$online_count = count($sessions);
-			unset($sessions);
-			break;
-		case "pgsql":
-		default:
-			$query = $db->simple_select("sessions", "COUNT(sid) as online", "time > {$timesearch}", array(
-				'group_by' => 'uid, ip',
-			));
-			$online_count = $db->fetch_field($query, "online");
-			break;
-	}
-	
+	$query = $db->query("
+		SELECT COUNT(*) AS online FROM (
+			SELECT 1
+			FROM " . TABLE_PREFIX . "sessions
+			WHERE time > $timesearch
+			GROUP BY uid, ip
+		) s
+	");
+
+	$online_count = $db->fetch_field($query, "online");
+
 	if(!$mybb->settings['threadsperpage'] || (int)$mybb->settings['threadsperpage'] < 1)
 	{
 		$mybb->settings['threadsperpage'] = 20;
@@ -207,20 +194,56 @@ else
 	$multipage = multipage($online_count, $perpage, $page, "online.php".$refresh_string);
 
 	// Query for active sessions
-	$query = $db->query("
-		SELECT
-			s.sid, s.ip, s.uid, s.time, s.location, u.username, s.nopermission, u.invisible, u.usergroup, u.displaygroup
-		FROM
-			".TABLE_PREFIX."sessions s
-			INNER JOIN (
-				SELECT uid, ip, MAX(time) AS time
-				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
-			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
-			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time>'$timesearch'
-		ORDER BY $sql
-		LIMIT {$start}, {$perpage}
-	");
+	$dbversion = $db->get_version();
+	if(
+		(
+			$db->type == 'mysqli' && (
+				version_compare($dbversion, '10.2.0', '>=') || ( // MariaDB
+					version_compare($dbversion, '10', '<') &&
+					version_compare($dbversion, '8.0.2', '>=')
+				)
+			)
+		) ||
+		($db->type == 'pgsql' && version_compare($dbversion, '8.4.0', '>=')) ||
+		($db->type == 'sqlite' && version_compare($dbversion, '3.25.0', '>='))
+	)
+	{
+		$query = $db->query("
+			SELECT * FROM (
+				SELECT
+					s.sid, s.ip, s.uid, s.time, s.location, u.username, s.nopermission, u.invisible, u.usergroup, u.displaygroup,
+					row_number() OVER (PARTITION BY s.uid, s.ip ORDER BY time DESC) AS row_num
+				FROM
+					".TABLE_PREFIX."sessions s
+					LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid = u.uid)
+				WHERE s.time > $timesearch
+			) s
+			WHERE row_num = 1
+			ORDER BY $sql
+			LIMIT {$start}, {$perpage}
+		");
+	}
+	else
+	{
+		$query = $db->query("
+			SELECT
+				s.sid, s.ip, s.uid, s.time, s.location, u.username, s.nopermission, u.invisible, u.usergroup, u.displaygroup
+			FROM
+				".TABLE_PREFIX."sessions s
+				INNER JOIN (
+					SELECT
+						MIN(s2.sid) AS sid
+					FROM
+						".TABLE_PREFIX."sessions s2
+						LEFT JOIN ".TABLE_PREFIX."sessions s3 ON (s2.sid = s3.sid AND s2.time < s3.time)
+					WHERE s2.time > $timesearch AND s3.sid IS NULL
+					GROUP BY s2.uid, s2.ip
+				) s2 ON (s.sid = s2.sid)
+				LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid = u.uid)
+			ORDER BY $sql
+			LIMIT {$start}, {$perpage}
+		");
+	}
 
 	// Fetch spiders
 	$spiders = $cache->read("spiders");

--- a/online.php
+++ b/online.php
@@ -143,7 +143,7 @@ else
 		{
 			case "sqlite":
 			case "pgsql":
-				$sql = "s.time DESC";
+				$sql = "CASE WHEN s.uid > 0 THEN 1 ELSE 0 END DESC, s.time DESC";
 				break;
 			default:
 				$sql = "IF( s.uid >0, 1, 0 ) DESC, s.time DESC";

--- a/portal.php
+++ b/portal.php
@@ -235,17 +235,17 @@ if($mybb->settings['portal_showwol'] != 0 && $mybb->usergroup['canviewonline'] !
 	$timesearch = TIME_NOW - $mybb->settings['wolcutoff'];
 	$guestcount = $membercount = $botcount = $anoncount = 0;
 	$doneusers = $onlinemembers = $onlinebots = array();
+
+	$query = $db->simple_select("sessions", "COUNT(DISTINCT ip) AS guestcount", "uid = 0 AND time > $timesearch");
+	$guestcount = $db->fetch_field($query, "guestcount");
+
 	$query = $db->query("
 		SELECT
 			s.sid, s.ip, s.uid, s.time, s.location, u.username, u.invisible, u.usergroup, u.displaygroup
 		FROM
 			".TABLE_PREFIX."sessions s
-			INNER JOIN (
-				SELECT uid, ip, MAX(time) AS time
-				FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
-			) s2 ON (s.ip=s2.ip AND s.uid=s2.uid AND s.time=s2.time)
 			LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-		WHERE s.time>'$timesearch'
+		WHERE (s.uid != 0 OR SUBSTR(s.sid,4,1) = '=') AND s.time > $timesearch
 		ORDER BY {$order_by}, {$order_by2}
 	");
 
@@ -303,10 +303,6 @@ if($mybb->settings['portal_showwol'] != 0 && $mybb->usergroup['canviewonline'] !
 
 			$onlinebots[$key] = format_name($spiders[$botkey]['name'], $spiders[$botkey]['usergroup']);
 			++$botcount;
-		}
-		else
-		{
-			++$guestcount;
 		}
 	}
 

--- a/showthread.php
+++ b/showthread.php
@@ -1519,27 +1519,22 @@ if($mybb->input['action'] == "thread")
 		$onlinemembers = '';
 		$doneusers = array();
 
+		$query = $db->simple_select("sessions", "COUNT(DISTINCT ip) AS guestcount", "uid = 0 AND time > $timecut AND location2 = $tid AND nopermission != 1");
+		$guestcount = $db->fetch_field($query, 'guestcount');
+
 		$query = $db->query("
 			SELECT
 				s.ip, s.uid, s.time, u.username, u.invisible, u.usergroup, u.displaygroup
 			FROM
 				".TABLE_PREFIX."sessions s
-				INNER JOIN (
-					SELECT uid, ip, MAX(time) AS time
-					FROM ".TABLE_PREFIX."sessions GROUP BY uid, ip
-				) s2 ON (s.ip=s2.ip AND s.uid=s2.uid)
 				LEFT JOIN ".TABLE_PREFIX."users u ON (s.uid=u.uid)
-			WHERE s.time > '$timecut' AND location2='$tid' AND nopermission != 1
+			WHERE s.uid != 0 AND s.time > '$timecut' AND location2='$tid' AND nopermission != 1
 			ORDER BY u.username ASC, s.time DESC
 		");
 
 		while($user = $db->fetch_array($query))
 		{
-			if($user['uid'] == 0)
-			{
-				++$guestcount;
-			}
-			else if(empty($doneusers[$user['uid']]) || $doneusers[$user['uid']] < $user['time'])
+			if(empty($doneusers[$user['uid']]) || $doneusers[$user['uid']] < $user['time'])
 			{
 				++$membercount;
 				$doneusers[$user['uid']] = $user['time'];


### PR DESCRIPTION
Resolves #3762
Extends #3837

- DB interaction modified to count guests in a separate query with `COUNT(DISTINCT ip)`,
- `index.php` guest count query extended to return counts grouped by `location1` when `$mybb->settings['showforumviewing'] != 0` for the _N users browsing_ forum counts,
- `online.php`:
  - more complex queries to filter guests by IP database engine version-dependent window functions, with a fallback for older versions (`MIN(sid)` only used to pick unique `sid` for each `{uid,ip}` pair when same timestamp is stored); no duplicate `{uid,ip}` pairs will be returned anymore (side effect in #3837), but spider and guest sessions associated with same IP may exclude each other in statistics
  - fixed sorting for SQLite to show users first

Queries in this state rely on https://github.com/mybb/mybb/blob/mybb_1821/inc/class_session.php#L498 to not show duplicate user entries when the forum is visited using the same account from different IP addresses.