### PR TITLE
Fix #3804 Post Merge Verification

### DIFF
--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -1053,7 +1053,9 @@ class PostDataHandler extends DataHandler
 					$plugins->run_hooks("datahandler_post_insert_merge", $this);
 					
 					return $this->return_values;
-				} else {
+				}
+				else
+				{
 					$post['message'] = $_message;
 				}
 			}

--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -791,8 +791,20 @@ class PostDataHandler extends DataHandler
 			}
 		}
 
-		// Verify all post assets.
+		// Make sure there isn't multiple posts (due to merge) that need to be verified
+		if ($this->method == "insert") 
+		{
+			$double_post = $this->verify_post_merge();
+		}
 
+		if($double_post !== true && $double_post['visible'] == 1)
+		{
+			$this->pid = $double_post['pid'];
+
+			$post['message'] = $double_post['message'] .= "\n".$mybb->settings['postmergesep']."\n".$post['message'];
+		}
+		
+		// Verify all post assets.
 		if($this->method == "insert" || array_key_exists('uid', $post))
 		{
 			$this->verify_author();

--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -790,8 +790,9 @@ class PostDataHandler extends DataHandler
 				$this->first_post = true;
 			}
 		}
-		
+
 		// Verify all post assets.
+
 		if($this->method == "insert" || array_key_exists('uid', $post))
 		{
 			$this->verify_author();
@@ -1002,11 +1003,11 @@ class PostDataHandler extends DataHandler
 			if($double_post !== true && $double_post['visible'] == $visible)
 			{
 				$_message = $post['message'];
-				
+
 				$post['message'] = $double_post['message'] .= "\n".$mybb->settings['postmergesep']."\n".$post['message'];
 				
-				// Extra check to validate the merged version
-				if ($this->validate_post()) {
+				if ($this->validate_post())
+				{
 					$this->pid = $double_post['pid'];
 					
 					$update_query = array(

--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -792,6 +792,8 @@ class PostDataHandler extends DataHandler
 		}
 
 		// Make sure there isn't multiple posts (due to merge) that need to be verified
+		$old_message = $post['message'];
+
 		if ($this->method == "insert") 
 		{
 			$double_post = $this->verify_post_merge();
@@ -799,11 +801,9 @@ class PostDataHandler extends DataHandler
 
 		if($double_post !== true && $double_post['visible'] == 1)
 		{
-			$this->pid = $double_post['pid'];
-
 			$post['message'] = $double_post['message'] .= "\n".$mybb->settings['postmergesep']."\n".$post['message'];
 		}
-		
+
 		// Verify all post assets.
 		if($this->method == "insert" || array_key_exists('uid', $post))
 		{
@@ -846,6 +846,9 @@ class PostDataHandler extends DataHandler
 		{
 			$this->verify_prefix();
 		}
+
+		// Revert message in case of double_post
+		$post['message'] = $old_message;
 
 		$plugins->run_hooks("datahandler_post_validate_post", $this);
 


### PR DESCRIPTION
Due to missing check on whether a post is a merge before a post is validated, it was possible to double post and merge multiple images and videos despite the limitations imposed through settings in AdminCP (Post Settings).

Resolves #3804 
