### PR TITLE
Fix #3901 - calendar event name double encoded

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -937,7 +937,7 @@ if($mybb->input['action'] == "editevent")
 	{
 		$event_errors = '';
 		$mybb->input['calendar'] = $event['cid'];
-		$name = htmlspecialchars_uni($event['name']);
+		$name = $event['name'];
 		$description = htmlspecialchars_uni($event['description']);
 		if($event['private'] == 1)
 		{


### PR DESCRIPTION
Resolves #3901

