### PR TITLE
PHP>=7.1 [] operator not supported for strings

### DIFF
--- a/inc/tasks/checktables.php
+++ b/inc/tasks/checktables.php
@@ -28,7 +28,7 @@ function task_checktables($task)
 
 	$comma = "";
 	$tables_list = "";
-	$repaired = "";
+	$repaired = [];
 	$setting_done = false;
 
 	$tables = $db->list_tables($mybb->config['database']['database'], $mybb->config['database']['table_prefix']);


### PR DESCRIPTION
Since PHP 7.1, you cannot add array elements in a string initialised variable. Causing the cachetables task to crash if it finds a corrupt table, leaving the forum closed until it's manually opened.

Resolves #4133 

