### PR TITLE
Fixes #3853 Missing plugin language file for AdminCP prevents from using/entering AdminCP

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -45,10 +45,6 @@ $mybb->settings['cookiepath'] = substr($loc, 0, strrpos($loc, "/{$config['admin_
 
 if(!isset($cp_language))
 {
-	if(!file_exists(MYBB_ROOT."inc/languages/".$mybb->settings['cplanguage']."/admin/home_dashboard.lang.php"))
-	{
-		$mybb->settings['cplanguage'] = "english";
-	}
 	$lang->set_language($mybb->settings['cplanguage'], "admin");
 }
 
@@ -665,7 +661,7 @@ if(!empty($admin_options['authsecret']) && $admin_session['authenticated'] != 1)
 }
 
 // Now the user is fully authenticated setup their personal options
-if(!empty($admin_options['cplanguage']) && file_exists(MYBB_ROOT."inc/languages/".$admin_options['cplanguage']."/admin/home_dashboard.lang.php"))
+if(!empty($admin_options['cplanguage']))
 {
 	$cp_language = $admin_options['cplanguage'];
 	$lang->set_language($cp_language, "admin");

--- a/inc/class_language.php
+++ b/inc/class_language.php
@@ -19,18 +19,29 @@ class MyLanguage
 	public $path;
 
 	/**
-	 * The language we are using.
+	 * The language we are using and the area (if admin).
+	 * 
+	 * For example 'english' or 'english/admin'.
 	 *
 	 * @var string
 	 */
 	public $language;
 
 	/**
-	 * The fallback language we are using.
+	 * The fallback language we are using and the area (if admin).
+	 * 
+	 * For example 'english' or 'english/admin'.
 	 *
 	 * @var string
 	 */
 	public $fallback = 'english';
+
+	/**
+	 * The fallback language we are using.
+	 *
+	 * @var string
+	 */
+	public $fallbackLanguage = 'english';
 
 	/**
 	 * Information about the current language.
@@ -118,7 +129,7 @@ class MyLanguage
 				}
 			}
 			$this->language = $language."/{$area}";
-			$this->fallback = $this->fallback."/{$area}";
+			$this->fallback = $this->fallbackLanguage."/{$area}";
 		}
 	}
 
@@ -159,7 +170,7 @@ class MyLanguage
 		}
 
 		// We must unite and protect our language variables!
-		$lang_keys_ignore = array('language', 'path', 'settings');
+		$lang_keys_ignore = array('language', 'fallback', 'fallbackLanguage', 'path', 'settings');
 
 		if(isset($l) && is_array($l))
 		{

--- a/inc/class_language.php
+++ b/inc/class_language.php
@@ -137,29 +137,30 @@ class MyLanguage
 	 * Load the language variables for a section.
 	 *
 	 * @param string $section The section name.
-	 * @param boolean $isdatahandler Is this a datahandler?
+	 * @param boolean $forceuserarea Should use the user area even if in admin? For example for datahandlers
 	 * @param boolean $supress_error supress the error if the file doesn't exist?
 	 */
-	function load($section, $isdatahandler=false, $supress_error=false)
+	function load($section, $forceuserarea=false, $supress_error=false)
 	{
-		// Assign language variables.
-		// Datahandlers are never in admin lang directory.
-		if($isdatahandler === true)
+		$language = $this->language;
+		$fallback = $this->fallback;
+
+		if($forceuserarea === true)
 		{
-			$lfile = $this->path."/".str_replace('/admin', '', $this->language)."/".$section.".lang.php";
+			$language = str_replace('/admin', '', $language);
+			$fallback = str_replace('/admin', '', $fallback);
 		}
-		else
-		{
-			$lfile = $this->path."/".$this->language."/".$section.".lang.php";
-		}
+
+		$lfile = $this->path."/".$language."/".$section.".lang.php";
+		$ffile = $this->path."/".$fallback."/".$section.".lang.php";
 
 		if(file_exists($lfile))
 		{
 			require_once $lfile;
 		}
-		elseif(file_exists($this->path."/".$this->fallback."/".$section.".lang.php"))
+		elseif(file_exists($ffile))
 		{
-			require_once $this->path."/".$this->fallback."/".$section.".lang.php";
+			require_once $ffile;
 		}
 		else
 		{


### PR DESCRIPTION
Resolves #3853

The extra checks in admin/index.php are not necessary as the same is performed in the `set_language` method.

Note this only falls back to `english` since `$lang->fallback` is never changed in the core.
It could be worth exploring for 1.9 to use a fallback array and step through each fallback until giving up if the file doesn't exist in any.