### PR TITLE
Fix a mismatched HTML tag in the footer template.

### DIFF
--- a/inc/views/base/partials/footer.twig
+++ b/inc/views/base/partials/footer.twig
@@ -111,7 +111,7 @@
                 </p>
             </div>
         </div>
-    </div>
+    </footer>
     {# The following piece of code allows MyBB to run scheduled tasks. DO NOT REMOVE #}{{ task_image }}{# End task image code. TODO: convert task_image template #}
     {% if mybb.settings.dst_correction %}
         {{ mybb.settings.dst_correction }}


### PR DESCRIPTION
There was a mismatched closing HTML tag in the footer template - the opening tag was `<footer>` but the closing tag was `</div>`. Spotted by @yuliu and reported on Discord.

