### PR TITLE
Fix #4134 - add mail handler hook

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -631,7 +631,7 @@ function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $k
 	$mail = &get_my_mailhandler();
 
 	// If MyBB's built-in SMTP mail handler is used, set the keep alive bit accordingly.
-	if(isset($mybb->settings['mail_handler']) && $mybb->settings['mail_handler'] == 'smtp' && $keep_alive == true && !empty($mail->keep_alive))
+	if($keep_alive == true && isset($mail->keep_alive) && isset($mybb->settings['mail_handler']) && $mybb->settings['mail_handler'] == 'smtp')
 	{
 		require_once MYBB_ROOT . "inc/class_mailhandler.php";
 		require_once MYBB_ROOT . "inc/mailhandlers/smtp.php";

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -550,6 +550,64 @@ function my_date($format, $stamp=0, $offset="", $ty=1, $adodb=false)
 }
 
 /**
+ * Get a mail handler instance, a MyBB's built-in SMTP / PHP mail hander or one created by a plugin.
+ * @param bool $use_buitlin Whether to use MyBB's built-in mail handler.
+ *
+ * @return object A MyBB's built-in mail handler or one created by plugin(s).
+ */
+function &get_mybb_mailhandler($use_buitlin = false)
+{
+	global $mybb, $plugins;
+	static $mybb_mailhandler;
+	static $mybb_mailhandler_builtin;
+
+	if($use_buitlin)
+	{
+		// If our built-in mail handler doesn't exist, create it.
+		if(!is_object($mybb_mailhandler_builtin))
+		{
+			require_once MYBB_ROOT . "inc/class_mailhandler.php";
+
+			// Using SMTP.
+			if(isset($mybb->settings['mail_handler']) && $mybb->settings['mail_handler'] == 'smtp')
+			{
+				require_once MYBB_ROOT . "inc/mailhandlers/smtp.php";
+				$mybb_mailhandler_builtin = new SmtpMail();
+			}
+			// Using PHP mail().
+			else
+			{
+				require_once MYBB_ROOT . "inc/mailhandlers/php.php";
+				$mybb_mailhandler_builtin = new PhpMail();
+				if(!empty($mybb->settings['mail_parameters']))
+				{
+					$mybb_mailhandler_builtin->additional_parameters = $mybb->settings['mail_parameters'];
+				}
+			}
+		}
+
+		return $mybb_mailhandler_builtin;
+	}
+
+	// If our mail handler doesn't exist, create it.
+	if(!is_object($mybb_mailhandler))
+	{
+		require_once MYBB_ROOT . "inc/class_mailhandler.php";
+
+		$plugins->run_hooks('mybb_mailhandler_init', $mybb_mailhandler);
+
+		if(!is_object($mybb_mailhandler) || !($mybb_mailhandler instanceof MailHandler))
+		{
+			$mybb_mailhandler = &get_mybb_mailhandler(true);
+		}
+
+		$plugins->run_hooks('mybb_mailhandler_after_init', $mybb_mailhandler);
+	}
+
+	return $mybb_mailhandler;
+}
+
+/**
  * Sends an email using PHP's mail function, formatting it appropriately.
  *
  * @param string $to Address the email should be addressed to.
@@ -569,49 +627,70 @@ function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $k
 	global $mybb, $plugins;
 	static $mail;
 
-	// Does our object not exist? Create it
-	if(!is_object($mail))
+	// Get our mail handler.
+	$mail = &get_mybb_mailhandler();
+
+	// If MyBB's built-in SMTP mail handler is used, set the keep alive bit accordingly.
+	if(isset($mybb->settings['mail_handler']) && $mybb->settings['mail_handler'] == 'smtp' && $keep_alive == true && !empty($mail->keep_alive))
 	{
-		require_once MYBB_ROOT."inc/class_mailhandler.php";
-
-		$plugins->run_hooks('my_mail_mailhandler_init', $mail);
-
-		if(!is_object($mail) || !($mail instanceof MailHandler))
-		{
-			if($mybb->settings['mail_handler'] == 'smtp')
-			{
-				require_once MYBB_ROOT."inc/mailhandlers/smtp.php";
-				$mail = new SmtpMail();
-			}
-			else
-			{
-				require_once MYBB_ROOT."inc/mailhandlers/php.php";
-				$mail = new PhpMail();
-			}
-		}
-	}
-
-	// Using SMTP based mail
-	if($mybb->settings['mail_handler'] == 'smtp')
-	{
-		if($keep_alive == true)
+		require_once MYBB_ROOT . "inc/class_mailhandler.php";
+		require_once MYBB_ROOT . "inc/mailhandlers/smtp.php";
+		if($mail instanceof MailHandler && $mail instanceof SmtpMail)
 		{
 			$mail->keep_alive = true;
 		}
 	}
 
-	// Using PHP based mail()
-	else
+	$my_mail_parameters = compact("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email");
+
+	$my_mail_parameters = $plugins->run_hooks('my_mail_pre_build_message', $my_mail_parameters);
+
+	if(is_array($my_mail_parameters))
 	{
-		if($mybb->settings['mail_parameters'] != '')
+		foreach($my_mail_parameters as $key => $value)
 		{
-			$mail->additional_parameters = $mybb->settings['mail_parameters'];
+			// Using extract() here may not be safe, so we work it out manually.
+			if(in_array($key, array("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email")))
+			{
+				$$key = $value;
+			}
 		}
 	}
 
-	// Build and send
+	// Build the mail message.
 	$mail->build_message($to, $subject, $message, $from, $charset, $headers, $format, $message_text, $return_email);
-	return $mail->send();
+
+	// Following variables will help sequential plugins to determine how to process the hook.
+	// Mark this variable true if the hooked plugin has sent the mail, otherwise don't modify it.
+	$is_mail_sent = false;
+	// Mark this variable false if the hooked plugin doesn't suggest sequential plugins to continue processing.
+	$continue_process = true;
+
+	$my_mail_parameters = compact("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email", "is_mail_sent", "continue_process");
+
+	$plugins->run_hooks('my_mail_pre_send', $my_mail_parameters);
+
+	// Check if the hooked plugins have sent the mail.
+	if(isset($my_mail_parameters['is_mail_sent']))
+	{
+		$is_mail_sent = (bool)$my_mail_parameters['is_mail_sent'];
+	}
+	// Check if the hooked plugins still suggest to send the mail.
+	if(isset($my_mail_parameters['continue_process']))
+	{
+		$continue_process = (bool)$my_mail_parameters['continue_process'];
+	}
+
+	if($continue_process)
+	{
+		$is_mail_sent = $mail->send();
+	}
+
+	$my_mail_parameters = compact("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email", "is_mail_sent", "continue_process");
+
+	$plugins->run_hooks('my_mail_post_send', $my_mail_parameters);
+
+	return $is_mail_sent;
 }
 
 /**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -566,7 +566,7 @@ function my_date($format, $stamp=0, $offset="", $ty=1, $adodb=false)
  */
 function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $keep_alive=false, $format="text", $message_text="", $return_email="")
 {
-	global $mybb;
+	global $mybb, $plugins;
 	static $mail;
 
 	// Does our object not exist? Create it
@@ -574,15 +574,20 @@ function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $k
 	{
 		require_once MYBB_ROOT."inc/class_mailhandler.php";
 
-		if($mybb->settings['mail_handler'] == 'smtp')
+		$plugins->run_hooks('my_mail_mailhandler_init', $mail);
+
+		if(!is_object($mail) || !($mail instanceof MailHandler))
 		{
-			require_once MYBB_ROOT."inc/mailhandlers/smtp.php";
-			$mail = new SmtpMail();
-		}
-		else
-		{
-			require_once MYBB_ROOT."inc/mailhandlers/php.php";
-			$mail = new PhpMail();
+			if($mybb->settings['mail_handler'] == 'smtp')
+			{
+				require_once MYBB_ROOT."inc/mailhandlers/smtp.php";
+				$mail = new SmtpMail();
+			}
+			else
+			{
+				require_once MYBB_ROOT."inc/mailhandlers/php.php";
+				$mail = new PhpMail();
+			}
 		}
 	}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -596,6 +596,7 @@ function &get_my_mailhandler($use_buitlin = false)
 
 		$plugins->run_hooks('my_mailhandler_init', $my_mailhandler);
 
+		// If no plugin creates the mail handler, resort to use the built-in one.
 		if(!is_object($my_mailhandler) || !($my_mailhandler instanceof MailHandler))
 		{
 			$my_mailhandler = &get_my_mailhandler(true);
@@ -625,7 +626,6 @@ function &get_my_mailhandler($use_buitlin = false)
 function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $keep_alive=false, $format="text", $message_text="", $return_email="")
 {
 	global $mybb, $plugins;
-	static $mail;
 
 	// Get our mail handler.
 	$mail = &get_my_mailhandler();

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -553,18 +553,18 @@ function my_date($format, $stamp=0, $offset="", $ty=1, $adodb=false)
  * Get a mail handler instance, a MyBB's built-in SMTP / PHP mail hander or one created by a plugin.
  * @param bool $use_buitlin Whether to use MyBB's built-in mail handler.
  *
- * @return object A MyBB's built-in mail handler or one created by plugin(s).
+ * @return object A MyBB built-in mail handler or one created by plugin(s).
  */
-function &get_mybb_mailhandler($use_buitlin = false)
+function &get_my_mailhandler($use_buitlin = false)
 {
 	global $mybb, $plugins;
-	static $mybb_mailhandler;
-	static $mybb_mailhandler_builtin;
+	static $my_mailhandler;
+	static $my_mailhandler_builtin;
 
 	if($use_buitlin)
 	{
 		// If our built-in mail handler doesn't exist, create it.
-		if(!is_object($mybb_mailhandler_builtin))
+		if(!is_object($my_mailhandler_builtin))
 		{
 			require_once MYBB_ROOT . "inc/class_mailhandler.php";
 
@@ -572,39 +572,39 @@ function &get_mybb_mailhandler($use_buitlin = false)
 			if(isset($mybb->settings['mail_handler']) && $mybb->settings['mail_handler'] == 'smtp')
 			{
 				require_once MYBB_ROOT . "inc/mailhandlers/smtp.php";
-				$mybb_mailhandler_builtin = new SmtpMail();
+				$my_mailhandler_builtin = new SmtpMail();
 			}
 			// Using PHP mail().
 			else
 			{
 				require_once MYBB_ROOT . "inc/mailhandlers/php.php";
-				$mybb_mailhandler_builtin = new PhpMail();
+				$my_mailhandler_builtin = new PhpMail();
 				if(!empty($mybb->settings['mail_parameters']))
 				{
-					$mybb_mailhandler_builtin->additional_parameters = $mybb->settings['mail_parameters'];
+					$my_mailhandler_builtin->additional_parameters = $mybb->settings['mail_parameters'];
 				}
 			}
 		}
 
-		return $mybb_mailhandler_builtin;
+		return $my_mailhandler_builtin;
 	}
 
 	// If our mail handler doesn't exist, create it.
-	if(!is_object($mybb_mailhandler))
+	if(!is_object($my_mailhandler))
 	{
 		require_once MYBB_ROOT . "inc/class_mailhandler.php";
 
-		$plugins->run_hooks('mybb_mailhandler_init', $mybb_mailhandler);
+		$plugins->run_hooks('my_mailhandler_init', $my_mailhandler);
 
-		if(!is_object($mybb_mailhandler) || !($mybb_mailhandler instanceof MailHandler))
+		if(!is_object($my_mailhandler) || !($my_mailhandler instanceof MailHandler))
 		{
-			$mybb_mailhandler = &get_mybb_mailhandler(true);
+			$my_mailhandler = &get_my_mailhandler(true);
 		}
 
-		$plugins->run_hooks('mybb_mailhandler_after_init', $mybb_mailhandler);
+		$plugins->run_hooks('my_mailhandler_after_init', $my_mailhandler);
 	}
 
-	return $mybb_mailhandler;
+	return $my_mailhandler;
 }
 
 /**
@@ -620,7 +620,7 @@ function &get_mybb_mailhandler($use_buitlin = false)
  * @param string $format The format of the email to be sent (text or html). text is default
  * @param string $message_text The text message of the email if being sent in html format, for email clients that don't support html
  * @param string $return_email The email address to return to. Defaults to admin return email address.
- * @return bool
+ * @return bool True if the mail is sent, false otherwise.
  */
 function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $keep_alive=false, $format="text", $message_text="", $return_email="")
 {
@@ -628,7 +628,7 @@ function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $k
 	static $mail;
 
 	// Get our mail handler.
-	$mail = &get_mybb_mailhandler();
+	$mail = &get_my_mailhandler();
 
 	// If MyBB's built-in SMTP mail handler is used, set the keep alive bit accordingly.
 	if(isset($mybb->settings['mail_handler']) && $mybb->settings['mail_handler'] == 'smtp' && $keep_alive == true && !empty($mail->keep_alive))
@@ -641,52 +641,39 @@ function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $k
 		}
 	}
 
