### PR TITLE
Fixes #3619 Bugs with advanced database configuration

### DIFF
--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -191,7 +191,7 @@ class DB_MySQL implements DB_Base
 			if(array_key_exists('hostname', $connections[$type]))
 			{
 				$details = $connections[$type];
-				unset($connections);
+				unset($connections[$type]);
 				$connections[$type][] = $details;
 			}
 

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -190,7 +190,7 @@ class DB_MySQLi implements DB_Base
 			if(array_key_exists('hostname', $connections[$type]))
 			{
 				$details = $connections[$type];
-				unset($connections);
+				unset($connections[$type]);
 				$connections[$type][] = $details;
 			}
 

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -194,7 +194,7 @@ class DB_PgSQL implements DB_Base
 			if(array_key_exists('hostname', $connections[$type]))
 			{
 				$details = $connections[$type];
-				unset($connections);
+				unset($connections[$type]);
 				$connections[$type][] = $details;
 			}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -224,7 +224,7 @@ function run_shutdown()
 		// Loop through and run them all
 		foreach($shutdown_queries as $query)
 		{
-			$db->query($query);
+			$db->write_query($query);
 		}
 	}
 


### PR DESCRIPTION
Resolves #3619

The purpose of these small bits of code seems to be moving the connection details to an array element when the details are specified in the top level so that afterwards `$connections[TYPE]` for `TYPE=read/write` is an array.

The issue has been that the whole of `$connections` is unset once the first one is processed which has prevented the multi connection code from working properly! 😢

Note it would have worked previously if specified by the user like this:
```php
$config['database']['read'][] = array(
	'hostname' => 'localhost',
	'username' => 'mybb',
	'password' => 'password',
);
$config['database']['write'][] = array(
	'hostname' => 'localhost',
	'username' => 'mybb',
	'password' => 'password',
);
```

but not like this:
```php
$config['database']['read'] = array(
	'hostname' => 'localhost',
	'username' => 'mybb',
	'password' => 'password',
);
$config['database']['write'] = array(
	'hostname' => 'localhost',
	'username' => 'mybb',
	'password' => 'password',
);
```

With this PR, both work correctly.