### PR TITLE
Fixes #3526 ft_min_word_len query every search

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -968,6 +968,19 @@ if($mybb->input['action'] == "change")
 			$lang->success_settings_updated .= $lang->success_settings_updated_captchaimage;
 		}
 
+		// If using fulltext then enforce minimum word length given by database
+		if(isset($mybb->input['upsetting']['minsearchword']) && $mybb->input['upsetting']['minsearchword'] > 0 && $mybb->input['upsetting']['searchtype'] == "fulltext" && $db->supports_fulltext_boolean("posts") && $db->supports_fulltext("threads"))
+		{
+			// Attempt to determine minimum word length from MySQL for fulltext searches
+			$query = $db->query("SHOW VARIABLES LIKE 'ft_min_word_len';");
+			$min_length = $db->fetch_field($query, 'Value');
+			if(is_numeric($min_length) && $mybb->input['upsetting']['minsearchword'] < $min_length)
+			{
+				$mybb->input['upsetting']['minsearchword'] = $min_length;
+				$lang->success_settings_updated .= $lang->success_settings_updated_minsearchword;
+			}
+		}
+
 		// Get settings which optionscode is a forum/group select, checkbox or numeric
 		// We cannot rely on user input to decide this
 		$checkbox_settings = $forum_group_select = $prefix_select = array();

--- a/inc/functions_search.php
+++ b/inc/functions_search.php
@@ -1381,15 +1381,7 @@ function perform_search_mysql_ft($search)
 
 	$keywords = clean_keywords_ft($search['keywords']);
 
-	// Attempt to determine minimum word length from MySQL for fulltext searches
-	$query = $db->query("SHOW VARIABLES LIKE 'ft_min_word_len';");
-	$min_length = $db->fetch_field($query, 'Value');
-	if(is_numeric($min_length))
-	{
-		$mybb->settings['minsearchword'] = $min_length;
-	}
-	// Otherwise, could not fetch - default back to MySQL fulltext default setting
-	else
+	if($mybb->settings['minsearchword'] < 1)
 	{
 		$mybb->settings['minsearchword'] = 4;
 	}

--- a/inc/languages/english/admin/config_settings.lang.php
+++ b/inc/languages/english/admin/config_settings.lang.php
@@ -99,6 +99,7 @@ $l['success_settings_updated_hiddencaptchaimage'] = '<div class="smalltext" styl
 $l['success_settings_updated_username_method'] = '<div class="smalltext" style="font-weight: normal;">Please note that the <b>Allowed Login Methods</b> setting was not updated due to multiple users using the same e-mail address at this time.</div>';
 $l['success_settings_updated_allowmultipleemails'] = '<div class="smalltext" style="font-weight: normal;">Please note that the <b>Allow emails to be registered multiple times?</b> setting can\'t be enabled because the <b>Allowed Login Methods</b> setting allows users to login by e-mail address.</div>';
 $l['success_settings_updated_captchaimage'] = '<div class="smalltext" style="font-weight: normal;">Please note that the <strong>CAPTCHA Images for Registration &amp; Posting</strong> setting was reverted to <strong>MyBB Default Captcha</strong> due to the lack of public/private key(s).</div>';
+$l['success_settings_updated_minsearchword'] = '<div class="smalltext" style="font-weight: normal;">Please note that the <strong>Minimum Search Word Length</strong> setting was set to match the database system configuration.</div>';
 $l['success_display_orders_updated'] = "The setting display orders have been updated successfully.";
 $l['success_setting_group_added'] = "The setting group has been created successfully.";
 $l['success_setting_group_updated'] = "The setting group has been updated successfully.";

--- a/install/resources/upgrade50.php
+++ b/install/resources/upgrade50.php
@@ -36,7 +36,7 @@ function upgrade50_dbchanges()
 	echo "<p>Updating settings...</p>";
 	$db->update_query("settings", array('name' => 'recaptchapublickey'), "name='captchapublickey'");
 	$db->update_query("settings", array('name' => 'recaptchaprivatekey'), "name='captchaprivatekey'");
-  $db->update_query("settings", array('optionscode' => 'select\r\n0=No CAPTCHA\r\n1=MyBB Default CAPTCHA\r\n2=reCAPTCHA\r\n3=NoCAPTCHA reCAPTCHA\r\n4=reCAPTCHA invisible\r\n5=hCAPTCHA\r\n6=hCAPTCHA invisible\r\n7=reCAPTCHA v3'), "name='captchaimage'");
+	$db->update_query("settings", array('optionscode' => 'select\r\n0=No CAPTCHA\r\n1=MyBB Default CAPTCHA\r\n2=reCAPTCHA\r\n3=NoCAPTCHA reCAPTCHA\r\n4=reCAPTCHA invisible\r\n5=hCAPTCHA\r\n6=hCAPTCHA invisible\r\n7=reCAPTCHA v3'), "name='captchaimage'");
 
 	// If using fulltext then enforce minimum word length given by database
 	if($mybb->settings['minsearchword'] > 0 && $mybb->settings['searchtype'] == "fulltext" && $db->supports_fulltext_boolean("posts") && $db->supports_fulltext("threads"))

--- a/install/resources/upgrade50.php
+++ b/install/resources/upgrade50.php
@@ -22,7 +22,7 @@ $upgrade_detail = array(
 
 function upgrade50_dbchanges()
 {
-	global $output, $cache, $db;
+	global $output, $cache, $db, $mybb;
 
 	$output->print_header("Updating Database");
 
@@ -36,7 +36,22 @@ function upgrade50_dbchanges()
 	echo "<p>Updating settings...</p>";
 	$db->update_query("settings", array('name' => 'recaptchapublickey'), "name='captchapublickey'");
 	$db->update_query("settings", array('name' => 'recaptchaprivatekey'), "name='captchaprivatekey'");
-	
+
+	// If using fulltext then enforce minimum word length given by database
+	if($mybb->settings['minsearchword'] > 0 && $mybb->settings['searchtype'] == "fulltext" && $db->supports_fulltext_boolean("posts") && $db->supports_fulltext("threads"))
+	{
+		// Attempt to determine minimum word length from MySQL for fulltext searches
+		$query = $db->query("SHOW VARIABLES LIKE 'ft_min_word_len';");
+		$min_length = $db->fetch_field($query, 'Value');
+		if(is_numeric($min_length) && $mybb->settings['minsearchword'] < $min_length)
+		{
+			$min_length = (int) $min_length;
+			$old_min_length = (int) $mybb->settings['minsearchword'];
+			echo "<p>Updating Minimum Search Word Length setting to match the database system configuration (was {$old_min_length}, now {$min_length})</p>";
+			$db->update_query("settings", array('value' => $min_length), "name='minsearchword'");
+		}
+	}
+
 	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
 	$output->print_footer("50_done");
 }


### PR DESCRIPTION
Resolves #3526

`perform_search_mysql_ft` now behaves like `perform_search_mysql` by setting the hard coded minimum when `minsearchword` < 0

`minsearchword` has an enforced minimum when updating settings and using fulltext. This minimum is the one provided by the DB and uses the logic that used to be done on every fulltext search.

Upgrade script used to ensure minimum is enforced on upgrade so that searches aren't performed with a value less then the DB minimum.