### PR TITLE
Fixes #4085 Thread View Mode cannot be set to Use Default

### DIFF
--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -690,7 +690,7 @@ class UserDataHandler extends DataHandler
 		{
 			$options['dst'] = 0;
 		}
-		
+
 		if($this->method == "insert" || (isset($options['threadmode']) && $options['threadmode'] != "linear" && $options['threadmode'] != "threaded" && $options['threadmode'] != ''))
 		{
 			$options['threadmode'] = '';

--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -690,6 +690,11 @@ class UserDataHandler extends DataHandler
 		{
 			$options['dst'] = 0;
 		}
+		
+		if($this->method == "insert" || (isset($options['threadmode']) && $options['threadmode'] != "linear" && $options['threadmode'] != "threaded" && $options['threadmode'] != ''))
+		{
+			$options['threadmode'] = '';
+		}
 
 		// Verify the "threads per page" option.
 		if($this->method == "insert" || (array_key_exists('tpp', $options) && $mybb->settings['usertppoptions']))

--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -691,18 +691,6 @@ class UserDataHandler extends DataHandler
 			$options['dst'] = 0;
 		}
 
-		if($this->method == "insert" || (isset($options['threadmode']) && $options['threadmode'] != "linear" && $options['threadmode'] != "threaded"))
-		{
-			if($mybb->settings['threadusenetstyle'])
-			{
-				$options['threadmode'] = 'threaded';
-			}
-			else
-			{
-				$options['threadmode'] = 'linear';
-			}
-		}
-
 		// Verify the "threads per page" option.
 		if($this->method == "insert" || (array_key_exists('tpp', $options) && $mybb->settings['usertppoptions']))
 		{


### PR DESCRIPTION
Closes #4085

This omitted code checks if the User Thread Mode is User Default (empty string) then sets it to Admin Default.
Now, this creates problem.
If Admin has set to "Threaded" or "Linear" it sets User Thread Mode instead of leaving the field unset.
Now, if admin re-changes the field, it will not change the User Thread Mode again as it is already been set.