### PR TITLE
Fixes #4054 Default PM Folder Structure

### DIFF
--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -1173,7 +1173,7 @@ class UserDataHandler extends DataHandler
 			"referrals" => 0,
 			"buddylist" => '',
 			"ignorelist" => '',
-			"pmfolders" => '',
+			"pmfolders" => "0**$%%$1**$%%$2**$%%$3**$%%$4**",
 			"notepad" => '',
 			"warningpoints" => 0,
 			"moderateposts" => 0,

--- a/install/index.php
+++ b/install/index.php
@@ -2326,7 +2326,7 @@ function install_done()
 		'referrer' => 0,
 		'buddylist' => '',
 		'ignorelist' => '',
-		'pmfolders' => '',
+		'pmfolders' => "0**$%%$1**$%%$2**$%%$3**$%%$4**",
 		'notepad' => '',
 		'showredirect' => 1,
 		'usernotes' => ''

--- a/install/resources/upgrade50.php
+++ b/install/resources/upgrade50.php
@@ -29,7 +29,11 @@ function upgrade50_dbchanges()
 	echo "<p>Updating cache...</p>";
 
 	$cache->delete("banned");
-	
+
+	// Moved PM wrong folder correction
+	$db->update_query("privatemessages", array('folder' => 1), "folder='0'");
+
+	// PM folder structure conversion
 	$db->update_query('users', array('pmfolders' => "0**$%%$1**$%%$2**$%%$3**$%%$4**"), "pmfolders = ''");
 	switch($db->type)
 	{
@@ -41,10 +45,8 @@ function upgrade50_dbchanges()
 			$update = "CONCAT('0**$%%$', pmfolders)";
 	}
 	$db->write_query("UPDATE ".TABLE_PREFIX."users SET pmfolders=".$update." WHERE pmfolders NOT LIKE '0%'");
-	$db->update_query('settings', array('value' => 1), "name='nocacheheaders'");
 
-	// Moved PM wrong folder correction
-	$db->update_query("privatemessages", array('folder' => 1), "folder='0'");
+	$db->update_query('settings', array('value' => 1), "name='nocacheheaders'");
 
 	// Add hCaptcha support
 	echo "<p>Updating settings...</p>";

--- a/install/resources/upgrade50.php
+++ b/install/resources/upgrade50.php
@@ -30,7 +30,17 @@ function upgrade50_dbchanges()
 
 	$cache->delete("banned");
 	
-	$db->update_query('users', array('pmfolders' => "0**$%%$1**$%%$2**$%%$3**$%%$4**"), "pmfolders NOT LIKE '0%'");
+	$db->update_query('users', array('pmfolders' => "0**$%%$1**$%%$2**$%%$3**$%%$4**"), "pmfolders = ''");
+	switch($db->type)
+	{
+		case "pgsql":
+		case "sqlite":
+			$update = "'0**$%%$' || pmfolders";
+			break;
+		default:
+			$update = "CONCAT('0**$%%$', pmfolders)";
+	}
+	$db->write_query("UPDATE ".TABLE_PREFIX."users SET pmfolders=".$update." WHERE pmfolders NOT LIKE '0%'");
 	$db->update_query('settings', array('value' => 1), "name='nocacheheaders'");
 
 	// Add hCaptcha support

--- a/install/resources/upgrade50.php
+++ b/install/resources/upgrade50.php
@@ -29,7 +29,8 @@ function upgrade50_dbchanges()
 	echo "<p>Updating cache...</p>";
 
 	$cache->delete("banned");
-
+	
+	$db->update_query('users', array('pmfolders' => "0**$%%$1**$%%$2**$%%$3**$%%$4**"), "pmfolders NOT LIKE '0%'");
 	$db->update_query('settings', array('value' => 1), "name='nocacheheaders'");
 
 	// Add hCaptcha support

--- a/private.php
+++ b/private.php
@@ -42,29 +42,6 @@ if($mybb->user['uid'] == '/' || $mybb->user['uid'] == 0 || $mybb->usergroup['can
 	error_no_permission();
 }
 
-$update = false;
-if(!$mybb->user['pmfolders'])
-{
-	$update = true;
-	$mybb->user['pmfolders'] = "0**$%%$1**$%%$2**$%%$3**$%%$4**";
-}
-elseif ((int)my_substr($mybb->user['pmfolders'], 0, 1) != 0)
-{
-	// Old folder structure. Need to update
-	// Since MyBB 1.8.20 fid[0] represents 'Inbox' and fid[1] represents 'Unread'
-	$update = true;
-	$mybb->user['pmfolders'] = '0'. ltrim(str_replace("$%%$2**", "$%%$1**$%%$2**", $mybb->user['pmfolders']), '1');
-}
-
-// Folder structure update required?
-if($update)
-{
-	$sql_array = array(
-		 "pmfolders" => $db->escape_string($mybb->user['pmfolders']),
-	);
-	$db->update_query("users", $sql_array, "uid = ".$mybb->user['uid']);
-}
-
 $mybb->input['fid'] = $mybb->get_input('fid', MyBB::INPUT_INT);
 
 $folder_id = $folder_name = '';

--- a/usercp.php
+++ b/usercp.php
@@ -44,12 +44,6 @@ if($mybb->user['uid'] == 0 || $mybb->usergroup['canusercp'] == 0)
 	error_no_permission();
 }
 
-if(!$mybb->user['pmfolders'])
-{
-	$mybb->user['pmfolders'] = '1**$%%$2**$%%$3**$%%$4**';
-	$db->update_query('users', array('pmfolders' => $mybb->user['pmfolders']), "uid = {$mybb->user['uid']}");
-}
-
 $errors = '';
 
 $mybb->input['action'] = $mybb->get_input('action');


### PR DESCRIPTION
Resolves #4054 

Task List:
- [x] Add default folder structure in user datahandler to be created during registration
- [x] Add default folder structure for superadmin account during installation
- [x] Drop old folder structure creation from usercp.php
- [x] Drop new folder structure correction codes from private.php
- [x] Add an upgrade script entry to check for / correct / create new folder structure once for all. 