### PR TITLE
managegroup do_manageusers: Fix check for whether any users are selected

### DIFF
--- a/managegroup.php
+++ b/managegroup.php
@@ -241,7 +241,7 @@ elseif($mybb->input['action'] == "do_manageusers" && $mybb->request_method == "p
 
 	$plugins->run_hooks("managegroup_do_manageusers_start");
 
-	if(is_array($users) && count($users))
+	if(!empty($users))
 	{
 		foreach($users as $uid)
 		{

--- a/managegroup.php
+++ b/managegroup.php
@@ -239,7 +239,6 @@ elseif($mybb->input['action'] == "do_manageusers" && $mybb->request_method == "p
 
 	$plugins->run_hooks("managegroup_do_manageusers_start");
 
-	$users = $mybb->get_input('removeuser', MyBB::INPUT_ARRAY);
 	if(is_array($users) && count($users))
 	{
 		foreach($users as $uid)

--- a/managegroup.php
+++ b/managegroup.php
@@ -239,9 +239,10 @@ elseif($mybb->input['action'] == "do_manageusers" && $mybb->request_method == "p
 
 	$plugins->run_hooks("managegroup_do_manageusers_start");
 
-	if(is_array($mybb->get_input('removeuser', MyBB::INPUT_ARRAY)))
+	$users = $mybb->get_input('removeuser', MyBB::INPUT_ARRAY);
+	if(is_array($users) && count($users))
 	{
-		foreach($mybb->get_input('removeuser', MyBB::INPUT_ARRAY) as $uid)
+		foreach($users as $uid)
 		{
 			leave_usergroup($uid, $gid);
 		}

--- a/managegroup.php
+++ b/managegroup.php
@@ -237,6 +237,8 @@ elseif($mybb->input['action'] == "do_manageusers" && $mybb->request_method == "p
 		error_no_permission();
 	}
 
+	$users = $mybb->get_input('removeuser', MyBB::INPUT_ARRAY);
+
 	$plugins->run_hooks("managegroup_do_manageusers_start");
 
 	if(is_array($users) && count($users))


### PR DESCRIPTION
no_users_selected was only being shown if `removeuser` was not an array.
If it was an empty array the error would not be shown and MyBB would continue as if nothing were wrong.