-	$my_mail_parameters = compact("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email");
-
-	$my_mail_parameters = $plugins->run_hooks('my_mail_pre_build_message', $my_mail_parameters);
-
-	if(is_array($my_mail_parameters))
-	{
-		foreach($my_mail_parameters as $key => $value)
-		{
-			// Using extract() here may not be safe, so we work it out manually.
-			if(in_array($key, array("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email")))
-			{
-				$$key = $value;
-			}
-		}
-	}
-
-	// Build the mail message.
-	$mail->build_message($to, $subject, $message, $from, $charset, $headers, $format, $message_text, $return_email);
-
-	// Following variables will help sequential plugins to determine how to process the hook.
+	// Following variables will help sequential plugins to determine how to process plugin hooks.
 	// Mark this variable true if the hooked plugin has sent the mail, otherwise don't modify it.
 	$is_mail_sent = false;
 	// Mark this variable false if the hooked plugin doesn't suggest sequential plugins to continue processing.
 	$continue_process = true;
 
-	$my_mail_parameters = compact("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email", "is_mail_sent", "continue_process");
+	$my_mail_parameters = array(
+		'to' => &$to,
+		'subject' => &$subject,
+		'message' => &$message,
+		'from' => &$from,
+		'charset' => &$charset,
+		'headers' => &$headers,
+		'keep_alive' => &$keep_alive,
+		'format' => &$format,
+		'message_text' => &$message_text,
+		'return_email' => &$return_email,
+		'is_mail_sent' => &$is_mail_sent,
+		'continue_process' => &$continue_process,
+	);
+
+	$my_mail_parameters = $plugins->run_hooks('my_mail_pre_build_message', $my_mail_parameters);
+
+	// Build the mail message.
+	$mail->build_message($to, $subject, $message, $from, $charset, $headers, $format, $message_text, $return_email);
 
 	$plugins->run_hooks('my_mail_pre_send', $my_mail_parameters);
 
