### PR TITLE
#2962 error page display

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1857,7 +1857,7 @@ function print_setting_peekers()
 	$peekers = array(
 		'new Peeker($(".setting_boardclosed"), $("#row_setting_boardclosed_reason"), 1, true)',
 		'new Peeker($(".setting_gzipoutput"), $("#row_setting_gziplevel"), 1, true)',
-		'new Peeker($(".setting_useerrorhandling"), $("#row_setting_errorlogmedium, #row_setting_errortypemedium, #row_setting_errorloglocation"), 1, true)',
+		'new Peeker($(".setting_useerrorhandling"), $("#row_setting_errorlogmedium, #row_setting_errorloglocation"), 1, true)',
 		'new Peeker($("#setting_subforumsindex"), $("#row_setting_subforumsstatusicons"), /[^0+|]/, false)',
 		'new Peeker($(".setting_showsimilarthreads"), $("#row_setting_similarityrating, #row_setting_similarlimit"), 1, true)',
 		'new Peeker($(".setting_disableregs"), $("#row_setting_regtype, #row_setting_securityquestion, #row_setting_regtime, #row_setting_allowmultipleemails, #row_setting_hiddencaptchaimage, #row_setting_betweenregstime"), 0, true)',
@@ -1890,7 +1890,6 @@ function print_setting_peekers()
 		'new Peeker($(".setting_showbirthdays"), $("#row_setting_showbirthdayspostlimit"), 1, true)',
 		'new Peeker($("#setting_betweenregstime"), $("#row_setting_maxregsbetweentime"), /[^0+|]/, false)',
 		'new Peeker($(".setting_usecdn"), $("#row_setting_cdnurl, #row_setting_cdnpath"), 1, true)',
-		'new Peeker($("#setting_errorlogmedium"), $("#row_setting_errortypemedium"), /^(log|email|both)/, false)',
 		'new Peeker($("#setting_errorlogmedium"), $("#row_setting_errorloglocation"), /^(log|both)/, false)',
 		'new Peeker($(".setting_sigmycode"), $("#row_setting_sigcountmycode, #row_setting_sigimgcode"), 1, true)',
 		'new Peeker($(".setting_pmsallowmycode"), $("#row_setting_pmsallowimgcode, #row_setting_pmsallowvideocode"), 1, true)',

--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -539,6 +539,28 @@ class errorHandler {
 			$charset = 'UTF-8';
 		}
 
+		if(isset($mybb->user) && is_array($mybb->usergroup) && $mybb->usergroup['cancp'] == 1)
+		{
+			// admins directed to contact MyBB
+			$contact = 'Please contact the <a href="https://mybb.com">MyBB Group</a> for technical support.';
+		}
+		else
+		{
+			// users directed to contact the site owner
+			$contact_us = 'site owner';
+			if(($mybb->settings['contactlink'] == "contact.php" && $mybb->settings['contact'] == 1 && ($mybb->settings['contact_guests'] != 1 && $mybb->user['uid'] == 0 || $mybb->user['uid'] > 0)) || $mybb->settings['contactlink'] != "contact.php")
+			{
+				if(!my_validate_url($mybb->settings['contactlink'], true, true) && my_substr($mybb->settings['contactlink'], 0, 7) != 'mailto:')
+				{
+					$mybb->settings['contactlink'] = $mybb->settings['bburl'].'/'.$mybb->settings['contactlink'];
+				}
+
+				$contact_us = '<a href="' . $mybb->settings['contactlink'] . '">' . $contact_us . '</a>';
+			}
+
+			$contact = 'Please contact the ' . $contact_us . ' for technical support.';
+		}
+
 		if(!headers_sent() && !defined("IN_INSTALL") && !defined("IN_UPGRADE"))
 		{
 			@header('HTTP/1.1 503 Service Temporarily Unavailable');
@@ -579,7 +601,7 @@ class errorHandler {
 
 			<div id="error">
 				{$error_message}
-				<p id="footer">Please contact the <a href="https://mybb.com">MyBB Group</a> for technical support.</p>
+				<p id="footer">{$contact}</p>
 			</div>
 		</div>
 	</div>
@@ -604,7 +626,7 @@ EOF;
 		<h2>{$title}</h2>
 		<div id="mybb_error_error">
 		{$error_message}
-			<p id="mybb_error_footer">Please contact the <a href="https://mybb.com">MyBB Group</a> for technical support.</p>
+			<p id="mybb_error_footer">{$contact}</p>
 		</div>
 	</div>
 EOF;

--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -555,11 +555,11 @@ HTML;
 
 			$contact = <<<HTML
 <p>
-	<strong>If you're a visitor of this website</strong>, please wait a few minutes.{$contact_site_owner}
+	<strong>If you're a visitor of this website</strong>, please wait a few minutes and try again.{$contact_site_owner}
 </p>
 
 <p>
-	<strong>If you are the site owner</strong>, lease check the <a href="https://docs.mybb.com">MyBB Documentation</a> for help resolving <a href="https://docs.mybb.com/1.8/faq/">common issues</a>, or get technical help on the <a href="https://community.mybb.com/">MyBB Community Forums</a>.
+	<strong>If you are the site owner</strong>, please check the <a href="https://docs.mybb.com">MyBB Documentation</a> for help resolving <a href="https://docs.mybb.com/1.8/faq/">common issues</a>, or get technical help on the <a href="https://community.mybb.com/">MyBB Community Forums</a>.
 </p>
 HTML;
 

--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -423,7 +423,7 @@ class errorHandler {
 		{
 			$mybb->settings['bbname'] = "MyBB";
 		}
-
+		
 		if($type == MYBB_SQL)
 		{
 			$title = "MyBB SQL Error";
@@ -539,27 +539,29 @@ class errorHandler {
 			$charset = 'UTF-8';
 		}
 
-		if(isset($mybb->user) && is_array($mybb->usergroup) && $mybb->usergroup['cancp'] == 1)
+		$contact_site_owner = '';
+		$is_in_contact = defined('THIS_SCRIPT') && THIS_SCRIPT === 'contact.php';
+		if(!$is_in_contact && ($mybb->settings['contactlink'] == "contact.php" && $mybb->settings['contact'] == 1 && ($mybb->settings['contact_guests'] != 1 && $mybb->user['uid'] == 0 || $mybb->user['uid'] > 0)) || $mybb->settings['contactlink'] != "contact.php")
 		{
-			// admins directed to contact MyBB
-			$contact = 'Please contact the <a href="https://mybb.com">MyBB Group</a> for technical support.';
-		}
-		else
-		{
-			// users directed to contact the site owner
-			$contact_us = 'site owner';
-			if(($mybb->settings['contactlink'] == "contact.php" && $mybb->settings['contact'] == 1 && ($mybb->settings['contact_guests'] != 1 && $mybb->user['uid'] == 0 || $mybb->user['uid'] > 0)) || $mybb->settings['contactlink'] != "contact.php")
+			if(!my_validate_url($mybb->settings['contactlink'], true, true) && my_substr($mybb->settings['contactlink'], 0, 7) != 'mailto:')
 			{
-				if(!my_validate_url($mybb->settings['contactlink'], true, true) && my_substr($mybb->settings['contactlink'], 0, 7) != 'mailto:')
-				{
-					$mybb->settings['contactlink'] = $mybb->settings['bburl'].'/'.$mybb->settings['contactlink'];
-				}
-
-				$contact_us = '<a href="' . $mybb->settings['contactlink'] . '">' . $contact_us . '</a>';
+				$mybb->settings['contactlink'] = $mybb->settings['bburl'].'/'.$mybb->settings['contactlink'];
 			}
 
-			$contact = 'Please contact the ' . $contact_us . ' for technical support.';
+			$contact_site_owner = <<<HTML
+ If this problem persists, please <a href="{$mybb->settings['contactlink']}">contact the site owner</a>.
+HTML;
 		}
+
+			$contact = <<<HTML
+<p>
+	<strong>If you're a visitor of this website</strong>, please wait a few minutes.{$contact_site_owner}
+</p>
+
+<p>
+	<strong>If you are the site owner</strong>, please contact the <a href="https://mybb.com">MyBB Group</a> for technical support.
+</p>
+HTML;
 
 		if(!headers_sent() && !defined("IN_INSTALL") && !defined("IN_UPGRADE"))
 		{

--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -165,7 +165,7 @@ class errorHandler {
 		$accepted_error_types = array('both', 'error', 'warning', 'none');
 		if(!in_array($mybb->settings['errortypemedium'], $accepted_error_types))
 		{
-			$mybb->settings['errortypemedium'] = "both";
+			$mybb->settings['errortypemedium'] = "none";
 		}
 
 		if(defined("IN_TASK"))

--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -559,7 +559,7 @@ HTML;
 </p>
 
 <p>
-	<strong>If you are the site owner</strong>, please contact the <a href="https://mybb.com">MyBB Group</a> for technical support.
+	<strong>If you are the site owner</strong>, lease check the <a href="https://docs.mybb.com">MyBB Documentation</a> for help resolving <a href="https://docs.mybb.com/1.8/faq/">common issues</a>, or get technical help on the <a href="https://community.mybb.com/">MyBB Community Forums</a>.
 </p>
 HTML;
 

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -396,7 +396,7 @@ error=Errors
 both=Warnings and Errors
 none=Hide Errors and Warnings
 ]]></optionscode>
-			<settingvalue><![CDATA[both]]></settingvalue>
+			<settingvalue><![CDATA[none]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
 		<setting name="errorloglocation">


### PR DESCRIPTION
Resolves #2962

This makes the following changes relating to how errors are displayed:

- Default the `Error Type Medium` setting to `Hide Errors and Warning`, meaning that by default full error details are not shown, which could leak potentially sensitive information such as database table prefixes.
- Prevent the `Error Type Medium` setting being hidden when the `Error Logging Medium` is `Neither`.
- When displaying an error, if the user is not an administrator change the text in the footer. For administrators, the text is:

    > Please contact the MyBB Group for technical support.

    For users, the text is:

    > Please contact the site owner for technical support.

    This should cut back on the number of emails we receive to `contact@` relating to an error on a site that we can do nothing about.

## Other possible future enhancements (for a future PR)

- For SQL errors, show the file where the error happened
- During install, if the URL is configured to localhost, set the `Error Type Medium` to `Warnings and Errors`
- Additional option for `Error Type Medium` to show errors to logged in admins, and hide them from normal users


