### PR TITLE
Fixes #4025 Insert image width & height uses incorrect MyCode

### DIFF
--- a/jscripts/bbcodes_sceditor.js
+++ b/jscripts/bbcodes_sceditor.js
@@ -522,6 +522,76 @@ $(function ($) {
 		tooltip: 'Insert a video'
 	});
 
+	// Update image command to support MyBB syntax
+	$.sceditor.formats.bbcode.set('img', {
+		format: function (element, content) {
+			if ($(element).data('sceditor-emoticon'))
+				return content;
+
+			var url = $(element).attr('src'),
+				width = $(element).attr('width'),
+				height = $(element).attr('height')
+			;
+
+			var attrs = width && height
+				? '=' + width + 'x' + height
+				: ''
+			;
+
+			return '[img' + attrs + ']' + url + '[/img]';
+		},
+	})
+
+	$.sceditor.command.set('image', {
+		_dropDown: function (editor, caller) {
+			var $content;
+
+			$content = $(
+				'<div>' +
+				'<div>' +
+				'<label for="image">' + editor._('URL') + ':</label> ' +
+				'<input type="text" id="image" placeholder="https://" />' +
+				'</div>' +
+				'<div>' +
+				'<label for="width">' + editor._('Width (optional)') + ':</label> ' +
+				'<input type="text" id="width" size="2" />' +
+				'</div>' +
+				'<div>' +
+				'<label for="height">' + editor._('Height (optional)') + ':</label> ' +
+				'<input type="text" id="height" size="2" />' +
+				'</div>' +
+				'<div><input type="button" class="button" value="' + editor._('Insert') + '" /></div>' +
+				'</div>'
+			);
+
+			$content.find('.button').on('click', function (e) {
+				var url = $content.find('#image').val(),
+					width = $content.find('#width').val(),
+					height = $content.find('#height').val()
+				;
+
+				var attrs = width && height
+					? '=' + width + 'x' + height
+					: ''
+				;
+
+				if (url)
+					editor.insert('[img' + attrs + ']' + url + '[/img]');
+
+				editor.closeDropDown(true);
+				e.preventDefault();
+			});
+
+			editor.createDropDown(caller, 'insertimage', $content.get(0));
+		},
+		exec: function (caller) {
+			$.sceditor.command.get('image')._dropDown(this, caller);
+		},
+		txtExec: function (caller) {
+			$.sceditor.command.get('image')._dropDown(this, caller);
+		},
+	});
+
 	// Remove last bits of table, superscript/subscript, youtube and ltr/rtl support
 	$.sceditor.command
 		.remove('table').remove('subscript').remove('superscript').remove('youtube').remove('ltr').remove('rtl');
@@ -533,44 +603,6 @@ $(function ($) {
 	if (partialmode) {
 		$.sceditor.formats.bbcode.remove('code').remove('php').remove('quote').remove('video').remove('img');
 		$.sceditor.command
-			.set('image', {
-				exec: function (caller) {
-					var editor = this,
-						content = $(this._('<form><div><label for="link">{0}</label> <input type="text" id="image" value="http://" /></div>' +
-							'<div><label for="width">{1}</label> <input type="text" id="width" size="2" /></div>' +
-							'<div><label for="height">{2}</label> <input type="text" id="height" size="2" /></div></form>',
-							this._("URL:"),
-							this._("Width (optional):"),
-							this._("Height (optional):")
-						))
-						.submit(function () {
-							return false;
-						});
-
-					content.append($(this._('<div><input type="button" class="button" value="Insert" /></div>',
-						this._("Insert")
-					)).on('click', function (e) {
-						var $form = $(this).parent('form'),
-							val = $form.find('#image').val(),
-							width = $form.find('#width').val(),
-							height = $form.find('#height').val(),
-							attrs = '';
-
-						if (width && height) {
-							attrs = '=' + width + 'x' + height;
-						}
-
-						if (val && val !== 'http://') {
-							editor.wysiwygEditorInsertHtml('[img' + attrs + ']' + val + '[/img]');
-						}
-
-						editor.closeDropDown(true);
-						e.preventDefault();
-					}));
-
-					editor.createDropDown(caller, 'insertimage', content.get(0));
-				}
-			})
 			.set('quote', {
 				exec: function () {
 					this.insert('[quote]', '[/quote]');

--- a/jscripts/bbcodes_sceditor.js
+++ b/jscripts/bbcodes_sceditor.js
@@ -560,7 +560,9 @@ $(function ($) {
 				'<label for="height">' + editor._('Height (optional)') + ':</label> ' +
 				'<input type="text" id="height" size="2" />' +
 				'</div>' +
-				'<div><input type="button" class="button" value="' + editor._('Insert') + '" /></div>' +
+				'<div>' +
+				'<input type="button" class="button" value="' + editor._('Insert') + '" />' +
+				'</div>' +
 				'</div>'
 			);
 


### PR DESCRIPTION
Resolves #4025 

The format part  can be omitted for an actual bug of SCEditor: it should format to the new syntax `[img width="" height=""]`  but it is stuck to an old syntax (I guess) which matches to the mybb current one:

https://github.com/samclarke/SCEditor/blob/7fd14aecc6f0c68f1e8bb98b12f6f0da769c671a/src/formats/bbcode.js#L578-L579

So I added it in case they are gonna resolve it one day.