### PR TITLE
Fixes #4021 empty `From:` field in mail letter's header when from addr is given

### DIFF
--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -157,6 +157,7 @@ class MailHandler
 		if($from)
 		{
 			$this->from = $from;
+			$this->from_named = $this->from;
 		}
 		else
 		{

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -172,7 +172,6 @@ class MailHandler
 		}
 		else
 		{
-			$this->return_email = "";
 			$this->return_email = $this->get_from_email();
 		}
 


### PR DESCRIPTION
Resolves #4021.

Seems a pretty easy fix. Tested with SMTP. PHP mail should be fine as well.

@andrewjs18 's help is much appreciated.