### PR TITLE
Fixes #3618: Attachments not working properly in latest version

### DIFF
--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -375,36 +375,6 @@ function upload_attachment($attachment, $update_attachment=false)
 	$posthash = $db->escape_string($mybb->get_input('posthash'));
 	$pid = (int)$pid;
 
-	if(isset($attachment['error']) && $attachment['error'] != 0)
-	{
-		$ret['error'] = $lang->error_uploadfailed.$lang->error_uploadfailed_detail;
-		switch($attachment['error'])
-		{
-			case 1: // UPLOAD_ERR_INI_SIZE
-				$ret['error'] .= $lang->error_uploadfailed_php1;
-				break;
-			case 2: // UPLOAD_ERR_FORM_SIZE
-				$ret['error'] .= $lang->error_uploadfailed_php2;
-				break;
-			case 3: // UPLOAD_ERR_PARTIAL
-				$ret['error'] .= $lang->error_uploadfailed_php3;
-				break;
-			case 4: // UPLOAD_ERR_NO_FILE
-				$ret['error'] .= $lang->error_uploadfailed_php4;
-				break;
-			case 6: // UPLOAD_ERR_NO_TMP_DIR
-				$ret['error'] .= $lang->error_uploadfailed_php6;
-				break;
-			case 7: // UPLOAD_ERR_CANT_WRITE
-				$ret['error'] .= $lang->error_uploadfailed_php7;
-				break;
-			default:
-				$ret['error'] .= $lang->sprintf($lang->error_uploadfailed_phpx, $attachment['error']);
-				break;
-		}
-		return $ret;
-	}
-
 	if(!is_uploaded_file($attachment['tmp_name']) || empty($attachment['tmp_name']))
 	{
 		$ret['error'] = $lang->error_uploadfailed.$lang->error_uploadfailed_php4;
@@ -694,6 +664,52 @@ function upload_attachment($attachment, $update_attachment=false)
 }
 
 /**
+ * Check whether the input $FILE variable indicates a PHP file upload error,
+ * and if so, return an appropriate user-friendly error message.
+ *
+ * @param array $FILE File data (as fed by PHP's $_FILE).
+ *
+ * @return string Error message or empty if no error detected.
+ */
+function check_parse_php_upload_err($FILE)
+{
+	global $lang;
+
+	$err = '';
+
+	if(isset($FILE['error']) && $FILE['error'] != 0 && ($FILE['error'] != UPLOAD_ERR_NO_FILE || $FILE['name']))
+	{
+		$err = $lang->error_uploadfailed.$lang->error_uploadfailed_detail;
+		switch($FILE['error'])
+		{
+			case 1: // UPLOAD_ERR_INI_SIZE
+				$err .= $lang->error_uploadfailed_php1;
+				break;
+			case 2: // UPLOAD_ERR_FORM_SIZE
+				$err .= $lang->error_uploadfailed_php2;
+				break;
+			case 3: // UPLOAD_ERR_PARTIAL
+				$err .= $lang->error_uploadfailed_php3;
+				break;
+			case 4: // UPLOAD_ERR_NO_FILE
+				$err .= $lang->error_uploadfailed_php4;
+				break;
+			case 6: // UPLOAD_ERR_NO_TMP_DIR
+				$err .= $lang->error_uploadfailed_php6;
+				break;
+			case 7: // UPLOAD_ERR_CANT_WRITE
+				$err .= $lang->error_uploadfailed_php7;
+				break;
+			default:
+				$err .= $lang->sprintf($lang->error_uploadfailed_phpx, $FILE['error']);
+				break;
+		}
+	}
+
+	return $err;
+}
+
+/**
  * Process adding attachment(s) when the "Add Attachment" button is pressed.
  *
  * @param int $pid The ID of the post.
@@ -745,7 +761,12 @@ function add_attachments($pid, $forumpermissions, $attachwhere, $action=false)
 
 		foreach($attachments as $FILE)
 		{
-			if(!empty($FILE['name']) && !empty($FILE['type']))
+			if($err = check_parse_php_upload_err($FILE))
+			{
+				$ret['errors'][] = $err;
+				$mybb->input['action'] = $action;
+			}
+			else if(!empty($FILE['name']) && !empty($FILE['type']))
 			{
 				if($FILE['size'] > 0)
 				{
@@ -775,6 +796,7 @@ function add_attachments($pid, $forumpermissions, $attachwhere, $action=false)
 						$ret['errors'][] = $attachedfile['error'];
 						$mybb->input['action'] = $action;
 					}
+
 				}
 				else
 				{


### PR DESCRIPTION
The main problem was that in some (all?) cases, PHP upload
errors were being ignored. This was because the check for, and parsing
of, PHP upload errors occurred in the function `upload_attachment()`
which was sometimes not called on PHP upload errors due to the
following conditional in `add_attachments()`:

`if(!empty($FILE['name']) && !empty($FILE['type']))`

More specifically, `$FILE['type']` can be set to empty even though a
file with a valid file type was uploaded which exceeded the php.ini
setting `upload_max_filesize`, thus generating an `UPLOAD_ERR_INI_SIZE`
error.

This refactoring of the code ensures that the check for, and parsing of,
PHP upload errors is moved into a separate function, called up-front,
before that conditional, so that they cannot be ignored.

Resolves #3618 

