### PR TITLE
Improve ACP settings search

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1191,40 +1191,29 @@ if($mybb->input['action'] == "change")
 		// Search
 
 		// Search for settings
-		$search = $db->escape_string_like($mybb->input['search']);
-		$query = $db->query("
-			SELECT s.* , g.name as gname, g.title as gtitle, g.description as gdescription
-			FROM ".TABLE_PREFIX."settings s
-			LEFT JOIN ".TABLE_PREFIX."settinggroups g ON(s.gid=g.gid)
-			ORDER BY s.disporder
-		");
-		while($setting = $db->fetch_array($query))
+		$search = trim($mybb->input['search']);
+		if(!empty($search))
 		{
-			$lang_var = "setting_{$setting['name']}";
-			if(isset($lang->$lang_var))
+			$query = $db->query("
+				SELECT s.* , g.name as gname, g.title as gtitle, g.description as gdescription
+				FROM ".TABLE_PREFIX."settings s
+				LEFT JOIN ".TABLE_PREFIX."settinggroups g ON(s.gid=g.gid)
+				ORDER BY s.disporder
+			");
+			while($setting = $db->fetch_array($query))
 			{
-				$setting["title"] = $lang->$lang_var;
-			}
-			$lang_var = "setting_{$setting['name']}_desc";
-			if(isset($lang->$lang_var))
-			{
-				$setting["description"] = $lang->$lang_var;
-			}
-			$lang_var = "setting_group_{$setting['gname']}";
-			if(isset($lang->$lang_var))
-			{
-				$setting["gtitle"] = $lang->$lang_var;
-			}
-			$lang_var = "setting_group_{$setting['gname']}_desc";
-			if(isset($lang->$lang_var))
-			{
-				$setting["gdescription"] = $lang->$lang_var;
-			}
-			$lang_var = $setting["title"] . " " . $setting["description"] . " " . $setting["gtitle"] . " " . $setting["gdescription"];
-			$search = mb_convert_encoding($search, mb_detect_encoding($setting["title"], "auto"));
-			if (mb_stripos($lang_var, $search))
-			{
-				$cache_settings[$setting['gid']][$setting['sid']] = $setting;
+				$search_in = $setting['name'] . ' ' . $setting['title'] . ' ' . $setting['description'] . ' ' . $setting['gtitle'] . ' ' . $setting['gdescription'];
+				foreach(array("setting_{$setting['name']}", "setting_{$setting['name']}_desc", "setting_group_{$setting['gname']}", "setting_group_{$setting['gname']}_desc") as $search_in_lang_key)
+				{
+					if(!empty($lang->$search_in_lang_key))
+					{
+						$search_in .= ' ' . $lang->$search_in_lang_key;
+					}
+				}
+				if(my_stripos($search_in, $search) !== false)
+				{
+					$cache_settings[$setting['gid']][$setting['sid']] = $setting;
+				}
 			}
 		}
 		if(!count($cache_settings))

--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1202,7 +1202,7 @@ if($mybb->input['action'] == "change")
 			");
 			while($setting = $db->fetch_array($query))
 			{
-				$search_in = $setting['name'] . ' ' . $setting['title'] . ' ' . $setting['description'] . ' ' . $setting['gtitle'] . ' ' . $setting['gdescription'];
+				$search_in = $setting['name'] . ' ' . $setting['title'] . ' ' . $setting['description'] . ' ' . $setting['gname'] . ' ' . $setting['gtitle'] . ' ' . $setting['gdescription'];
 				foreach(array("setting_{$setting['name']}", "setting_{$setting['name']}_desc", "setting_group_{$setting['gname']}", "setting_group_{$setting['gname']}_desc") as $search_in_lang_key)
 				{
 					if(!empty($lang->$search_in_lang_key))

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -5841,6 +5841,33 @@ function my_strtolower($string)
 }
 
 /**
+ * Finds a needle in a haystack and returns it position, mb strings accounted for, case insensitive
+ *
+ * @param string $haystack String to look in (haystack)
+ * @param string $needle What to look for (needle)
+ * @param int $offset (optional) How much to offset
+ * @return int|bool false on needle not found, integer position if found
+ */
+function my_stripos($haystack, $needle, $offset=0)
+{
+	if($needle == '')
+	{
+		return false;
+	}
+
+	if(function_exists("mb_stripos"))
+	{
+		$position = mb_stripos($haystack, $needle, $offset);
+	}
+	else
+	{
+		$position = stripos($haystack, $needle, $offset);
+	}
+
+	return $position;
+}
+
+/**
  * Finds a needle in a haystack and returns it position, mb strings accounted for
  *
  * @param string $haystack String to look in (haystack)


### PR DESCRIPTION
Resolves #4004.

Removed encoding conversion for user input.
Added a case insensitive version of mb accounted string search function `my_strpos()`, and changed to use it.
Added setting names and setting group names in the search.
...

IMO we don't need encoding conversion. The encoding of user input should be the one sent via HTTP HEADER or set in HTML's meta, which is the encoding property of the language used by current user. And the encoding of a language pack is expected to a same type encoding used by the database. Otherwise the board couldn't run properly. Anyway, if there's really something wrong with the encoding, it'll prevent the board from properly running first rather than the setting search function.