### PR TITLE
Added error handling in (and,or) keyword search

### DIFF
--- a/inc/functions_search.php
+++ b/inc/functions_search.php
@@ -199,7 +199,7 @@ function get_password_protected_forums($fids=array())
  */
 function clean_keywords($keywords)
 {
-	global $db;
+	global $db, $lang;
 
 	$keywords = my_strtolower($keywords);
 	$keywords = $db->escape_string_like($keywords);
@@ -213,11 +213,18 @@ function clean_keywords($keywords)
 	if(my_strpos($keywords, "or") === 0)
 	{
 		$keywords = substr_replace($keywords, "", 0, 2);
+		$keywords = " ".$keywords;
 	}
 
 	if(my_strpos($keywords, "and") === 0)
 	{
 		$keywords = substr_replace($keywords, "", 0, 3);
+		$keywords = " ".$keywords;
+	}
+
+	if(!$keywords)
+	{
+		error($lang->error_nosearchterms);
 	}
 
 	return $keywords;


### PR DESCRIPTION
Closes #4033

    1) Removes starting "and"/"or" and appends a " " space.
    2) Throws error if keyword is empty.

