### PR TITLE
Fix for #4240

### DIFF
--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -1019,7 +1019,7 @@ function get_post_attachments($id, &$post)
 					}
 					elseif((($attachment['thumbnail'] == "SMALL" && $forumpermissions['candlattachments'] == 1) || $mybb->settings['attachthumbnails'] == "no") && $isimage)
 					{
-						if (forum_permissions($post['fid'])['candlattachments'])
+						if ($forumpermissions['candlattachments'])
 						{
 							eval("\$post['imagelist'] .= \"".$templates->get("postbit_attachments_images_image")."\";");
 						} 

--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -1019,7 +1019,20 @@ function get_post_attachments($id, &$post)
 					}
 					elseif((($attachment['thumbnail'] == "SMALL" && $forumpermissions['candlattachments'] == 1) || $mybb->settings['attachthumbnails'] == "no") && $isimage)
 					{
-						eval("\$post['imagelist'] .= \"".$templates->get("postbit_attachments_images_image")."\";");
+						if (forum_permissions($post['fid'])['candlattachments'])
+						{
+							eval("\$post['imagelist'] .= \"".$templates->get("postbit_attachments_images_image")."\";");
+						} 
+						else 
+						{
+							eval("\$post['thumblist'] .= \"".$templates->get("postbit_attachments_thumbnails_thumbnail")."\";");
+							if($tcount == 5)
+							{
+								$thumblist .= "<br />";
+								$tcount = 0;
+							}
+							++$tcount;
+						}
 					}
 					else
 					{


### PR DESCRIPTION
Resolves #4240 

As @Sama34 (Omar) said, it should show the thumbnail of an image in the attachment area if the user does not have permission to download the image.

