### PR TITLE
escape_string_like(): escape the '\' escape character

### DIFF
--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -1042,7 +1042,7 @@ class DB_MySQL implements DB_Base
 	 */
 	function escape_string_like($string)
 	{
-		return $this->escape_string(str_replace(array('%', '_') , array('\\%' , '\\_') , $string));
+		return $this->escape_string(str_replace(array('\\', '%', '_') , array('\\\\', '\\%' , '\\_') , $string));
 	}
 
 	/**

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -1035,7 +1035,7 @@ class DB_MySQLi implements DB_Base
 	 */
 	function escape_string_like($string)
 	{
-		return $this->escape_string(str_replace(array('%', '_') , array('\\%' , '\\_') , $string));
+		return $this->escape_string(str_replace(array('\\', '%', '_') , array('\\\\', '\\%' , '\\_') , $string));
 	}
 
 	/**

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -962,7 +962,7 @@ class DB_PgSQL implements DB_Base
 	 */
 	function escape_string_like($string)
 	{
-		return $this->escape_string(str_replace(array('%', '_') , array('\\%' , '\\_') , $string));
+		return $this->escape_string(str_replace(array('\\', '%', '_') , array('\\\\', '\\%' , '\\_') , $string));
 	}
 
 	/**

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -884,7 +884,7 @@ class DB_SQLite implements DB_Base
 	 */
 	function escape_string_like($string)
 	{
-		return $this->escape_string(str_replace(array('%', '_') , array('\\%' , '\\_') , $string));
+		return $this->escape_string(str_replace(array('\\', '%', '_') , array('\\\\', '\\%' , '\\_') , $string));
 	}
 
 	/**


### PR DESCRIPTION
Not escaping LIKE strings properly leads to unexpected search results.

For example, on https://community.mybb.com/memberlist.php if you search for `"Website contains: \"` (single backslash), it instead finds websites that end with literal `%` character. since the given `\` actually ends up escaping the internally used `%` LIKE wildcard.

Similarly if you search `Website contains: \%x` it would find `I_did_not_\_search_for_this_%_not_x` since it contains `\` and ends with `x`. The `\` ends up escaping the `\` of escaped `%`, so it's searching for a literal `\`, leaving the given `%` unescaped.

Regarding the `str_replace()` function, it is important that `\` is the first to be escaped, otherwise it will double the `\` inserted by the other escapes. Alternatively the replacement could be performed using `strtr()`.