### PR TITLE
Implement PDO based DB drivers for MySQL and PostgreSQL

### DIFF
--- a/inc/AbstractPdoDbDriver.php
+++ b/inc/AbstractPdoDbDriver.php
@@ -300,10 +300,10 @@ abstract class AbstractPdoDbDriver implements DB_Base
 				$portSeparator = strpos($hostname, ':', $closingSquareBracket);
 
 				// there is no port specified
-				if ($portSeparator === false && strlen($hostname) > $portSeparator + 1) {
+				if ($portSeparator === false) {
 					return array($hostname, null);
 				} else {
-					$host = substr($hostname, $openingSquareBracket, $closingSquareBracket);
+					$host = substr($hostname, $openingSquareBracket, $closingSquareBracket + 1);
 					$port = (int) substr($hostname, $portSeparator + 1);
 
 					return array($host, $port);
@@ -315,7 +315,7 @@ abstract class AbstractPdoDbDriver implements DB_Base
 
 		// either an IPv4 address or a hostname
 		$portSeparator = strpos($hostname, ':', 0);
-		if ($portSeparator === false && strlen($hostname) > $portSeparator + 1) {
+		if ($portSeparator === false) {
 			return array($hostname, null);
 		} else {
 			$host = substr($hostname, 0, $portSeparator);

--- a/inc/AbstractPdoDbDriver.php
+++ b/inc/AbstractPdoDbDriver.php
@@ -417,7 +417,7 @@ abstract class AbstractPdoDbDriver implements DB_Base
 	 *
 	 * @return PDOStatement|null The result of the query, or null if an error occurred and {@see $hideErrors} was set.
 	 */
-	function query($string, $hideErrors = false, $writeQuery = 0)
+	public function query($string, $hideErrors = false, $writeQuery = false)
 	{
 		global $mybb;
 
@@ -474,9 +474,9 @@ abstract class AbstractPdoDbDriver implements DB_Base
 	 *
 	 * @return PDOStatement|null The result of the query, or null if an error occurred and {@see $hideErrors} was set.
 	 */
-	function write_query($query, $hideErrors = false)
+	public function write_query($query, $hideErrors = false)
 	{
-		return $this->query($query, $hideErrors, 1);
+		return $this->query($query, $hideErrors, true);
 	}
 
 	/**
@@ -490,7 +490,7 @@ abstract class AbstractPdoDbDriver implements DB_Base
 	 *
 	 * @return array|bool The array of results, or false if there are no more results.
 	 */
-	function fetch_array($query, $resultType = PDO::FETCH_ASSOC)
+	public function fetch_array($query, $resultType = PDO::FETCH_ASSOC)
 	{
 		if (is_null($query) || !($query instanceof PDOStatement)) {
 			return false;
@@ -525,7 +525,7 @@ abstract class AbstractPdoDbDriver implements DB_Base
 	 * @return mixed The resulting field, of false if no more rows are in th result set.
 	 *  Note that when querying fields that have a boolean value, this method should not be used.
 	 */
-	function fetch_field($query, $field, $row = false)
+	public function fetch_field($query, $field, $row = false)
 	{
 		if (is_null($query) || !($query instanceof PDOStatement)) {
 			return false;
@@ -553,7 +553,7 @@ abstract class AbstractPdoDbDriver implements DB_Base
 	 *
 	 * @return bool Whether seeking was successful.
 	 */
-	function data_seek($query, $row)
+	public function data_seek($query, $row)
 	{
 		if (is_null($query) || !($query instanceof PDOStatement)) {
 			return false;
@@ -579,7 +579,7 @@ abstract class AbstractPdoDbDriver implements DB_Base
 			return false;
 		}
 
-		if (stripos($query->queryString, 'SELECT') !== false) {
+		if (preg_match('/(^|\\s)SELECT\\b/i', $query->queryString) === 1) {
 			// rowCount does not return the number of rows in a select query on most DBMS, so we instead fetch all results then count them
 			// TODO: how do we handle the case where we issued a prepared statement with parameters..?
 			$countQuery = $this->read_link->query($query->queryString);

--- a/inc/AbstractPdoDbDriver.php
+++ b/inc/AbstractPdoDbDriver.php
@@ -425,9 +425,9 @@ abstract class AbstractPdoDbDriver implements DB_Base
 
 		// Only execute write queries on master server
 		if (($writeQuery || $this->last_query_type) && $this->write_link) {
-			$this->current_link = &$this->write_link;
+			$this->current_link = $this->write_link;
 		} else {
-			$this->current_link = &$this->read_link;
+			$this->current_link = $this->read_link;
 		}
 
 		/** @var PDOStatement|null $query */
@@ -484,7 +484,7 @@ abstract class AbstractPdoDbDriver implements DB_Base
 	 *
 	 * @param PDOStatement $query The query to retrieve a result for.
 	 * @param int $resultType The type of array to return. Can be any of the following values:
-	 *  - {@see PDO::FETCH_ASSOC} Fetch an array o results keyed by column name. This is the default.
+	 *  - {@see PDO::FETCH_ASSOC} Fetch an array of results keyed by column name. This is the default.
 	 *  - {@see PDO::FETCH_NUM} Fetch an array of results keyed by column number, starting at 0.
 	 *  - {@see PDO::FETCH_BOTH} Fetch an array of results keyed by both column name and number.
 	 *

--- a/inc/AbstractPdoDbDriver.php
+++ b/inc/AbstractPdoDbDriver.php
@@ -682,7 +682,11 @@ abstract class AbstractPdoDbDriver implements DB_Base
 
 	 public function free_result($query)
 	 {
-		 return true;
+	 	 if (is_object($query) && $query instanceof PDOStatement) {
+		     return $query->closeCursor();
+	     }
+
+	 	 return false;
 	 }
 
 	 public function escape_string_like($string)

--- a/inc/AbstractPdoDbDriver.php
+++ b/inc/AbstractPdoDbDriver.php
@@ -1,0 +1,704 @@
+<?php
+/**
+ * MyBB 1.8
+ * Copyright 2020 MyBB Group, All Rights Reserved
+ *
+ * Website: http://www.mybb.com
+ * License: http://www.mybb.com/about/license
+ */
+
+abstract class AbstractPdoDbDriver implements DB_Base
+{
+	/**
+	 * Whether error reporting is enabled.
+	 *
+	 * @var boolean
+	 */
+	public $error_reporting = 1;
+
+	/**
+	 * The read database connection resource.
+	 *
+	 * @var PDO|null
+	 */
+	public $read_link = null;
+
+	/**
+	 * The write database connection resource.
+	 *
+	 * @var PDO|null
+	 */
+	public $write_link = null;
+
+	/**
+	 * Reference to the last database connection resource used.
+	 *
+	 * @var PDO|null
+	 */
+	public $current_link = null;
+
+	/**
+	 * The database name.
+	 *
+	 * @var string
+	 */
+	public $database;
+
+	/**
+	 * The database encoding currently in use (if supported).
+	 *
+	 * @var string
+	 */
+	public $db_encoding = "utf8";
+
+	/**
+	 * The time spent performing queries.
+	 *
+	 * @var float
+	 */
+	public $query_time = 0;
+
+	/**
+	 * A count of the number of queries.
+	 *
+	 * @var int
+	 */
+	public $query_count = 0;
+
+	/**
+	 * @var array
+	 */
+	public $connections = array();
+
+	/**
+	 * @var PDOException|null
+	 */
+	private $lastPdoException;
+
+	/**
+	 * The type of the previous query.
+	 *
+	 * 1 => write; 0 => read
+	 *
+	 * @var int
+	 */
+	protected $last_query_type = 0;
+
+	/**
+	 * Used to store row offsets for queries when seeking.
+	 *
+	 * @var array
+	 */
+	private $resultSeekPositions = array();
+
+	/**
+	 * The last result, used to get the number of affected rows in {@see AbstractPdoDbDriver::affected_rows()}.
+	 *
+	 * @var PDOStatement|null
+	 */
+	private $lastResult = null;
+
+	/**
+	 * The table prefix used for simple select, update, insert and delete queries
+	 *
+	 * @var string
+	 */
+	public $table_prefix;
+
+	/**
+	 * The current version of the DBMS.
+	 *
+	 * Note that this is the version used by the {@see AbstractPdoDbDriver::$read_link}.
+	 *
+	 * @var string
+	 */
+	public $version;
+
+	/**
+	 * A list of the performed queries.
+	 *
+	 * @var array
+	 */
+	public $querylist = array();
+
+	/**
+	 * Build a DSN string using the given configuration.
+	 *
+	 * @param string $hostname The hostname of the database serer to connect to.
+	 * @param string $db The name of the database to connect to.
+	 * @param int|null The optional port to use to connect to the database server.
+	 * @param string|null The character encoding to use for the connection.
+	 *
+	 * @return string The DSN string, including the driver prefix.
+	 */
+	protected abstract function getDsn($hostname, $db, $port, $encoding);
+
+	/**
+	 * Connect to the database server.
+	 *
+	 * @param array $config Array of DBMS connection details.
+	 *
+	 * @return bool Whether opening the connection was successful.
+	 */
+	public function connect($config)
+	{
+		$connections = array(
+			'read' => array(),
+			'write' => array(),
+		);
+
+		if (isset($config['hostname'])) {
+			// simple connection, with single DB server
+			$connections['read'][] = $config;
+		} else {
+			if (!isset($config['read'])) {
+				// multiple servers, but no specific read/write servers
+				foreach ($config as $key => $settings) {
+					if (is_int($key)) {
+						$connections['read'][] = $settings;
+					}
+				}
+			} else {
+				// both read and write servers
+				$connections = $config;
+			}
+		}
+
+		$this->db_encoding = $config['encoding'];
+
+		// Actually connect to the specified servers
+		foreach (array('read', 'write') as $type) {
+			if (!isset($connections[$type]) || !is_array($connections[$type])){
+				break;
+			}
+
+			if (isset($connections[$type]['hostname'])) {
+				$details = $connections[$type];
+				unset($connections[$type]);
+				$connections[$type][] = $details;
+			}
+
+			// shuffle the connections
+			shuffle($connections[$type]);
+
+			// loop through the connections
+			foreach($connections[$type] as $singleConnection)
+			{
+				$flags = array(
+					PDO::ATTR_PERSISTENT => false,
+					PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+					PDO::ATTR_EMULATE_PREPARES => false,
+				);
+
+				if (!empty($singleConnection['pconnect'])) {
+					$flags[PDO::ATTR_PERSISTENT] = true;
+				}
+
+				$link = "{$type}_link";
+
+				get_execution_time();
+
+				list($hostname, $port) = self::parseHostname($singleConnection['hostname']);
+
+				$dsn = $this->getDsn(
+					$hostname,
+					$config['database'],
+					$port,
+					$this->db_encoding
+				);
+
+				try {
+					$this->$link = new PDO(
+						$dsn,
+						$singleConnection['username'],
+						$singleConnection['password'],
+						$flags
+					);
+
+					$this->lastPdoException = null;
+				} catch (PDOException $e) {
+					$this->$link = null;
+					$this->lastPdoException = $e;
+				}
+
+				$time_spent = get_execution_time();
+				$this->query_time += $time_spent;
+
+				// Successful connection? break down brother!
+				if ($this->$link !== null) {
+					$this->connections[] = "[".strtoupper($type)."] {$singleConnection['username']}@{$singleConnection['hostname']} (Connected in ".format_time_duration($time_spent).")";
+					break;
+				} else {
+					$this->connections[] = "<span style=\"color: red\">[FAILED] [".strtoupper($type)."] {$singleConnection['username']}@{$singleConnection['hostname']}</span>";
+				}
+			}
+		}
+
+		// No write server was specified (simple connection or just multiple servers) - mirror write link
+		if (empty($connections['write'])) {
+			$this->write_link = $this->read_link;
+		}
+
+		// Have no read connection?
+		if ($this->read_link === null) {
+			$this->error("[READ] Unable to connect to database server");
+			return false;
+		} else if($this->write_link === null) {
+			$this->error("[WRITE] Unable to connect to database server");
+			return false;
+		}
+
+		$this->database = $config['database'];
+
+		if (version_compare('PHP_VERSION', '5.3.6', '<') === true) {
+			// character set in DSN was ignored before PHP 5.3.6, so we must SET NAMES
+			$this->setCharacterSet($this->db_encoding);
+		}
+
+		$this->current_link = $this->read_link;
+		return true;
+	}
+
+	/**
+	 * Parse a hostname and possible port combination.
+	 *
+	 * @param string $hostname The hostname string. Can be any of the following formats:
+	 * - `127.0.0.1` - IPv4 address.
+	 * - `[::1]` - IPv6 address.
+	 * - `localhost` - hostname.
+	 * - `127.0.0.1:3306` - IPv4 address and port combination.
+	 *  `[::1]:3306` - IPv6 address and port combination.
+	 * - `localhost:3306` - hostname and port combination.
+	 *
+	 * @return array Array of host and port.
+	 *
+	 * @throws InvalidArgumentException Thrown if {@see $hostname} is an IPv6 address which lacks a closing square bracket.
+	 */
+	private static function parseHostname($hostname)
+	{
+		// first, check for an IPv6 address - IPv6 addresses always start with `[`
+		$openingSquareBracket = strpos($hostname, '[');
+		if ($openingSquareBracket === 0) {
+			// find ending `]`
+			$closingSquareBracket = strpos($hostname, ']', $openingSquareBracket);
+
+			if ($closingSquareBracket !== false) {
+				$portSeparator = strpos($hostname, ':', $closingSquareBracket);
+
+				// there is no port specified
+				if ($portSeparator === false && strlen($hostname) > $portSeparator + 1) {
+					return array($hostname, null);
+				} else {
+					$host = substr($hostname, $openingSquareBracket, $closingSquareBracket);
+					$port = (int) substr($hostname, $portSeparator + 1);
+
+					return array($host, $port);
+				}
+			} else {
+				throw new InvalidArgumentException("Hostname is missing a closing square bracket for IPv6 address: {$hostname}");
+			}
+		}
+
+		// either an IPv4 address or a hostname
+		$portSeparator = strpos($hostname, ':', 0);
+		if ($portSeparator === false && strlen($hostname) > $portSeparator + 1) {
+			return array($hostname, null);
+		} else {
+			$host = substr($hostname, 0, $portSeparator);
+			$port = (int) substr($hostname, $portSeparator + 1);
+
+			return array($host, $port);
+		}
+	}
+
+	/**
+	 * Set the character set to use. This issues a `SET NAMES` query to both the read and write links.
+	 *
+	 * @param string $characterSet The character set to use.
+	 *
+	 * @return void
+	 */
+	public function setCharacterSet($characterSet)
+	{
+		$query = "SET NAMES {$characterSet}";
+
+		self::execIgnoreError($this->read_link, $query);
+
+		if ($this->write_link !== $this->read_link) {
+			self::execIgnoreError($this->write_link, $query);
+		}
+	}
+
+	/**
+	 * Execute a query, ignoring any errors.
+	 *
+	 * @param PDO $connection The connection to execute the query on.
+	 * @param string $query The query to execute.
+	 */
+	private static function execIgnoreError($connection, $query)
+	{
+		try {
+			$connection->exec($query);
+		} catch (PDOException $e) {
+			// ignored on purpose
+		}
+	}
+
+	/**
+	 * Output a database error.
+	 *
+	 * @param string $string The string to present as an error.
+	 *
+	 * @return bool Whether error reporting is enabled or not
+	 */
+	public function error($string = '')
+	{
+		if ($this->error_reporting) {
+			if (class_exists("errorHandler")) {
+				global $error_handler;
+
+				if(!is_object($error_handler))
+				{
+					require_once MYBB_ROOT."inc/class_error.php";
+					$error_handler = new errorHandler();
+				}
+
+				$error = array(
+					"error_no" => $this->error_number(),
+					"error" => $this->error_string(),
+					"query" => $string
+				);
+
+				$error_handler->error(MYBB_SQL, $error);
+			} else {
+				trigger_error("<strong>[SQL] [". $this->error_number() ."]" . $this->error_string() . " </strong><br />{$string}", E_USER_ERROR);
+			}
+
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Return the error code for the last error that occurred.
+	 *
+	 * @return string|null The error code for the last error that occurred, or null if no error occurred.
+	 */
+	public function error_number()
+	{
+		if ($this->lastPdoException !== null) {
+			return $this->lastPdoException->getCode();
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return athe error message for the last error that occurred.
+	 *
+	 * @return string|null The error message for the last error that occurred, or null if no error occurred.
+	 */
+	public function error_string()
+	{
+		if ($this->lastPdoException !== null && isset($this->lastPdoException->errorInfo[2])) {
+			return $this->lastPdoException->errorInfo[2];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Query the database.
+	 *
+	 * @param string $string The query SQL.
+	 * @param boolean|int $hideErrors Whether to hide any errors that occur.
+	 * @param boolean|int $writeQuery Whether to run the query on the write connection rather than the read connection.
+	 *
+	 * @return PDOStatement|null The result of the query, or null if an error occurred and {@see $hideErrors} was set.
+	 */
+	function query($string, $hideErrors = false, $writeQuery = 0)
+	{
+		global $mybb;
+
+		get_execution_time();
+
+		// Only execute write queries on master server
+		if (($writeQuery || $this->last_query_type) && $this->write_link) {
+			$this->current_link = &$this->write_link;
+		} else {
+			$this->current_link = &$this->read_link;
+		}
+
+		/** @var PDOStatement|null $query */
+		$query = null;
+
+		try {
+			// NOTE: we use prepare + execute here rather than just query so that we may request a scrollable cursor...
+			$query = $this->current_link->prepare($string, array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));
+			$query->execute();
+			$this->lastPdoException = null;
+		} catch (PDOException $e) {
+			$this->lastPdoException = $e;
+			$query = null;
+
+			if (!$hideErrors) {
+				$this->error($string);
+				exit;
+			}
+		}
+
+		if ($writeQuery) {
+			$this->last_query_type = 1;
+		} else {
+			$this->last_query_type = 0;
+		}
+
+		$query_time = get_execution_time();
+		$this->query_time += $query_time;
+		$this->query_count++;
+		$this->lastResult = $query;
+
+//TODO:		if ($mybb->debug_mode) {
+//			// TODO: $this->explain_query($string, $query_time);
+//		}
+
+		return $query;
+	}
+
+	/**
+	 * Execute a write query on the master database
+	 *
+	 * @param string $query The query SQL.
+	 * @param boolean|int $hideErrors Whether to hide any errors that occur.
+	 *
+	 * @return PDOStatement|null The result of the query, or null if an error occurred and {@see $hideErrors} was set.
+	 */
+	function write_query($query, $hideErrors = false)
+	{
+		return $this->query($query, $hideErrors, 1);
+	}
+
+	/**
+	 * Return a result array for a query.
+	 *
+	 * @param PDOStatement $query The query to retrieve a result for.
+	 * @param int $resultType The type of array to return. Can be any of the following values:
+	 *  - {@see PDO::FETCH_ASSOC} Fetch an array o results keyed by column name. This is the default.
+	 *  - {@see PDO::FETCH_NUM} Fetch an array of results keyed by column number, starting at 0.
+	 *  - {@see PDO::FETCH_BOTH} Fetch an array of results keyed by both column name and number.
+	 *
+	 * @return array|bool The array of results, or false if there are no more results.
+	 */
+	function fetch_array($query, $resultType = PDO::FETCH_ASSOC)
+	{
+		if (is_null($query) || !($query instanceof PDOStatement)) {
+			return false;
+		}
+
+		switch($resultType)
+		{
+			case PDO::FETCH_NUM:
+			case PDO::FETCH_BOTH:
+				break;
+			default:
+				$resultType = PDO::FETCH_ASSOC;
+				break;
+		}
+
+		$hash = spl_object_hash($query);
+
+		if (isset($this->resultSeekPositions[$hash])) {
+			return $query->fetch($resultType, PDO::FETCH_ORI_ABS, $this->resultSeekPositions[$hash]);
+		}
+
+		return $query->fetch($resultType);
+	}
+
+	/**
+	 * Return a specific field from a query.
+	 *
+	 * @param PDOStatement $query The query to retrieve a result for.
+	 * @param string $field The name of the field to return.
+	 * @param int|bool $row The number of the row to fetch it from, or false to fetch from the next row in the result set.
+	 *
+	 * @return mixed The resulting field, of false if no more rows are in th result set.
+	 *  Note that when querying fields that have a boolean value, this method should not be used.
+	 */
+	function fetch_field($query, $field, $row = false)
+	{
+		if (is_null($query) || !($query instanceof PDOStatement)) {
+			return false;
+		}
+
+		if ($row !== false) {
+			$this->data_seek($query, (int) $row);
+		}
+
+		// NOTE: PDOStatement::fetchColumn only operates on numbered columns, so we must fetch the array result
+		$array = $this->fetch_array($query, PDO::FETCH_ASSOC);
+
+		if ($array === false) {
+			return false;
+		}
+
+		return $array[$field];
+	}
+
+	/**
+	 * Move the internal row pointer to the specified row.
+	 *
+	 * @param PDOStatement $query The query to move the row pointer for.
+	 * @param int $row The row to move to. Rows are numbered from 0.
+	 *
+	 * @return bool Whether seeking was successful.
+	 */
+	function data_seek($query, $row)
+	{
+		if (is_null($query) || !($query instanceof PDOStatement)) {
+			return false;
+		}
+
+		$hash = spl_object_hash($query);
+
+		// NOTE: PDO numbers rows from 1, but all other drivers are 0 based. We add 1 to the row number for compatibility
+		$this->resultSeekPositions[$hash] = ((int) $row) + 1;
+
+		return true;
+	}
+
+	/**
+	 * Return the number of rows resulting from a query.
+	 *
+	 * @param PDOStatement $query The query data.
+	 * @return int|bool The number of rows in the result, or false on failure.
+	 */
+	public function num_rows($query)
+	{
+		if (is_null($query) || !($query instanceof PDOStatement)) {
+			return false;
+		}
+
+		if (stripos($query->queryString, 'SELECT') !== false) {
+			// rowCount does not return the number of rows in a select query on most DBMS, so we instead fetch all results then count them
+			// TODO: how do we handle the case where we issued a prepared statement with parameters..?
+			$countQuery = $this->read_link->query($query->queryString);
+			$result = $countQuery->fetchAll(PDO::FETCH_COLUMN, 0);
+
+			return count($result);
+		} else {
+			return $query->rowCount();
+		}
+	}
+
+	/**
+	 * Return the last id number of inserted data.
+	 *
+	 * @return string The id number.
+	 */
+	public function insert_id()
+	{
+		return $this->current_link->lastInsertId();
+	}
+
+	/**
+	 * Close the connection with the DBMS.
+	 */
+	public function close()
+	{
+		$this->read_link = $this->write_link = $this->current_link = null;
+	}
+
+	/**
+	 * Returns the number of affected rows in a query.
+	 *
+	 * @return int The number of affected rows.
+	 */
+	public function affected_rows()
+	{
+		if ($this->lastResult === null) {
+			return 0;
+		}
+
+		return $this->lastResult->rowCount();
+	}
+
+	/**
+	 * Return the number of fields.
+	 *
+	 * @param PDOStatement $query The query result to get the number of fields for.
+	 *
+	 * @return int|bool The number of fields, or false if the number of fields could not be retrieved.
+	 */
+	public function num_fields($query)
+	{
+		if (is_null($query) || !($query instanceof PDOStatement)) {
+			return false;
+		}
+
+		return $query->columnCount();
+	}
+
+	 public function shutdown_query($query, $name = '')
+	 {
+		 global $shutdown_queries;
+
+		 if($name) {
+			 $shutdown_queries[$name] = $query;
+		 } else {
+			 $shutdown_queries[] = $query;
+		 }
+	 }
+
+	 public function escape_string($string)
+	 {
+		 $string = $this->read_link->quote($string);
+
+		 // Remove ' from the beginning of the string and at the end of the string, because we already quote parameters
+		 $string = substr($string, 1);
+		 $string = substr($string, 0, -1);
+
+		 return $string;
+	 }
+
+	 public function free_result($query)
+	 {
+		 return true;
+	 }
+
+	 public function escape_string_like($string)
+	 {
+		 return $this->escape_string(str_replace(array('\\', '%', '_') , array('\\\\', '\\%' , '\\_') , $string));
+	 }
+
+	 public function get_version()
+	 {
+		 if ($this->version) {
+			 return $this->version;
+		 }
+
+		 $this->version = $this->read_link->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+		 return $this->version;
+	 }
+
+	 public function set_table_prefix($prefix)
+	 {
+		 $this->table_prefix = $prefix;
+	 }
+
+	 public function get_execution_time()
+	 {
+		 return get_execution_time();
+	 }
+
+	 public function escape_binary($string)
+	 {
+		 // TODO: Implement escape_binary() method.
+	 }
+
+	 public function unescape_binary($string)
+	 {
+		 // TODO: Implement unescape_binary() method.
+	 }
+ }

--- a/inc/AbstractPdoDbDriver.php
+++ b/inc/AbstractPdoDbDriver.php
@@ -122,6 +122,20 @@ abstract class AbstractPdoDbDriver implements DB_Base
 	public $querylist = array();
 
 	/**
+	 * The engine used to run the SQL database.
+	 *
+	 * @var string
+	 */
+	public $engine = "pdo";
+
+	/**
+	 * Whether or not this engine can use the search functionality.
+	 *
+	 * @var boolean
+	 */
+	public $can_search = true;
+
+	/**
 	 * Build a DSN string using the given configuration.
 	 *
 	 * @param string $hostname The hostname of the database serer to connect to.

--- a/inc/db_base.php
+++ b/inc/db_base.php
@@ -8,6 +8,14 @@
  *
  */
 
+/**
+ * @property string title The title of the database access layer.
+ * @property string short_title The short title of the database access layer.
+ * @property string type The type of db software being used.
+ * @property int query_count A count of the number of queries.
+ * @property array querylist A list of the performed queries.
+ * @property float query_time The time spent performing queries.
+ */
 interface DB_Base
 {
 	/**

--- a/inc/db_base.php
+++ b/inc/db_base.php
@@ -15,6 +15,8 @@
  * @property int query_count A count of the number of queries.
  * @property array querylist A list of the performed queries.
  * @property float query_time The time spent performing queries.
+ * @property string engine The engine used to run the SQL database.
+ * @property bool can_search Whether or not this engine can use the search functionality.
  */
 interface DB_Base
 {

--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -1416,7 +1416,7 @@ class DB_MySQL implements DB_Base
 			$default = '';
 		}
 
-		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition} {$not_null}");
+		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition} {$not_null} {$default}");
 	}
 
 	/**

--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -23,4 +23,354 @@ class MysqlPdoDbDriver extends AbstractPdoDbDriver
 
 		return $dsn;
 	}
+
+	function explain_query($string, $qtime)
+	{
+		// TODO: Implement explain_query() method.
+	}
+
+	function list_tables($database, $prefix = '')
+	{
+		if ($prefix) {
+			if (version_compare($this->get_version(), '5.0.2', '>=')) {
+				$query = $this->query("SHOW FULL TABLES FROM `{$database}` WHERE table_type = 'BASE TABLE' AND `Tables_in_{$database}` LIKE '".$this->escape_string($prefix)."%'");
+			} else {
+				$query = $this->query("SHOW TABLES FROM `{$database}` LIKE '".$this->escape_string($prefix)."%'");
+			}
+		} else {
+			if (version_compare($this->get_version(), '5.0.2', '>=')) {
+				$query = $this->query("SHOW FULL TABLES FROM `{$database}` WHERE table_type = 'BASE TABLE'");
+			} else {
+				$query = $this->query("SHOW TABLES FROM `{$database}`");
+			}
+		}
+
+		$tables = array();
+		while (list($table) = $this->fetch_array($query)) {
+			$tables[] = $table;
+		}
+
+		return $tables;
+	}
+
+	public function table_exists($table)
+	{
+		// Execute on master server to ensure if we've just created a table that we get the correct result
+		if (version_compare($this->get_version(), '5.0.2', '>=')) {
+			$query = $this->query("SHOW FULL TABLES FROM `{$this->database}` WHERE table_type = 'BASE TABLE' AND `Tables_in_{$this->database}` = '{$this->table_prefix}{$table}'");
+		} else {
+			$query = $this->query("SHOW TABLES LIKE '{$this->table_prefix}{$table}'");
+		}
+
+		$count = 0;
+		while ($row = $this->fetch_array($query)) {
+			$count++;
+		}
+
+		return $count > 0;
+	}
+
+	public function field_exists($field, $table)
+	{
+		$query = $this->write_query("
+			SHOW COLUMNS
+			FROM {$this->table_prefix}$table
+			LIKE '$field'
+		");
+
+		$exists = $this->num_rows($query);
+
+		return $exists > 0;
+	}
+
+	public function simple_select($table, $fields = "*", $conditions = "", $options = array())
+	{
+		$query = "SELECT ".$fields." FROM ".$this->table_prefix.$table;
+
+		if (!empty($conditions)) {
+			$query .= " WHERE {$conditions}";
+		}
+
+		if (isset($options['group_by'])) {
+			$query .= " GROUP BY {$options['group_by']}";
+		}
+
+		if (isset($options['order_by'])) {
+			$query .= " ORDER BY {$options['order_by']}";
+
+			if (isset($options['order_dir'])) {
+				$query .= " ".my_strtoupper($options['order_dir']);
+			}
+		}
+
+		if (isset($options['limit_start']) && isset($options['limit'])) {
+			$query .= " LIMIT {$options['limit_start']}, {$options['limit']}";
+		}
+		else if (isset($options['limit'])) {
+			$query .= " LIMIT {$options['limit']}";
+		}
+
+		return $this->query($query);
+	}
+
+	public function insert_query($table, $array)
+	{
+		global $mybb;
+
+		if (!is_array($array)) {
+			return false;
+		}
+
+		foreach ($array as $field => $value) {
+			if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
+				if ($value[0] != 'X') { // Not escaped?
+					$value = $this->escape_binary($value);
+				}
+
+				$array[$field] = $value;
+			} else {
+				$array[$field] = $this->quote_val($value);
+			}
+		}
+
+		$fields = "`".implode("`,`", array_keys($array))."`";
+
+		$values = implode(",", $array);
+
+		$this->write_query("
+			INSERT
+			INTO {$this->table_prefix}{$table} ({$fields})
+			VALUES ({$values})
+		");
+
+		return $this->insert_id();
+	}
+
+	public function insert_query_multiple($table, $array)
+	{
+		global $mybb;
+
+		if (!is_array($array)) {
+			return;
+		}
+
+		// Field names
+		$fields = array_keys($array[0]);
+		$fields = "`".implode("`,`", $fields)."`";
+
+		$insert_rows = array();
+		foreach ($array as $values) {
+			foreach ($values as $field => $value) {
+				if (isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
+					if($value[0] != 'X') { // Not escaped?
+						$value = $this->escape_binary($value);
+					}
+
+					$values[$field] = $value;
+				} else {
+					$values[$field] = $this->quote_val($value);
+				}
+			}
+
+			$insert_rows[] = "(".implode(",", $values).")";
+		}
+
+		$insert_rows = implode(", ", $insert_rows);
+
+		$this->write_query("
+			INSERT
+			INTO {$this->table_prefix}{$table} ({$fields})
+			VALUES {$insert_rows}
+		");
+	}
+
+	public function update_query($table, $array, $where = "", $limit = "", $no_quote = false)
+	{
+		global $mybb;
+
+		if (!is_array($array)) {
+			return false;
+		}
+
+		$comma = "";
+		$query = "";
+		$quote = "'";
+
+		if ($no_quote == true) {
+			$quote = "";
+		}
+
+		foreach ($array as $field => $value) {
+			if (isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
+				if($value[0] != 'X') { // Not escaped?
+					$value = $this->escape_binary($value);
+				}
+
+				$query .= "{$comma}`{$field}`={$value}";
+			} else {
+				$quoted_value = $this->quote_val($value, $quote);
+
+				$query .= "{$comma}`{$field}`={$quoted_value}";
+			}
+
+			$comma = ', ';
+		}
+
+		if (!empty($where)) {
+			$query .= " WHERE {$where}";
+		}
+
+		if (!empty($limit)) {
+			$query .= " LIMIT {$limit}";
+		}
+
+		return $this->write_query("
+			UPDATE {$this->table_prefix}{$table}
+			SET {$query}
+		");
+	}
+
+	public function delete_query($table, $where = "", $limit = "")
+	{
+		$query = "";
+		if (!empty($where)) {
+			$query .= " WHERE {$where}";
+		}
+
+		if (!empty($limit)) {
+			$query .= " LIMIT {$limit}";
+		}
+
+		return $this->write_query("DELETE FROM {$this->table_prefix}{$table} {$query}");
+	}
+
+	function optimize_table($table)
+	{
+		// TODO: Implement optimize_table() method.
+	}
+
+	function analyze_table($table)
+	{
+		// TODO: Implement analyze_table() method.
+	}
+
+	function show_create_table($table)
+	{
+		// TODO: Implement show_create_table() method.
+	}
+
+	function show_fields_from($table)
+	{
+		// TODO: Implement show_fields_from() method.
+	}
+
+	function is_fulltext($table, $index = "")
+	{
+		// TODO: Implement is_fulltext() method.
+	}
+
+	function supports_fulltext($table)
+	{
+		// TODO: Implement supports_fulltext() method.
+	}
+
+	function index_exists($table, $index)
+	{
+		// TODO: Implement index_exists() method.
+	}
+
+	function supports_fulltext_boolean($table)
+	{
+		// TODO: Implement supports_fulltext_boolean() method.
+	}
+
+	function create_fulltext_index($table, $column, $name = "")
+	{
+		// TODO: Implement create_fulltext_index() method.
+	}
+
+	function drop_index($table, $name)
+	{
+		// TODO: Implement drop_index() method.
+	}
+
+	function drop_table($table, $hard = false, $table_prefix = true)
+	{
+		// TODO: Implement drop_table() method.
+	}
+
+	function rename_table($old_table, $new_table, $table_prefix = true)
+	{
+		// TODO: Implement rename_table() method.
+	}
+
+	function replace_query($table, $replacements = array(), $default_field = "", $insert_id = true)
+	{
+		// TODO: Implement replace_query() method.
+	}
+
+	function drop_column($table, $column)
+	{
+		// TODO: Implement drop_column() method.
+	}
+
+	function add_column($table, $column, $definition)
+	{
+		// TODO: Implement add_column() method.
+	}
+
+	function modify_column($table, $column, $new_definition, $new_not_null = false, $new_default_value = false)
+	{
+		// TODO: Implement modify_column() method.
+	}
+
+	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null = false, $new_default_value = false)
+	{
+		// TODO: Implement rename_column() method.
+	}
+
+	function fetch_size($table = '')
+	{
+		// TODO: Implement fetch_size() method.
+	}
+
+	function fetch_db_charsets()
+	{
+		// TODO: Implement fetch_db_charsets() method.
+	}
+
+	function fetch_charset_collation($charset)
+	{
+		// TODO: Implement fetch_charset_collation() method.
+	}
+
+	function build_create_table_collation()
+	{
+		// TODO: Implement build_create_table_collation() method.
+	}
+
+	function escape_binary($string)
+	{
+		// TODO: Implement escape_binary() method.
+	}
+
+	function unescape_binary($string)
+	{
+		// TODO: Implement unescape_binary() method.
+	}
+
+	/**
+	 * @param int|string $value
+	 * @param string $quote
+	 *
+	 * @return int|string
+	 */
+	private function quote_val($value, $quote="'")
+	{
+		if (is_int($value)) {
+			return $value;
+		}
+
+		return "{$quote}{$value}{$quote}";
+	}
 }

--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * MyBB 1.8
+ * Copyright 2020 MyBB Group, All Rights Reserved
+ *
+ * Website: http://www.mybb.com
+ * License: http://www.mybb.com/about/license
+ */
+
+class MysqlPdoDbDriver extends AbstractPdoDbDriver
+{
+	protected function getDsn($hostname, $db, $port, $encoding)
+	{
+		$dsn = "mysql:host={$hostname};dbname={$db}";
+
+		if ($port !== null) {
+			$dsn .= ";port={$port}";
+		}
+
+		if (!empty($encoding)) {
+			$dsn .= ";charset={$encoding}";
+		}
+
+		return $dsn;
+	}
+}

--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -113,13 +113,13 @@ HTML;
 		$this->querylist[$this->query_count]['time'] = $qtime;
 	}
 
-	function list_tables($database, $prefix = '')
+	public function list_tables($database, $prefix = '')
 	{
 		if ($prefix) {
 			if (version_compare($this->get_version(), '5.0.2', '>=')) {
 				$query = $this->query("SHOW FULL TABLES FROM `{$database}` WHERE table_type = 'BASE TABLE' AND `Tables_in_{$database}` LIKE '".$this->escape_string($prefix)."%'");
 			} else {
-				$query = $this->query("SHOW TABLES FROM `{$database}` LIKE '".$this->escape_string($prefix)."%'");
+				$query = $this->query("SHOW TABLES FROM `{$database}` LIKE '{$this->escape_string($prefix)}%'");
 			}
 		} else {
 			if (version_compare($this->get_version(), '5.0.2', '>=')) {
@@ -158,8 +158,8 @@ HTML;
 	{
 		$query = $this->write_query("
 			SHOW COLUMNS
-			FROM {$this->table_prefix}$table
-			LIKE '$field'
+			FROM {$this->table_prefix}{$table}
+			LIKE '{$field}'
 		");
 
 		$exists = $this->num_rows($query);
@@ -169,7 +169,7 @@ HTML;
 
 	public function simple_select($table, $fields = "*", $conditions = "", $options = array())
 	{
-		$query = "SELECT ".$fields." FROM ".$this->table_prefix.$table;
+		$query = "SELECT {$fields} FROM {$this->table_prefix}{$table}";
 
 		if (!empty($conditions)) {
 			$query .= " WHERE {$conditions}";
@@ -362,7 +362,7 @@ HTML;
 	{
 		$structure = $this->show_create_table($table);
 		if ($index != "") {
-			if(preg_match("#FULLTEXT KEY (`?)$index(`?)#i", $structure)) {
+			if(preg_match("#FULLTEXT KEY (`?){$index}(`?)#i", $structure)) {
 				return true;
 			}
 
@@ -436,9 +436,9 @@ HTML;
 		}
 
 		if ($hard == false) {
-			$this->write_query('DROP TABLE IF EXISTS '.$table_prefix.$table);
+			$this->write_query("DROP TABLE IF EXISTS {$table_prefix}{$table}");
 		} else {
-			$this->write_query('DROP TABLE '.$table_prefix.$table);
+			$this->write_query("DROP TABLE {$table_prefix}{$table}");
 		}
 	}
 

--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -9,6 +9,13 @@
 
 class MysqlPdoDbDriver extends AbstractPdoDbDriver
 {
+	/**
+	 * Explanation of a query.
+	 *
+	 * @var string
+	 */
+	public $explain = '';
+
 	protected function getDsn($hostname, $db, $port, $encoding)
 	{
 		$dsn = "mysql:host={$hostname};dbname={$db}";
@@ -63,7 +70,6 @@ HTML;
 		<td><strong>Rows</strong></td>
 		<td><strong>Extra</strong></td>
 	</tr>
-</table>
 HTML;
 
 			while ($table = $query->fetch(PDO::FETCH_ASSOC)) {
@@ -102,7 +108,7 @@ HTML;
 		<td><span style="font-family: Courier; font-size: 14px;">{$queryText}</span></td>
 	</tr>
 	<tr>
-		<td bgcolor="#ffffff">Query Time:{$duration}</td>
+		<td bgcolor="#ffffff">Query Time: {$duration}</td>
 	</tr>
 </table>
 <br/>
@@ -129,12 +135,7 @@ HTML;
 			}
 		}
 
-		$tables = array();
-		while (list($table) = $this->fetch_array($query)) {
-			$tables[] = $table;
-		}
-
-		return $tables;
+		return $query->fetchAll(PDO::FETCH_COLUMN, 0);
 	}
 
 	public function table_exists($table)

--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -244,24 +244,34 @@ class MysqlPdoDbDriver extends AbstractPdoDbDriver
 		return $this->write_query("DELETE FROM {$this->table_prefix}{$table} {$query}");
 	}
 
-	function optimize_table($table)
+	public function optimize_table($table)
 	{
-		// TODO: Implement optimize_table() method.
+		$this->write_query("OPTIMIZE TABLE {$this->table_prefix}{$table}");
 	}
 
-	function analyze_table($table)
+	public function analyze_table($table)
 	{
-		// TODO: Implement analyze_table() method.
+		$this->write_query("ANALYZE TABLE {$this->table_prefix}{$table}");
 	}
 
-	function show_create_table($table)
+	public function show_create_table($table)
 	{
-		// TODO: Implement show_create_table() method.
+		$query = $this->write_query("SHOW CREATE TABLE {$this->table_prefix}{$table}");
+		$structure = $this->fetch_array($query);
+
+		return $structure['Create Table'];
 	}
 
-	function show_fields_from($table)
+	public function show_fields_from($table)
 	{
-		// TODO: Implement show_fields_from() method.
+		$query = $this->write_query("SHOW FIELDS FROM {$this->table_prefix}{$table}");
+
+		$field_info = array();
+		while ($field = $this->fetch_array($query)) {
+			$field_info[] = $field;
+		}
+
+		return $field_info;
 	}
 
 	function is_fulltext($table, $index = "")

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -1388,7 +1388,7 @@ class DB_MySQLi implements DB_Base
 			$not_null = '';
 		}
 
-		if($new_default_value !== null)
+		if($new_default_value !== false)
 		{
 			$default = "DEFAULT ".$new_default_value;
 		}
@@ -1397,7 +1397,7 @@ class DB_MySQLi implements DB_Base
 			$default = '';
 		}
 
-		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition} {$not_null}");
+		return (bool)$this->write_query("ALTER TABLE {$this->table_prefix}{$table} MODIFY `{$column}` {$new_definition} {$not_null} {$default}");
 	}
 
 	/**

--- a/inc/db_pdo.php
+++ b/inc/db_pdo.php
@@ -8,25 +8,28 @@
  *
  */
 
-class dbpdoEngine {
-
+class dbpdoEngine
+{
 	/**
 	 * The database class to store PDO objects
 	 *
 	 * @var PDO
 	 */
-	public $db;
+	private $db;
 
 	/**
 	 * The last query resource that ran
 	 *
 	 * @var PDOStatement
 	 */
-	public $last_query = "";
+	public $last_query;
 
-	public $seek_array = array();
-
-	public $queries = 0;
+	/**
+	 * Array used to seek through result sets. This is used when using the `fetch_field` method with a row specified.
+	 *
+	 * @var array Array keyed by object hashes for {@see PDOStatement} instances.
+	 */
+	private $seek_array = array();
 
 	/**
 	 * Connect to the database.
@@ -35,35 +38,65 @@ class dbpdoEngine {
 	 * @param string $username The database username. (depends on DSN)
 	 * @param string $password The database user's password. (depends on DSN)
 	 * @param array $driver_options The databases driver options (optional)
+	 *
+	 * @throws Exception Thrown when failing to connect to the database.
 	 */
 	function __construct($dsn, $username="", $password="", $driver_options=array())
 	{
 		try
 		{
+			$driver_options = array_merge(
+				$driver_options,
+				array(
+					PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+					PDO::ATTR_EMULATE_PREPARES => false,
+				)
+			);
+
 			$this->db = new PDO($dsn, $username, $password, $driver_options);
 		}
 		catch(PDOException $exception)
 		{
-    		die('Connection failed: '.$exception->getMessage());
+			throw new Exception('Unable to connect to database server');
 		}
-
-		$this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 	}
 
 	/**
 	 * Query the database.
 	 *
 	 * @param string $string The query SQL.
+	 *
 	 * @return PDOStatement The query data.
 	 */
-	function query($string)
+	public function query($string)
 	{
-		++$this->queries;
-
 		$query = $this->db->query($string, PDO::FETCH_BOTH);
 		$this->last_query = $query;
 
-		$query->guid = $this->queries;
+		return $query;
+	}
+
+	/**
+	 * Query the database with a set of parameters.
+	 *
+	 * This will execute a prepared statement.
+	 *
+	 * @param string $query The query SQL.
+	 * @param array $parameters The parameters to pass when executing the prepared statement.
+	 *
+	 * @return PDOStatement The query data.
+	 */
+	public function query_prepared($query, $parameters=array())
+	{
+		if(!is_array($parameters))
+		{
+			$parameters = array($parameters);
+		}
+
+		$query = $this->db->prepare($query, array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));
+		$query->execute($parameters);
+
+		$this->last_query = $query;
 
 		return $query;
 	}
@@ -75,7 +108,7 @@ class dbpdoEngine {
 	 * @param int $resulttype One of PDO's constants: FETCH_ASSOC, FETCH_BOUND, FETCH_CLASS, FETCH_INTO, FETCH_LAZY, FETCH_NAMED, FETCH_NUM, FETCH_OBJ or FETCH_BOTH
 	 * @return array The array of results.
 	 */
-	function fetch_array($query, $resulttype=PDO::FETCH_BOTH)
+	public function fetch_array($query, $resulttype=PDO::FETCH_BOTH)
 	{
 		switch($resulttype)
 		{
@@ -93,9 +126,11 @@ class dbpdoEngine {
 				break;
 		}
 
-		if($this->seek_array[$query->guid])
+		$hash = spl_object_hash($query);
+
+		if(isset($this->seek_array[$hash]))
 		{
-			$array = $query->fetch($resulttype, $this->seek_array[$query->guid]['offset'], $this->seek_array[$query->guid]['row']);
+			$array = $query->fetch($resulttype, $this->seek_array[$hash]['offset'], $this->seek_array[$hash]['row']);
 		}
 		else
 		{
@@ -111,9 +146,11 @@ class dbpdoEngine {
 	 * @param PDOStatement $query The query resource.
 	 * @param int $row The pointer to move the row to.
 	 */
-	function seek($query, $row)
+	public function seek($query, $row)
 	{
-		$this->seek_array[$query->guid] = array('offset' => PDO::FETCH_ORI_ABS, 'row' => $row);
+		$hash = spl_object_hash($query);
+
+		$this->seek_array[$hash] = array('offset' => PDO::FETCH_ORI_ABS, 'row' => $row);
 	}
 
 	/**
@@ -122,7 +159,7 @@ class dbpdoEngine {
 	 * @param PDOStatement $query The query resource.
 	 * @return int The number of rows in the result.
 	 */
-	function num_rows($query)
+	public function num_rows($query)
 	{
 		if(stripos($query->queryString, 'SELECT') !== false)
 		{
@@ -139,10 +176,10 @@ class dbpdoEngine {
 	/**
 	 * Return the last id number of inserted data.
 	 *
-	 * @param string $name The name of the insert id to check. (Optional)
+	 * @param string|null $name The name of the insert id to check. (Optional)
 	 * @return int The id number.
 	 */
-	function insert_id($name="")
+	public function insert_id($name=null)
 	{
 		return $this->db->lastInsertId($name);
 	}
@@ -153,16 +190,14 @@ class dbpdoEngine {
 	 * @param PDOStatement $query The query resource.
 	 * @return int The error number of the current error.
 	 */
-	function error_number($query)
+	public function error_number($query)
 	{
 		if(!method_exists($query, "errorCode"))
 		{
 			return 0;
 		}
 
-		$errorcode = $query->errorCode();
-
-		return $errorcode;
+		return $query->errorCode();
 	}
 
 	/**
@@ -171,12 +206,13 @@ class dbpdoEngine {
 	 * @param PDOStatement $query The query resource.
 	 * @return array The error string of the current error.
 	 */
-	function error_string($query)
+	public function error_string($query)
 	{
 		if(!method_exists($query, "errorInfo"))
 		{
 			return $this->db->errorInfo();
 		}
+
 		return $query->errorInfo();
 	}
 
@@ -186,7 +222,7 @@ class dbpdoEngine {
 	 * @param PDOStatement $query
 	 * @return int The number of affected rows.
 	 */
-	function affected_rows($query)
+	public function affected_rows($query)
 	{
 		return $query->rowCount();
 	}
@@ -197,7 +233,7 @@ class dbpdoEngine {
 	 * @param PDOStatement $query The query resource.
 	 * @return int The number of fields.
 	 */
-	function num_fields($query)
+	public function num_fields($query)
 	{
 		return $query->columnCount();
 	}
@@ -208,11 +244,11 @@ class dbpdoEngine {
 	 * @param string $string The string to be escaped.
 	 * @return string The escaped string.
 	 */
-	function escape_string($string)
+	public function escape_string($string)
 	{
 		$string = $this->db->quote($string);
 
-		// Remove ' from the begginging of the string and at the end of the string, because we already use it in insert_query
+		// Remove ' from the beginning of the string and at the end of the string, because we already use it in insert_query
 		$string = substr($string, 1);
 		$string = substr($string, 0, -1);
 
@@ -225,9 +261,9 @@ class dbpdoEngine {
 	 * @param string $attribute The attribute to check.
 	 * @return string The value of the attribute.
 	 */
-	function get_attribute($attribute)
+	public function get_attribute($attribute)
 	{
-		$attribute = $this->db->getAttribute(constant("PDO::".$attribute.""));
+		$attribute = $this->db->getAttribute(constant("PDO::{$attribute}"));
 
 		return $attribute;
 	}

--- a/inc/db_pdo.php
+++ b/inc/db_pdo.php
@@ -77,31 +77,6 @@ class dbpdoEngine
 	}
 
 	/**
-	 * Query the database with a set of parameters.
-	 *
-	 * This will execute a prepared statement.
-	 *
-	 * @param string $query The query SQL.
-	 * @param array $parameters The parameters to pass when executing the prepared statement.
-	 *
-	 * @return PDOStatement The query data.
-	 */
-	public function query_prepared($query, $parameters=array())
-	{
-		if(!is_array($parameters))
-		{
-			$parameters = array($parameters);
-		}
-
-		$query = $this->db->prepare($query, array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));
-		$query->execute($parameters);
-
-		$this->last_query = $query;
-
-		return $query;
-	}
-
-	/**
 	 * Return a result array for a query.
 	 *
 	 * @param PDOStatement $query The query resource.

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -451,6 +451,8 @@ class DB_PgSQL implements DB_Base
 		{
 			return pg_fetch_result($query, $row, $field);
 		}
+
+		return pg_fetch_result($query, $row, $field);
 	}
 
 	/**

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -447,10 +447,6 @@ class DB_PgSQL implements DB_Base
 			}
 			return null;
 		}
-		else
-		{
-			return pg_fetch_result($query, $row, $field);
-		}
 
 		return pg_fetch_result($query, $row, $field);
 	}

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -211,9 +211,12 @@ class PostgresPdoDbDriver extends AbstractPdoDbDriver
 		// TODO: Implement create_fulltext_index() method.
 	}
 
-	function drop_index($table, $name)
+	public function drop_index($table, $name)
 	{
-		// TODO: Implement drop_index() method.
+		$this->write_query("
+			ALTER TABLE {$this->table_prefix}{$table}
+			DROP INDEX {$name}
+		");
 	}
 
 	function drop_table($table, $hard = false, $table_prefix = true)
@@ -231,14 +234,14 @@ class PostgresPdoDbDriver extends AbstractPdoDbDriver
 		// TODO: Implement replace_query() method.
 	}
 
-	function drop_column($table, $column)
+	public function drop_column($table, $column)
 	{
-		// TODO: Implement drop_column() method.
+		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} DROP {$column}");
 	}
 
-	function add_column($table, $column, $definition)
+	public function add_column($table, $column, $definition)
 	{
-		// TODO: Implement add_column() method.
+		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ADD {$column} {$definition}");
 	}
 
 	function modify_column($table, $column, $new_definition, $new_not_null = false, $new_default_value = false)

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -350,14 +350,40 @@ HTML;
 		");
 	}
 
-	function drop_table($table, $hard = false, $table_prefix = true)
+	public function drop_table($table, $hard = false, $table_prefix = true)
 	{
-		// TODO: Implement drop_table() method.
+		if ($table_prefix == false) {
+			$table_prefix = "";
+		} else {
+			$table_prefix = $this->table_prefix;
+		}
+
+		if ($hard == false) {
+			if($this->table_exists($table))
+			{
+				$this->write_query("DROP TABLE {$table_prefix}{$table}");
+			}
+		} else {
+			$this->write_query("DROP TABLE {$table_prefix}{$table}");
+		}
+
+		$query = $this->query("SELECT column_name FROM information_schema.constraint_column_usage WHERE table_name = '{$table}' and constraint_name = '{$table}_pkey' LIMIT 1");
+		$field = $this->fetch_field($query, 'column_name');
+
+		if ($field) {
+			$this->write_query('DROP SEQUENCE {$table}_{$field}_id_seq');
+		}
 	}
 
-	function rename_table($old_table, $new_table, $table_prefix = true)
+	public function rename_table($old_table, $new_table, $table_prefix = true)
 	{
-		// TODO: Implement rename_table() method.
+		if ($table_prefix == false) {
+			$table_prefix = "";
+		} else {
+			$table_prefix = $this->table_prefix;
+		}
+
+		return $this->write_query("ALTER TABLE {$table_prefix}{$old_table} RENAME TO {$table_prefix}{$new_table}");
 	}
 
 	function replace_query($table, $replacements = array(), $default_field = "", $insert_id = true)
@@ -406,18 +432,18 @@ HTML;
 		return $result[0] + $result[1];
 	}
 
-	function fetch_db_charsets()
+	public function fetch_db_charsets()
 	{
-		// TODO: Implement fetch_db_charsets() method.
+		return false;
 	}
 
-	function fetch_charset_collation($charset)
+	public function fetch_charset_collation($charset)
 	{
-		// TODO: Implement fetch_charset_collation() method.
+		return false;
 	}
 
-	function build_create_table_collation()
+	public function build_create_table_collation()
 	{
-		// TODO: Implement build_create_table_collation() method.
+		return '';
 	}
 }

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -319,27 +319,37 @@ HTML;
 
 	function is_fulltext($table, $index = "")
 	{
-		// TODO: Implement is_fulltext() method.
+		return false;
 	}
 
-	function supports_fulltext($table)
+	public function supports_fulltext($table)
 	{
-		// TODO: Implement supports_fulltext() method.
+		return false;
 	}
 
-	function index_exists($table, $index)
+	public function index_exists($table, $index)
 	{
-		// TODO: Implement index_exists() method.
+		$err = $this->error_reporting;
+		$this->error_reporting = 0;
+
+		$tableName = $this->escape_string("{$this->table_prefix}{$table}");
+
+		$query = $this->write_query("SELECT * FROM pg_indexes WHERE tablename = '{$tableName}'");
+
+		$exists = $this->fetch_field($query, $index);
+		$this->error_reporting = $err;
+
+		return (bool)$exists;
 	}
 
-	function supports_fulltext_boolean($table)
+	public function supports_fulltext_boolean($table)
 	{
-		// TODO: Implement supports_fulltext_boolean() method.
+		return false;
 	}
 
-	function create_fulltext_index($table, $column, $name = "")
+	public function create_fulltext_index($table, $column, $name = "")
 	{
-		// TODO: Implement create_fulltext_index() method.
+		return false;
 	}
 
 	public function drop_index($table, $name)
@@ -401,14 +411,41 @@ HTML;
 		return $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ADD {$column} {$definition}");
 	}
 
-	function modify_column($table, $column, $new_definition, $new_not_null = false, $new_default_value = false)
+	public function modify_column($table, $column, $new_definition, $new_not_null = false, $new_default_value = false)
 	{
-		// TODO: Implement modify_column() method.
+		$result1 = $result2 = $result3 = true;
+
+		if ($new_definition !== false) {
+			$result1 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} TYPE {$new_definition}");
+		}
+
+		if ($new_not_null !== false) {
+			$set_drop = "DROP";
+
+			if (strtolower($new_not_null) == "set") {
+				$set_drop = "SET";
+			}
+
+			$result2 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} {$set_drop} NOT NULL");
+		}
+
+		if ($new_default_value !== null) {
+			if($new_default_value !== false) {
+				$result3 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} SET DEFAULT {$new_default_value}");
+			} else {
+				$result3 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} ALTER COLUMN {$column} DROP DEFAULT");
+			}
+		}
+
+		return $result1 && $result2 && $result3;
 	}
 
-	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null = false, $new_default_value = false)
+	public function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null = false, $new_default_value = false)
 	{
-		// TODO: Implement rename_column() method.
+		$result1 = $this->write_query("ALTER TABLE {$this->table_prefix}{$table} RENAME COLUMN {$old_column} TO {$new_column}");
+		$result2 = $this->modify_column($table, $new_column, $new_definition, $new_not_null, $new_default_value);
+
+		return $result1 && $result2;
 	}
 
 	public function fetch_size($table = '')

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * MyBB 1.8
+ * Copyright 2020 MyBB Group, All Rights Reserved
+ *
+ * Website: http://www.mybb.com
+ * License: http://www.mybb.com/about/license
+ */
+
+class PostgresPdoDbDriver extends AbstractPdoDbDriver
+{
+	/**
+	 * Explanation of a query.
+	 *
+	 * @var string
+	 */
+	public $explain = '';
+
+	protected function getDsn($hostname, $db, $port, $encoding)
+	{
+		$dsn = "pgsql:host={$hostname};dbname={$db}";
+
+		if ($port !== null) {
+			$dsn .= ";port={$port}";
+		}
+
+		if (!empty($encoding)) {
+			$dsn .= ";options='--client_encoding={$encoding}'";
+		}
+
+		return $dsn;
+	}
+
+	public function explain_query($string, $qtime)
+	{
+		if (preg_match("#^\s*select#i", $string))
+		{
+			$query = $this->read_link->query("EXPLAIN {$string}");
+			$this->explain .= "<table style=\"background-color: #666;\" width=\"95%\" cellpadding=\"4\" cellspacing=\"1\" align=\"center\">\n".
+				"<tr>\n".
+				"<td colspan=\"8\" style=\"background-color: #ccc;\"><strong>#".$this->query_count." - Select Query</strong></td>\n".
+				"</tr>\n".
+				"<tr>\n".
+				"<td colspan=\"8\" style=\"background-color: #fefefe;\"><span style=\"font-family: Courier; font-size: 14px;\">".htmlspecialchars_uni($string)."</span></td>\n".
+				"</tr>\n".
+				"<tr style=\"background-color: #efefef;\">\n".
+				"<td><strong>Info</strong></td>\n".
+				"</tr>\n";
+
+			while ($table = $query->fetch(PDO::FETCH_ASSOC)) {
+				$this->explain .=
+					"<tr bgcolor=\"#ffffff\">\n".
+					"<td>".$table['QUERY PLAN']."</td>\n".
+					"</tr>\n";
+			}
+
+			$this->explain .=
+				"<tr>\n".
+				"<td colspan=\"8\" style=\"background-color: #fff;\">Query Time: ".format_time_duration($qtime)."</td>\n".
+				"</tr>\n".
+				"</table>\n".
+				"<br />\n";
+		}
+		else
+		{
+			$this->explain .= "<table style=\"background-color: #666;\" width=\"95%\" cellpadding=\"4\" cellspacing=\"1\" align=\"center\">\n".
+				"<tr>\n".
+				"<td style=\"background-color: #ccc;\"><strong>#".$this->query_count." - Write Query</strong></td>\n".
+				"</tr>\n".
+				"<tr style=\"background-color: #fefefe;\">\n".
+				"<td><span style=\"font-family: Courier; font-size: 14px;\">".htmlspecialchars_uni($string)."</span></td>\n".
+				"</tr>\n".
+				"<tr>\n".
+				"<td bgcolor=\"#ffffff\">Query Time: ".format_time_duration($qtime)."</td>\n".
+				"</tr>\n".
+				"</table>\n".
+				"<br />\n";
+		}
+
+		$this->querylist[$this->query_count]['query'] = $string;
+		$this->querylist[$this->query_count]['time'] = $qtime;
+	}
+
+	public function list_tables($database, $prefix = '')
+	{
+		if ($prefix) {
+			$query = $this->write_query("SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name LIKE '{$this->escape_string($prefix)}%'");
+		} else {
+			$query = $this->write_query("SELECT table_name FROM information_schema.tables WHERE table_schema='public'");
+		}
+
+		return $query->fetchAll(PDO::FETCH_COLUMN);
+	}
+
+	public function table_exists($table)
+	{
+		$query = $this->write_query("SELECT COUNT(table_name) as table_names FROM information_schema.tables WHERE table_schema = 'public' AND table_name='{$this->table_prefix}{$table}'");
+
+		$exists = $this->fetch_field($query, 'table_names');
+
+		return $exists > 0;
+	}
+
+	public function field_exists($field, $table)
+	{
+		$query = $this->write_query("SELECT COUNT(column_name) as column_names FROM information_schema.columns WHERE table_name='{$this->table_prefix}{$table}' AND column_name='{$field}'");
+
+		$exists = $this->fetch_field($query, 'column_names');
+
+		return $exists > 0;
+	}
+
+	function simple_select($table, $fields = "*", $conditions = "", $options = array())
+	{
+		// TODO: Implement simple_select() method.
+	}
+
+	function insert_query($table, $array)
+	{
+		// TODO: Implement insert_query() method.
+	}
+
+	function insert_query_multiple($table, $array)
+	{
+		// TODO: Implement insert_query_multiple() method.
+	}
+
+	function update_query($table, $array, $where = "", $limit = "", $no_quote = false)
+	{
+		// TODO: Implement update_query() method.
+	}
+
+	function delete_query($table, $where = "", $limit = "")
+	{
+		// TODO: Implement delete_query() method.
+	}
+
+	function optimize_table($table)
+	{
+		// TODO: Implement optimize_table() method.
+	}
+
+	function analyze_table($table)
+	{
+		// TODO: Implement analyze_table() method.
+	}
+
+	function show_create_table($table)
+	{
+		// TODO: Implement show_create_table() method.
+	}
+
+	function show_fields_from($table)
+	{
+		// TODO: Implement show_fields_from() method.
+	}
+
+	function is_fulltext($table, $index = "")
+	{
+		// TODO: Implement is_fulltext() method.
+	}
+
+	function supports_fulltext($table)
+	{
+		// TODO: Implement supports_fulltext() method.
+	}
+
+	function index_exists($table, $index)
+	{
+		// TODO: Implement index_exists() method.
+	}
+
+	function supports_fulltext_boolean($table)
+	{
+		// TODO: Implement supports_fulltext_boolean() method.
+	}
+
+	function create_fulltext_index($table, $column, $name = "")
+	{
+		// TODO: Implement create_fulltext_index() method.
+	}
+
+	function drop_index($table, $name)
+	{
+		// TODO: Implement drop_index() method.
+	}
+
+	function drop_table($table, $hard = false, $table_prefix = true)
+	{
+		// TODO: Implement drop_table() method.
+	}
+
+	function rename_table($old_table, $new_table, $table_prefix = true)
+	{
+		// TODO: Implement rename_table() method.
+	}
+
+	function replace_query($table, $replacements = array(), $default_field = "", $insert_id = true)
+	{
+		// TODO: Implement replace_query() method.
+	}
+
+	function drop_column($table, $column)
+	{
+		// TODO: Implement drop_column() method.
+	}
+
+	function add_column($table, $column, $definition)
+	{
+		// TODO: Implement add_column() method.
+	}
+
+	function modify_column($table, $column, $new_definition, $new_not_null = false, $new_default_value = false)
+	{
+		// TODO: Implement modify_column() method.
+	}
+
+	function rename_column($table, $old_column, $new_column, $new_definition, $new_not_null = false, $new_default_value = false)
+	{
+		// TODO: Implement rename_column() method.
+	}
+
+	function fetch_size($table = '')
+	{
+		// TODO: Implement fetch_size() method.
+	}
+
+	function fetch_db_charsets()
+	{
+		// TODO: Implement fetch_db_charsets() method.
+	}
+
+	function fetch_charset_collation($charset)
+	{
+		// TODO: Implement fetch_charset_collation() method.
+	}
+
+	function build_create_table_collation()
+	{
+		// TODO: Implement build_create_table_collation() method.
+	}
+}

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -503,22 +503,14 @@ HTML;
 
 	public function escape_binary($string)
 	{
-		var_dump(
-			[
-				'escape_binary',
-				'string' => $string,
-				'bin2hex' => bin2hex($string)
-			]
-		);
+		$hex = bin2hex($string);
+		return "decode('{$hex}', 'hex')";
 	}
 
 	public function unescape_binary($string)
 	{
-		var_dump(
-			[
-				'unescape_binary',
-				'string' => $string,
-			]
-		);
+		// binary fields are treated as streams
+		/** @var resource $string */
+		return fgets($string);
 	}
 }

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -141,7 +141,13 @@ class DB_SQLite implements DB_Base
 
 		require_once MYBB_ROOT."inc/db_pdo.php";
 
-		$this->db = new dbpdoEngine("sqlite:{$config['database']}");
+		try {
+			$this->db = new dbpdoEngine("sqlite:{$config['database']}");
+		} catch (Exception $ex) {
+			$this->error("[READ] Unable to open the SQLite database");
+
+			return false;
+		}
 
 		$query_time = get_execution_time();
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -176,6 +176,7 @@ function run_shutdown()
 		{
 			// Load DB interface
 			require_once MYBB_ROOT."inc/db_base.php";
+			require_once MYBB_ROOT . 'inc/AbstractPdoDbDriver.php';
 
 			require_once MYBB_ROOT."inc/db_".$config['database']['type'].".php";
 			switch($config['database']['type'])
@@ -185,6 +186,9 @@ function run_shutdown()
 					break;
 				case "pgsql":
 					$db = new DB_PgSQL;
+					break;
+				case "pgsql_pdo":
+					$db = new PostgresPdoDbDriver();
 					break;
 				case "mysqli":
 					$db = new DB_MySQLi;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -193,6 +193,9 @@ function run_shutdown()
 				case "mysqli":
 					$db = new DB_MySQLi;
 					break;
+				case "mysql_pdo":
+					$db = new MysqlPdoDbDriver();
+					break;
 				default:
 					$db = new DB_MySQL;
 			}

--- a/inc/init.php
+++ b/inc/init.php
@@ -111,6 +111,7 @@ if(is_dir(MYBB_ROOT."install") && !file_exists(MYBB_ROOT."install/lock"))
 
 // Load DB interface
 require_once MYBB_ROOT."inc/db_base.php";
+require_once MYBB_ROOT . 'inc/AbstractPdoDbDriver.php';
 
 require_once MYBB_ROOT."inc/db_".$config['database']['type'].".php";
 
@@ -121,6 +122,9 @@ switch($config['database']['type'])
 		break;
 	case "pgsql":
 		$db = new DB_PgSQL;
+		break;
+	case "pgsql_pdo":
+		$db = new PostgresPdoDbDriver();
 		break;
 	case "mysqli":
 		$db = new DB_MySQLi;

--- a/inc/init.php
+++ b/inc/init.php
@@ -129,6 +129,9 @@ switch($config['database']['type'])
 	case "mysqli":
 		$db = new DB_MySQLi;
 		break;
+	case "mysql_pdo":
+		$db = new MysqlPdoDbDriver();
+		break;
 	default:
 		$db = new DB_MySQL;
 }

--- a/install/index.php
+++ b/install/index.php
@@ -60,6 +60,7 @@ $lang->load('language');
 
 // Load DB interface
 require_once MYBB_ROOT."inc/db_base.php";
+require_once MYBB_ROOT."inc/AbstractPdoDbDriver.php";
 
 // Prevent any shut down functions from running
 $done_shutdown = 1;
@@ -119,6 +120,16 @@ if(class_exists('PDO'))
 			'title' => 'SQLite 3',
 			'short_title' => 'SQLite',
 			'structure_file' => 'sqlite_db_tables.php',
+			'population_file' => 'pgsql_db_inserts.php'
+		);
+	}
+
+	if (in_array('pgsql', $supported_dbs)) {
+		$dboptions['pgsql_pdo'] = array(
+			'class' => 'PostgresPdoDbDriver',
+			'title' => 'PostgreSQL (PDO)',
+			'short_title' => 'PostgreSQL (PDO)',
+			'structure_file' => 'pgsql_db_tables.php',
 			'population_file' => 'pgsql_db_inserts.php'
 		);
 	}
@@ -1423,6 +1434,9 @@ function create_tables()
 		case "pgsql":
 			$db = new DB_PgSQL;
 			break;
+		case "pgsql_pdo":
+			$db = new PostgresPdoDbDriver();
+			break;
 		case "mysqli":
 			$db = new DB_MySQLi;
 			break;
@@ -2466,7 +2480,7 @@ function install_done()
 /**
  * @param array $config
  *
- * @return DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite
+ * @return DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite|PostgresPdoDbDriver
  */
 function db_connection($config)
 {
@@ -2478,6 +2492,9 @@ function db_connection($config)
 			break;
 		case "pgsql":
 			$db = new DB_PgSQL;
+			break;
+		case "pgsql_pdo":
+			$db = new PostgresPdoDbDriver();
 			break;
 		case "mysqli":
 			$db = new DB_MySQLi;

--- a/install/index.php
+++ b/install/index.php
@@ -133,6 +133,16 @@ if(class_exists('PDO'))
 			'population_file' => 'pgsql_db_inserts.php'
 		);
 	}
+
+	if (in_array('mysql', $supported_dbs)) {
+		$dboptions['mysql_pdo'] = array(
+			'class' => 'MysqlPdoDbDriver',
+			'title' => 'MySQL (PDO)',
+			'short_title' => 'MySQL (PDO)',
+			'structure_file' => 'mysql_db_tables.php',
+			'population_file' => 'mysql_db_inserts.php'
+		);
+	}
 }
 
 if(file_exists('lock') && $mybb->dev_mode != true)

--- a/install/index.php
+++ b/install/index.php
@@ -1440,6 +1440,9 @@ function create_tables()
 		case "mysqli":
 			$db = new DB_MySQLi;
 			break;
+		case "mysql_pdo":
+			$db = new MysqlPdoDbDriver();
+			break;
 		default:
 			$db = new DB_MySQL;
 	}
@@ -2480,7 +2483,7 @@ function install_done()
 /**
  * @param array $config
  *
- * @return DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite|PostgresPdoDbDriver
+ * @return DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite|PostgresPdoDbDriver|MysqlPdoDbDriver
  */
 function db_connection($config)
 {
@@ -2498,6 +2501,9 @@ function db_connection($config)
 			break;
 		case "mysqli":
 			$db = new DB_MySQLi;
+			break;
+		case "mysql_pdo":
+			$db = new MysqlPdoDbDriver();
 			break;
 		default:
 			$db = new DB_MySQL;

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -61,6 +61,7 @@ if($config['database']['type'] == 'sqlite3' || $config['database']['type'] == 's
 
 // Load DB interface
 require_once MYBB_ROOT."inc/db_base.php";
+require_once MYBB_ROOT . 'inc/AbstractPdoDbDriver.php';
 
 require_once MYBB_ROOT."inc/db_{$config['database']['type']}.php";
 switch($config['database']['type'])
@@ -70,6 +71,9 @@ switch($config['database']['type'])
 		break;
 	case "pgsql":
 		$db = new DB_PgSQL;
+		break;
+	case "pgsql_pdo":
+		$db = new PostgresPdoDbDriver();
 		break;
 	case "mysqli":
 		$db = new DB_MySQLi;

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -78,6 +78,9 @@ switch($config['database']['type'])
 	case "mysqli":
 		$db = new DB_MySQLi;
 		break;
+	case "mysql_pdo":
+		$db = new MysqlPdoDbDriver();
+		break;
 	default:
 		$db = new DB_MySQL;
 }


### PR DESCRIPTION
This PR adds two new database drivers for MySQL and PostgreSQL that make use of [PDO](https://www.php.net/manual/en/book.pdo.php).

It also amends the SQLite driver to not just die if the database file cannot be opened.

It also fixes #4192.