### PR TITLE
Output details for initialization stage errors

### DIFF
--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -118,6 +118,13 @@ class errorHandler {
 	public $has_errors = false;
 
 	/**
+	 * Display errors regardless of related settings (useful during initialization stage)
+	 *
+	 * @var boolean
+	 */
+	public $force_display_errors = false;
+
+	/**
 	 * Initializes the error handler
 	 *
 	 */
@@ -421,7 +428,7 @@ class errorHandler {
 		{
 			$title = "MyBB SQL Error";
 			$error_message = "<p>MyBB has experienced an internal SQL error and cannot continue.</p>";
-			if($mybb->settings['errortypemedium'] == "both" || $mybb->settings['errortypemedium'] == "error" || defined("IN_INSTALL") || defined("IN_UPGRADE"))
+			if($this->force_display_errors || $mybb->settings['errortypemedium'] == "both" || $mybb->settings['errortypemedium'] == "error" || defined("IN_INSTALL") || defined("IN_UPGRADE"))
 			{
 				$message['query'] = htmlspecialchars_uni($message['query']);
 				$message['error'] = htmlspecialchars_uni($message['error']);
@@ -438,7 +445,7 @@ class errorHandler {
 		{
 			$title = "MyBB Internal Error";
 			$error_message = "<p>MyBB has experienced an internal error and cannot continue.</p>";
-			if($mybb->settings['errortypemedium'] == "both" || $mybb->settings['errortypemedium'] == "error" || defined("IN_INSTALL") || defined("IN_UPGRADE"))
+			if($this->force_display_errors || $mybb->settings['errortypemedium'] == "both" || $mybb->settings['errortypemedium'] == "error" || defined("IN_INSTALL") || defined("IN_UPGRADE"))
 			{
 				$error_message .= "<dl>\n";
 				$error_message .= "<dt>Error Type:</dt>\n<dd>{$this->error_types[$type]} ($type)</dd>\n";

--- a/inc/init.php
+++ b/inc/init.php
@@ -47,6 +47,9 @@ if(function_exists('date_default_timezone_set') && !ini_get('date.timezone'))
 require_once MYBB_ROOT."inc/class_error.php";
 $error_handler = new errorHandler();
 
+// Show errors triggered during initialization
+$error_handler->force_display_errors = true;
+
 if(!function_exists('json_encode') || !function_exists('json_decode'))
 {
 	require_once MYBB_ROOT.'inc/3rdparty/json/json.php';
@@ -232,6 +235,8 @@ if(!defined("IN_INSTALL") && !defined("IN_UPGRADE") && $version['version_code'] 
 		$mybb->trigger_generic_error("board_not_upgraded");
 	}
 }
+
+$error_handler->force_display_errors = false;
 
 // Load plugins
 if(!defined("NO_PLUGINS") && !($mybb->settings['no_plugins'] == 1))


### PR DESCRIPTION
Resolves #4156

Introduced in #2962 with new default of the `errortypemedium` setting https://github.com/mybb/mybb/pull/3882/files#diff-de99ee07e34571299c3477294cba3c0ea90ea18540ee667c1ea0ac57fc63d813R168, which is not be available during the setup phase.