### PR TITLE
Fixes #4100 Insecure connection used for Stop Forum Spam API

### DIFF
--- a/inc/class_stopforumspamchecker.php
+++ b/inc/class_stopforumspamchecker.php
@@ -18,7 +18,7 @@ class StopForumSpamChecker
 	 *
 	 * @var string
 	 */
-	const STOP_FORUM_SPAM_API_URL_FORMAT = 'http://api.stopforumspam.org/api?username=%s&email=%s&ip=%s&f=json&confidence';
+	const STOP_FORUM_SPAM_API_URL_FORMAT = 'https://api.stopforumspam.org/api?username=%s&email=%s&ip=%s&f=json&confidence';
 	/**
 	 * @var pluginSystem
 	 */


### PR DESCRIPTION
Resolves #4100

Changing to HTTPS worked fine in my tests in 5.6 and 7.4 with PHP using cURL 7.58.0, using `stream_context_create` and `fsockopen`. I didn't even need to add the [`SNI_enabled`](https://www.php.net/manual/en/context.ssl.php#context.ssl.sni-enabled) parameter in the stream options.

I couldn't find any stats on cURL versions used by PHP installs to see about SNI support but since mybb.com is also behind Cloudflare using SNI the same problem is present for the upgrade check. So I think this change is safe to make.