### PR TITLE
Fix #4209 - send the mail queue using a task that runs every minute

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -239,9 +239,6 @@ if(!defined("NO_PLUGINS") && !($mybb->settings['no_plugins'] == 1))
 	$plugins->load();
 }
 
-// Set up any shutdown functions we need to run globally
-add_shutdown('send_mail_queue');
-
 /* URL Definitions */
 if($mybb->settings['seourls'] == "yes" || ($mybb->settings['seourls'] == "auto" && isset($_SERVER['SEO_SUPPORT']) && $_SERVER['SEO_SUPPORT'] == 1))
 {

--- a/inc/languages/english/admin/global.lang.php
+++ b/inc/languages/english/admin/global.lang.php
@@ -328,6 +328,7 @@ $l['task_massmail_ran_errors'] = "One or more problems occurred sending to \"{1}
 $l['task_versioncheck_ran'] = "The version check task successfully ran.";
 $l['task_versioncheck_ran_errors'] = "Could not connect to MyBB for a version check.";
 $l['task_recachestylesheets_ran'] = 'Re-cached {1} stylesheets.';
+$l['task_sendmailqueue_ran'] = 'The send mail queue task sent up to {1} messages.';
 
 $l['massmail_username'] = "Username";
 $l['email_addr'] = "Email Address";

--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -518,6 +518,7 @@ $l['task_massmail_ran_errors'] = "One or more problems occurred sending to \"{1}
 $l['task_versioncheck_ran'] = "The version check task successfully ran.";
 $l['task_versioncheck_ran_errors'] = "Could not connect to MyBB for a version check.";
 $l['task_recachestylesheets_ran'] = 'Re-cached {1} stylesheets.';
+$l['task_sendmailqueue_ran'] = 'The send mail queue task sent up to {1} messages.';
 
 $l['dismiss_notice'] = "Dismiss this notice";
 

--- a/inc/tasks/sendmailqueue.php
+++ b/inc/tasks/sendmailqueue.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * MyBB 1.8
+ *
+ * Copyright 2020 MyBB Group, All Rights Reserved
+ *
+ * Website: http://www.mybb.com
+ * License: http://www.mybb.com/about/license
+ */
+
+// Disallow direct access to this file for security reasons
+if(!defined('IN_MYBB'))
+{
+	die('Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.');
+}
+
+function task_sendmailqueue($task)
+{
+	global $mybb, $lang;
+
+	$num_to_send = max(1, (int) $mybb->settings['mail_queue_limit']);
+
+	send_mail_queue($num_to_send);
+
+	add_task_log($task, $lang->sprintf($lang->task_sendmailqueue_ran, $num_to_send));
+}

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -2306,6 +2306,15 @@ smtp=SMTP mail]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
+		<setting name="mail_queue_limit">
+			<title>Messages to send from the mail queue</title>
+			<description><![CDATA[The number of messages to send from the mail queue every time the Send Mail Queue task is ran.]]></description>
+			<disporder>10</disporder>
+			<optionscode><![CDATA[numeric
+min=1]]></optionscode>
+			<settingvalue><![CDATA[10]]></settingvalue>
+			<isdefault>1</isdefault>
+		</setting>
 	</settinggroup>
 	<settinggroup name="contactsettings" title="Contact Settings" description="The various options to change the behaviour of the contact page (contact.php)." disporder="25" isdefault="1">
 		<setting name="contact">

--- a/install/resources/tasks.xml
+++ b/install/resources/tasks.xml
@@ -156,16 +156,16 @@
         <enabled>0</enabled>
         <logging>1</logging>
     </task>
-	<task>
-		<title>Send Mail Queue</title>
-		<description><![CDATA[Sends the mail queue every minute.]]></description>
-		<file>sendmailqueue</file>
-		<minute>*</minute>
-		<hour>*</hour>
-		<day>*</day>
-		<weekday>*</weekday>
-		<month>*</month>
-		<enabled>1</enabled>
-		<logging>1</logging>
-	</task>
+    <task>
+        <title>Send Mail Queue</title>
+        <description><![CDATA[Sends the mail queue every minute.]]></description>
+        <file>sendmailqueue</file>
+        <minute>*</minute>
+        <hour>*</hour>
+        <day>*</day>
+        <weekday>*</weekday>
+        <month>*</month>
+        <enabled>1</enabled>
+        <logging>1</logging>
+    </task>
 </tasks>

--- a/install/resources/tasks.xml
+++ b/install/resources/tasks.xml
@@ -156,4 +156,16 @@
         <enabled>0</enabled>
         <logging>1</logging>
     </task>
+	<task>
+		<title>Send Mail Queue</title>
+		<description><![CDATA[Sends the mail queue every minute.]]></description>
+		<file>sendmailqueue</file>
+		<minute>*</minute>
+		<hour>*</hour>
+		<day>*</day>
+		<weekday>*</weekday>
+		<month>*</month>
+		<enabled>1</enabled>
+		<logging>1</logging>
+	</task>
 </tasks>

--- a/install/resources/upgrade52.php
+++ b/install/resources/upgrade52.php
@@ -40,4 +40,8 @@ function upgrade51_dbchanges()
 			$db->add_column("usergroups", "canbeinvisible", "tinyint(1) NOT NULL default '1' AFTER canusercp");
 			break;
 	}
+
+	$added_tasks = sync_tasks();
+
+	echo "<p>Added {$added_tasks} new tasks.</p>";
 }

--- a/install/resources/upgrade52.php
+++ b/install/resources/upgrade52.php
@@ -46,4 +46,7 @@ function upgrade51_dbchanges()
 	$added_tasks = sync_tasks();
 
 	echo "<p>Added {$added_tasks} new tasks.</p>";
+
+	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
+	$output->print_footer("52_done");
 }


### PR DESCRIPTION
Fixes #4209.

This adds a new task, `sendmailqueue`, which defaults to running every minute.

It also adds a new setting to manage the maximum number of messages to send from the mail queue when the task runs - previously only the default value of 10 emails would be used.

