### PR TITLE
Fix #3889 - quotes for usernames with quotes

### DIFF
--- a/jscripts/bbcodes_sceditor.js
+++ b/jscripts/bbcodes_sceditor.js
@@ -255,7 +255,9 @@ $(function ($) {
 			return '<blockquote' + data + '>' + content + '</blockquote>';
 		},
 		quoteType: function (val, name) {
-			return "'" + val.replace("'", "\\'") + "'";
+			var quoteChar = val.indexOf('"') !== -1 ? "'" : '"';
+
+			return quoteChar + val + quoteChar;
 		},
 		breakStart: true,
 		breakEnd: true


### PR DESCRIPTION
Fixes #3889

Uses the suggestion by @JordanMussi in https://github.com/mybb/mybb/pull/3994

Some tests:

| SCEditor Source Mode Input | Source mode value after witching to WYSIWYG and back | Parsed by MyBB correctly? |
| ---- | ---- | ---- |
| ```[quote="euan's test"]double quote[/quote]``` | ```[quote="euan's test"]double quote[/quote]``` | Yes |
| ```[quote=euan]no quote[/quote]``` | ```[quote="euan"]no quote[/quote]``` | Yes |
| ```[quote="euan"]double quote[/quote]``` | ```[quote="euan"]double quote[/quote]``` | Yes |
| ```[quote='euan']single quote[/quote]``` | ```[quote="euan"]single quote[/quote]``` | Yes |
| ```[quote='euan says "hi"']single quote[/quote]``` | ```[quote='euan says "hi"']single quote[/quote]``` | Yes |