### PR TITLE
Fix #4176 Profile fields aren't loaded in quick replies

### DIFF
--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -17,7 +17,7 @@
  */
 function build_postbit($post, $post_type=0)
 {
-	global $db, $altbg, $theme, $mybb, $postcounter;
+	global $db, $altbg, $theme, $mybb, $postcounter, $profile_fields;
 	global $titlescache, $page, $templates, $forumpermissions, $attachcache;
 	global $lang, $ismod, $inlinecookie, $inlinecount, $groupscache, $fid;
 	global $plugins, $parser, $cache, $ignored_users, $hascustomtitle;
@@ -418,9 +418,7 @@ function build_postbit($post, $post_type=0)
 			eval("\$post['button_purgespammer'] = \"".$templates->get('postbit_purgespammer')."\";");
 		}
 
-		static $profile_fields = null;
-
-		if($profile_fields === null)
+		if(!isset($profile_fields))
 		{
 			$profile_fields = array();
 


### PR DESCRIPTION
Fix #4176 Profile fields aren't loaded in quick replies

This was already discussed, just need a different pair of eyes for a quick merge.