### PR TITLE
Suggestive fix to #4116

### DIFF
--- a/member.php
+++ b/member.php
@@ -31,6 +31,7 @@ require_once "./global.php";
 require_once MYBB_ROOT."inc/functions_post.php";
 require_once MYBB_ROOT."inc/functions_user.php";
 require_once MYBB_ROOT."inc/class_parser.php";
+require_once MYBB_ROOT."inc/functions_modcp.php";
 $parser = new postParser;
 
 // Load global language phrases
@@ -2730,17 +2731,21 @@ if($mybb->input['action'] == "profile")
 
 		if($mybb->usergroup['caneditprofiles'] == 1)
 		{
-			eval("\$editprofile = \"".$templates->get("member_profile_modoptions_editprofile")."\";");
-			eval("\$editnotes = \"".$templates->get("member_profile_modoptions_editnotes")."\";");
+			if(modcp_can_manage_user($memprofile['uid']))
+			{
+				eval("\$editprofile = \"".$templates->get("member_profile_modoptions_editprofile")."\";");
+				eval("\$editnotes = \"".$templates->get("member_profile_modoptions_editnotes")."\";");
+		
+			}
 		}
 
-		if($mybb->usergroup['canbanusers'] == 1 && !empty($memban) && (!$memban['uid'] || $memban['uid'] && ($mybb->user['uid'] == $memban['admin']) || $mybb->usergroup['issupermod'] == 1 || $mybb->usergroup['cancp'] == 1))
+		if($memperms['isbannedgroup'] == 1 && $mybb->usergroup['canbanusers'] == 1 && modcp_can_manage_user($memprofile['uid']))
 		{
-			if($memperms['isbannedgroup'] == 1 && $mybb->usergroup['canbanusers'] == 1)
-			{
-				eval("\$manageban = \"".$templates->get("member_profile_modoptions_manageban")."\";");
-			}
-			else
+			eval("\$manageban = \"".$templates->get("member_profile_modoptions_manageban")."\";");
+		}
+		else
+		{
+			if(modcp_can_manage_user($memprofile['uid']) && $mybb->usergroup['canbanusers'] == 1)
 			{
 				eval("\$banuser = \"".$templates->get("member_profile_modoptions_banuser")."\";");
 			}

--- a/member.php
+++ b/member.php
@@ -2729,7 +2729,7 @@ if($mybb->input['action'] == "profile")
 			$memprofile['usernotes'] = $lang->no_usernotes;
 		}
 
-		if($mybb->usergroup['caneditprofiles'] == 1)
+		if($mybb->usergroup['caneditprofiles'] == 1 && modcp_can_manage_user($memprofile['uid']))
 		{
 			if(modcp_can_manage_user($memprofile['uid']))
 			{

--- a/member.php
+++ b/member.php
@@ -2743,7 +2743,7 @@ if($mybb->input['action'] == "profile")
 		{
 			eval("\$manageban = \"".$templates->get("member_profile_modoptions_manageban")."\";");
 		}
-		else
+		elseif(modcp_can_manage_user($memprofile['uid']) && $mybb->usergroup['canbanusers'] == 1)
 		{
 			if(modcp_can_manage_user($memprofile['uid']) && $mybb->usergroup['canbanusers'] == 1)
 			{


### PR DESCRIPTION
By including modcp functions, we can remove redundant conditions and more effectively check whether a user has permission to manage/ban/notes of another user whilst visiting their profile.

Suggestive Resolution for #4116 [Ban user in MCP, Edit user in MCP]

