### PR TITLE
Fix #4231: client-side support for rgba() color specs

### DIFF
--- a/jscripts/bbcodes_sceditor.js
+++ b/jscripts/bbcodes_sceditor.js
@@ -753,12 +753,19 @@ $(function ($) {
 		colorStr = colorStr || '#000';
 
 		// rgb(n,n,n);
-		if ((match =
-			colorStr.match(/rgb\((\d{1,3}),\s*?(\d{1,3}),\s*?(\d{1,3})\)/i))) {
+		if ((match = colorStr.match(/rgb\((\d{1,3}),\s*?(\d{1,3}),\s*?(\d{1,3})\)/i))) {
 			return '#' +
 				toHex(match[1]) +
 				toHex(match[2]) +
 				toHex(match[3]);
+		}
+
+		// rgba(n,n,n,f.p);
+		if ((match = colorStr.match(/rgba\((\d{1,3}),\s*?(\d{1,3}),\s*?(\d{1,3}),\s*?(\d*\.?\d+\s*)\)/i))) {
+			return '#' +
+			toHex(match[1]) +
+			toHex(match[2]) +
+			toHex(match[3]);
 		}
 
 		// expand shorthand


### PR DESCRIPTION
Fix #4231 by converting rgba() in the editor to a 6-digit hex color
(discarding the transparency component).

Resolves #4231

