### PR TITLE
Resolve #3422 Loose comparison used for forum passwords

### DIFF
--- a/archive/index.php
+++ b/archive/index.php
@@ -26,7 +26,7 @@ switch($action)
 		if($announcement['fid'] != -1)
 		{
 			$forum = get_forum($announcement['fid']);
-			if(!$forum['fid'] || $forum['password'] != '')
+			if(!$forum['fid'] || $forum['password'] !== '')
 			{
 				archive_error($lang->error_invalidforum);
 			}
@@ -80,7 +80,7 @@ switch($action)
 
 		// Fetch the forum this thread is in
 		$forum = get_forum($thread['fid']);
-		if(!$forum['fid'] || $forum['password'] != '')
+		if(!$forum['fid'] || $forum['password'] !== '')
 		{
 			archive_error($lang->error_invalidforum);
 		}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1515,7 +1515,7 @@ function fetch_forum_permissions($fid, $gid, $groupperms)
  * Check whether password for given forum was validated for the current user
  *
  * @param array $forum The forum data
- * @param bool $ignore_empty Whether to true if configured forum password is an empty string
+ * @param bool $ignore_empty Whether to treat forum password configured as an empty string as validated
  * @param bool $check_parents Whether to check parent forums using `parentlist`
  * @return bool
  */

--- a/inc/functions_archive.php
+++ b/inc/functions_archive.php
@@ -239,31 +239,8 @@ function check_forum_password_archive($fid, $pid=0)
 		}
 	}
 
-	// Loop through each of parent forums to ensure we have a password for them too
-	$parents = explode(',', $forum_cache[$fid]['parentlist']);
-	rsort($parents);
-	if(!empty($parents))
+	if(!forum_password_validated($forum_cache[$fid], true, true))
 	{
-		foreach($parents as $parent_id)
-		{
-			if($parent_id == $fid || $parent_id == $pid)
-			{
-				continue;
-			}
-
-			if($forum_cache[$parent_id]['password'] != "")
-			{
-				check_forum_password_archive($parent_id, $fid);
-			}
-		}
-	}
-
-	$password = $forum_cache[$fid]['password'];
-	if($password)
-	{
-		if(!isset($mybb->cookies['forumpass'][$fid]) || !my_hash_equals(md5($mybb->user['uid'].$password), $mybb->cookies['forumpass'][$fid]))
-		{
-			archive_error_no_permission();
-		}
+		archive_error_no_permission();
 	}
 }

--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -142,13 +142,10 @@ function build_forumbits($pid=0, $depth=1)
 				);
 			}
 
-			if($forum['password'])
+			if(!forum_password_validated($forum, true))
 			{
-				if(!isset($mybb->cookies['forumpass'][$forum['fid']]) || !my_hash_equals($mybb->cookies['forumpass'][$forum['fid']], md5($mybb->user['uid'].$forum['password'])))
-				{
-					$hideinfo = true;
-					$showlockicon = 1;
-				}
+				$hideinfo = true;
+				$showlockicon = 1;
 			}
 
 			// Fetch subforums of this forum


### PR DESCRIPTION
Resolves #3422

- added function to check forum password validation status:
```php
function forum_password_validated($forum, $ignore_empty=false, $check_parents=false)
```
- weak comparisons (`==`, `empty()`) changed to identical (`===`) for no password check
- password verification comparison changed to use `my_hash_equals()`
- local optimizations