-	// Check if the hooked plugins have sent the mail.
-	if(isset($my_mail_parameters['is_mail_sent']))
-	{
-		$is_mail_sent = (bool)$my_mail_parameters['is_mail_sent'];
-	}
 	// Check if the hooked plugins still suggest to send the mail.
-	if(isset($my_mail_parameters['continue_process']))
-	{
-		$continue_process = (bool)$my_mail_parameters['continue_process'];
-	}
-
 	if($continue_process)
 	{
 		$is_mail_sent = $mail->send();
 	}
-
-	$my_mail_parameters = compact("to", "subject", "message", "from", "charset", "headers", "keep_alive", "format", "message_text", "return_email", "is_mail_sent", "continue_process");
 
 	$plugins->run_hooks('my_mail_post_send', $my_mail_parameters);
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -662,7 +662,7 @@ function my_mail($to, $subject, $message, $from="", $charset="", $headers="", $k
 		'continue_process' => &$continue_process,
 	);
 
-	$my_mail_parameters = $plugins->run_hooks('my_mail_pre_build_message', $my_mail_parameters);
+	$plugins->run_hooks('my_mail_pre_build_message', $my_mail_parameters);
 
 	// Build the mail message.
 	$mail->build_message($to, $subject, $message, $from, $charset, $headers, $format, $message_text, $return_email);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -586,6 +586,8 @@ function &get_my_mailhandler($use_buitlin = false)
 			}
 		}
 
+		$plugins->run_hooks('my_mailhandler_builtin_after_init', $my_mailhandler_builtin);
+
 		return $my_mailhandler_builtin;
 	}
 
@@ -596,13 +598,11 @@ function &get_my_mailhandler($use_buitlin = false)
 
 		$plugins->run_hooks('my_mailhandler_init', $my_mailhandler);
 
-		// If no plugin creates the mail handler, resort to use the built-in one.
+		// If no plugin has ever created the mail handler, resort to use the built-in one.
 		if(!is_object($my_mailhandler) || !($my_mailhandler instanceof MailHandler))
 		{
 			$my_mailhandler = &get_my_mailhandler(true);
 		}
-
-		$plugins->run_hooks('my_mailhandler_after_init', $my_mailhandler);
 	}
 
 	return $my_mailhandler;


### PR DESCRIPTION
Resolves #4134.

This adds a new hook to `my_mail` called `my_mail_mailhandler_init`. The hook is passed a reference to the `$mail` variable and should set up a new mail handler instance. 