### PR TITLE
Partial Fix to #3540

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -1494,6 +1494,12 @@ if($foruminfo['type'] != "c")
 
 	$prefixselect = build_forum_prefix_select($fid, $tprefix);
 
+	// Populate Forumsort
+	if($threadcount > 0)
+	{
+		eval("\$forumsort = \"".$templates->get("forumdisplay_forumsort")."\";");
+	}
+	
 	$plugins->run_hooks("forumdisplay_threadlist");
 
 	$lang->rss_discovery_forum = $lang->sprintf($lang->rss_discovery_forum, htmlspecialchars_uni(strip_tags($foruminfo['name'])));

--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -1495,6 +1495,8 @@ if($foruminfo['type'] != "c")
 	$prefixselect = build_forum_prefix_select($fid, $tprefix);
 
 	// Populate Forumsort
+	$forumsort = '';
+	
 	if($threadcount > 0)
 	{
 		eval("\$forumsort = \"".$templates->get("forumdisplay_forumsort")."\";");

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3823,7 +3823,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <td class="{$bgcolor} forumdisplay_announcement" style="white-space: nowrap; text-align: right"><span class="smalltext">{$postdate}</span></td>
 {$modann}
 </tr>]]></template>
-		<template name="forumdisplay_forumsort" version="1824"><![CDATA[<tr>
+		<template name="forumdisplay_forumsort" version="1825"><![CDATA[<tr>
 		<td class="tfoot" align="right" colspan="{$colspan}">
 			<form action="forumdisplay.php" method="get">
 				<input type="hidden" name="fid" value="{$fid}" />
@@ -4040,7 +4040,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 	</td>]]></template>
 		<template name="forumdisplay_thread_rating_moved" version="1800"><![CDATA[<td class="{$bgcolor}" style="text-align: center;">-</td>]]></template>
 		<template name="forumdisplay_thread_unapproved_posts" version="1800"><![CDATA[ <span title="{$unapproved_posts_count}">({$thread['unapprovedposts']})</span>]]></template>
-		<template name="forumdisplay_threadlist" version="1824"><![CDATA[<div class="float_left">
+		<template name="forumdisplay_threadlist" version="1825"><![CDATA[<div class="float_left">
 	{$multipage}
 </div>
 <div class="float_right">

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -3823,6 +3823,39 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 <td class="{$bgcolor} forumdisplay_announcement" style="white-space: nowrap; text-align: right"><span class="smalltext">{$postdate}</span></td>
 {$modann}
 </tr>]]></template>
+		<template name="forumdisplay_forumsort" version="1824"><![CDATA[<tr>
+		<td class="tfoot" align="right" colspan="{$colspan}">
+			<form action="forumdisplay.php" method="get">
+				<input type="hidden" name="fid" value="{$fid}" />
+				<select name="sortby">
+					<option value="subject"{$sortsel['subject']}>{$lang->sort_by_subject}</option>
+					<option value="lastpost"{$sortsel['lastpost']}>{$lang->sort_by_lastpost}</option>
+					<option value="starter"{$sortsel['starter']}>{$lang->sort_by_starter}</option>
+					<option value="started"{$sortsel['started']}>{$lang->sort_by_started}</option>
+					{$ratingsort}
+					<option value="replies"{$sortsel['replies']}>{$lang->sort_by_replies}</option>
+					<option value="views"{$sortsel['views']}>{$lang->sort_by_views}</option>
+				</select>
+				<select name="order">
+					<option value="asc"{$ordersel['asc']}>{$lang->sort_order_asc}</option>
+					<option value="desc"{$ordersel['desc']}>{$lang->sort_order_desc}</option>
+				</select>
+				<select name="datecut">
+					<option value="1"{$datecutsel['1']}>{$lang->datelimit_1day}</option>
+					<option value="5"{$datecutsel['5']}>{$lang->datelimit_5days}</option>
+					<option value="10"{$datecutsel['10']}>{$lang->datelimit_10days}</option>
+					<option value="20"{$datecutsel['20']}>{$lang->datelimit_20days}</option>
+					<option value="50"{$datecutsel['50']}>{$lang->datelimit_50days}</option>
+					<option value="75"{$datecutsel['75']}>{$lang->datelimit_75days}</option>
+					<option value="100"{$datecutsel['100']}>{$lang->datelimit_100days}</option>
+					<option value="365"{$datecutsel['365']}>{$lang->datelimit_lastyear}</option>
+					<option value="9999"{$datecutsel['9999']}>{$lang->datelimit_beginning}</option>
+				</select>
+				{$prefixselect}
+				{$gobutton}
+			</form>
+		</td>
+	</tr>]]></template>
 		<template name="forumdisplay_announcements_announcement_modbit" version="1800"><![CDATA[<td align="center" class="{$bgcolor} forumdisplay_announcement">-</td>]]></template>
 		<template name="forumdisplay_inlinemoderation" version="1821"><![CDATA[<script type="text/javascript" src="{$mybb->asset_url}/jscripts/inline_moderation.js?ver=1821"></script>
 		<form action="moderation.php" method="post">
@@ -4007,7 +4040,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 	</td>]]></template>
 		<template name="forumdisplay_thread_rating_moved" version="1800"><![CDATA[<td class="{$bgcolor}" style="text-align: center;">-</td>]]></template>
 		<template name="forumdisplay_thread_unapproved_posts" version="1800"><![CDATA[ <span title="{$unapproved_posts_count}">({$thread['unapprovedposts']})</span>]]></template>
-		<template name="forumdisplay_threadlist" version="1820"><![CDATA[<div class="float_left">
+		<template name="forumdisplay_threadlist" version="1824"><![CDATA[<div class="float_left">
 	{$multipage}
 </div>
 <div class="float_right">
@@ -4035,39 +4068,7 @@ var announcement_quickdelete_confirm = "{$lang->announcement_quickdelete_confirm
 	{$selectall}
 	{$announcementlist}
 	{$threads}
-	<tr>
-		<td class="tfoot" align="right" colspan="{$colspan}">
-			<form action="forumdisplay.php" method="get">
-				<input type="hidden" name="fid" value="{$fid}" />
-				<select name="sortby">
-					<option value="subject"{$sortsel['subject']}>{$lang->sort_by_subject}</option>
-					<option value="lastpost"{$sortsel['lastpost']}>{$lang->sort_by_lastpost}</option>
-					<option value="starter"{$sortsel['starter']}>{$lang->sort_by_starter}</option>
-					<option value="started"{$sortsel['started']}>{$lang->sort_by_started}</option>
-					{$ratingsort}
-					<option value="replies"{$sortsel['replies']}>{$lang->sort_by_replies}</option>
-					<option value="views"{$sortsel['views']}>{$lang->sort_by_views}</option>
-				</select>
-				<select name="order">
-					<option value="asc"{$ordersel['asc']}>{$lang->sort_order_asc}</option>
-					<option value="desc"{$ordersel['desc']}>{$lang->sort_order_desc}</option>
-				</select>
-				<select name="datecut">
-					<option value="1"{$datecutsel['1']}>{$lang->datelimit_1day}</option>
-					<option value="5"{$datecutsel['5']}>{$lang->datelimit_5days}</option>
-					<option value="10"{$datecutsel['10']}>{$lang->datelimit_10days}</option>
-					<option value="20"{$datecutsel['20']}>{$lang->datelimit_20days}</option>
-					<option value="50"{$datecutsel['50']}>{$lang->datelimit_50days}</option>
-					<option value="75"{$datecutsel['75']}>{$lang->datelimit_75days}</option>
-					<option value="100"{$datecutsel['100']}>{$lang->datelimit_100days}</option>
-					<option value="365"{$datecutsel['365']}>{$lang->datelimit_lastyear}</option>
-					<option value="9999"{$datecutsel['9999']}>{$lang->datelimit_beginning}</option>
-				</select>
-				{$prefixselect}
-				{$gobutton}
-			</form>
-		</td>
-	</tr>
+	{$forumsort}
 </table>
 <div class="float_left">
 	{$multipage}


### PR DESCRIPTION
This is a partial fix to #3540, and more specifically, see this comment:
https://github.com/mybb/mybb/issues/3540#issuecomment-643508337

When there are no threads in a forum, there is no need to sort the threads. This hides the sorting for the case where there are 0 threads in a threadlist.

_This is more visual/redundant than needed. There might be a need to rename the template 'forumdisplay_forumsort' and variable '$forumsort' to something more logical._