### PR TITLE
Fixes #4123: Removes warning link if user cannot warn

### DIFF
--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -5048,9 +5048,13 @@ if(use_xmlhttprequest == "1")
 <br />]]></template>
 		<template name="member_profile_userstar" version="1800"><![CDATA[<img src="{$starimage}" border="0" alt="*" />]]></template>
 		<template name="member_profile_warn" version="1400"><![CDATA[[<a href="warnings.php?action=warn&amp;uid={$memprofile['uid']}">{$lang->warn}</a>]]]></template>
-		<template name="member_profile_warninglevel" version="1600"><![CDATA[<tr>
+		<template name="member_profile_warninglevel" version="1825"><![CDATA[<tr>
 	<td class="{$bg_color}"><strong>{$lang->warning_level}</strong></td>
-	<td class="{$bg_color}"><a href="{$warning_link}">{$warning_level}</a> {$warn_user}</td>
+	<td class="{$bg_color}">{$warning_level}</td>
+</tr>]]></template>
+		<template name="member_profile_warninglevel_link" version="1825"><![CDATA[<tr>
+	<td class="{$bg_color}"><strong>{$lang->warning_level}</strong></td>
+	<td class="{$bg_color}"><a href="warnings.php?uid={$memprofile['uid']}">{$warning_level}</a> {$warn_user}</td>
 </tr>]]></template>
 		<template name="member_profile_website" version="1813"><![CDATA[<tr>
 	<td class="{$bgcolor}"><strong>{$lang->homepage}</strong></td>

--- a/member.php
+++ b/member.php
@@ -17,7 +17,7 @@ $nosession['avatar'] = 1;
 
 $templatelist = "member_register,member_register_hiddencaptcha,member_register_coppa,member_register_agreement_coppa,member_register_agreement,member_register_customfield,member_register_requiredfields,member_profile_findthreads";
 $templatelist .= ",member_loggedin_notice,member_profile_away,member_register_regimage,member_register_regimage_recaptcha_invisible,member_register_regimage_nocaptcha,post_captcha_hcaptcha_invisible,post_captcha_hcaptcha,post_captcha_hidden,post_captcha,member_register_referrer";
-$templatelist .= ",member_profile_email,member_profile_offline,member_profile_reputation,member_profile_warn,member_profile_warninglevel,member_profile_customfields_field,member_profile_customfields,member_profile_adminoptions_manageban,member_profile_adminoptions,member_profile";
+$templatelist .= ",member_profile_email,member_profile_offline,member_profile_reputation,member_profile_warn,member_profile_warninglevel,member_profile_warninglevel_link,member_profile_customfields_field,member_profile_customfields,member_profile_adminoptions_manageban,member_profile_adminoptions,member_profile";
 $templatelist .= ",member_profile_signature,member_profile_avatar,member_profile_groupimage,member_referrals_link,member_profile_referrals,member_profile_website,member_profile_reputation_vote,member_activate,member_lostpw,member_register_additionalfields";
 $templatelist .= ",member_profile_modoptions_manageuser,member_profile_modoptions_editprofile,member_profile_modoptions_banuser,member_profile_modoptions_viewnotes,member_profile_modoptions_editnotes,member_profile_modoptions_purgespammer";
 $templatelist .= ",usercp_profile_profilefields_select_option,usercp_profile_profilefields_multiselect,usercp_profile_profilefields_select,usercp_profile_profilefields_textarea,usercp_profile_profilefields_radio,member_viewnotes";
@@ -2520,16 +2520,16 @@ if($mybb->input['action'] == "profile")
 			$warning_level = 100;
 		}
 
-		$warn_user = '';
-		$warning_link = 'usercp.php';
 		$warning_level = get_colored_warning_level($warning_level);
-		if($mybb->usergroup['canwarnusers'] != 0 && $memprofile['uid'] != $mybb->user['uid'])
+		if($mybb->usergroup['canwarnusers'] != 0)
 		{
 			eval("\$warn_user = \"".$templates->get("member_profile_warn")."\";");
-			$warning_link = "warnings.php?uid={$memprofile['uid']}";
+			eval("\$warning_level = \"".$templates->get("member_profile_warninglevel_link")."\";");
 		}
-
-		eval("\$warning_level = \"".$templates->get("member_profile_warninglevel")."\";");
+		else
+		{
+			eval("\$warning_level = \"".$templates->get("member_profile_warninglevel")."\";");
+		}
 	}
 
 	$bgcolor = $alttrow = 'trow1';


### PR DESCRIPTION
Resolves #4123

This PR not only removes the check, if a user is his own profile (as [suggested](https://community.mybb.com/thread-228511.html)), but removes the link altogether, if the user isn´t permitted to warn:
Now users that are allowed to warn will always end up on `warnings.php`when clicking the percentage (even when they´re on their own profile) and users that are not won´t see a link at all (instead of a link to their own profile, so their currently opened site).