### PR TITLE
Add `peer_name` to SSL context options when SSL verification is ignored.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -7175,6 +7175,7 @@ function fetch_remote_file($url, $post_data=array(), $max_redirects=20)
 					'ssl' => array(
 						'verify_peer' => false,
 						'verify_peer_name' => false,
+						'peer_name' => $url_components['host'],
 					),
 				));
 			}


### PR DESCRIPTION
Resolves #3906.

`peer_name` is needed when PHP connecting to certain sites, e.g. some of Cloudflare proxied ones, by `stream_socket_client()` using IP as host.