### PR TITLE
Resolves #3560 - Missing captcha v2 in "error_nopermission"

### DIFF
--- a/inc/languages/english/messages.lang.php
+++ b/inc/languages/english/messages.lang.php
@@ -51,7 +51,7 @@ $l['error_invalidusername'] = "The username you have entered appears to be inval
 $l['error_invalidpassword'] = "The password you entered is incorrect. If you have forgotten your password, click <a href=\"member.php?action=lostpw\">here</a>. Otherwise, go back and try again.";
 $l['error_postflooding'] = "We are sorry but we cannot process your post. The administrator has specified you are only allowed to post once every {1} seconds.";
 $l['error_nopermission_guest_1'] = "You are either not logged in or do not have permission to view this page. This could be because one of the following reasons:";
-$l['error_nopermission_guest_2'] = "You are not logged in or registered. Please use the form at the bottom of this page to login.";
+$l['error_nopermission_guest_2'] = "You are not logged in or registered. Please login and retry the desired action.";
 $l['error_nopermission_guest_3'] = "You do not have permission to access this page. Are you trying to access administrative pages or a resource that you shouldn't be?  Check in the forum rules that you are allowed to perform this action.";
 $l['error_nopermission_guest_4'] = "Your account may have been disabled by an administrator, or it may be awaiting account activation.";
 $l['error_nopermission_guest_5'] = "You have accessed this page directly rather than using appropriate forms or links.";

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3639,7 +3639,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 </div>
 <br />]]></template>
 		<template name="error_inline_item" version="1818"><![CDATA[<li>{$error}</li>]]></template>
-		<template name="error_nopermission" version="1818"><![CDATA[{$lang->error_nopermission_guest_1}
+		<template name="error_nopermission" version="1824"><![CDATA[{$lang->error_nopermission_guest_1}
 <ol>
 <li>{$lang->error_nopermission_guest_2}</li>
 <li>{$lang->error_nopermission_guest_3}</li>
@@ -3647,28 +3647,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <li>{$lang->error_nopermission_guest_5}</li>
 </ol>
 <form action="member.php" method="post">
-<input type="hidden" name="action" value="do_login" />
-<input type="hidden" name="url" value="{$redirect_url}" />
-<input name="my_post_key" type="hidden" value="{$mybb->post_code}" />
-<table border="0" cellspacing="{$theme['borderwidth']}" cellpadding="{$theme['tablespace']}" class="tborder">
-<tr>
-<td class="thead" colspan="2"><span class="smalltext"><strong>{$lang->login}</strong></span></td>
-</tr>
-<tr>
-<td class="trow1"><strong>{$lang_username}</strong></td>
-<td class="trow1"><input type="text" class="textbox" name="username" tabindex="1" /></td>
-</tr>
-<tr>
-<td class="trow2"><strong>{$lang->password}</strong></td>
-<td class="trow2"><input type="password" class="textbox" name="password" tabindex="2" /></td>
-</tr>
-<tr>
-<td class="trow1" colspan="2" align="center"><label title="{$lang->remember_me_desc}"><input type="checkbox" class="checkbox" name="remember" checked="checked" value="yes" /> {$lang->remember_me}</label></td>
-</tr>
-<tr>
-<td class="trow2" colspan="2"><span class="smalltext float_right" style="padding-top: 3px;"><a href="member.php?action=register">{$lang->need_reg}</a> | <a href="member.php?action=lostpw">{$lang->forgot_password}</a>&nbsp;</span>&nbsp;<input type="submit" class="button" value="{$lang->login}" tabindex="3" /></td>
-</tr>
-</table>
+<div align="center"><input type="submit" class="button" value="{$lang->login}" tabindex="3" /></div>
 </form>
 <br />]]></template>
 		<template name="error_nopermission_loggedin" version="1600"><![CDATA[{$lang->error_nopermission_user_1}

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3639,7 +3639,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 </div>
 <br />]]></template>
 		<template name="error_inline_item" version="1818"><![CDATA[<li>{$error}</li>]]></template>
-		<template name="error_nopermission" version="1824"><![CDATA[{$lang->error_nopermission_guest_1}
+		<template name="error_nopermission" version="1823"><![CDATA[{$lang->error_nopermission_guest_1}
 <ol>
 <li>{$lang->error_nopermission_guest_2} <a href="member.php?action=login">{$lang->login}</a> | <a href="member.php?action=register">{$lang->need_reg}</a></li>
 <li>{$lang->error_nopermission_guest_3}</li>

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3645,11 +3645,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <li>{$lang->error_nopermission_guest_3}</li>
 <li>{$lang->error_nopermission_guest_4}</li>
 <li>{$lang->error_nopermission_guest_5}</li>
-</ol>
-<form action="member.php" method="post">
-<div align="center"><input type="submit" class="button" value="{$lang->login}" tabindex="3" /></div>
-</form>
-<br />]]></template>
+</ol>]]></template>
 		<template name="error_nopermission_loggedin" version="1600"><![CDATA[{$lang->error_nopermission_user_1}
 <ol>
 	<li>{$lang->error_nopermission_user_2}</li>


### PR DESCRIPTION
Note: This PR removes the login form from the error_nopermission template and leaves a single "Login" button which takes you to the full login form.

Resolves #3560 

