### PR TITLE
Fix #2056 - table name used for `is_fulltext` should be threads

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1138,7 +1138,7 @@ if($mybb->input['action'] == "change")
 			{
 				$db->create_fulltext_index("posts", "message");
 			}
-			if(!$db->is_fulltext("posts") && $db->supports_fulltext("threads"))
+			if(!$db->is_fulltext("threads") && $db->supports_fulltext("threads"))
 			{
 				$db->create_fulltext_index("threads", "subject");
 			}


### PR DESCRIPTION
Fixes #2056

When checking whether to add a full text index to the `threads` table the condition used `posts` - likely a copy & paste mistake.

