### PR TITLE
Fix for #4254

### DIFF
--- a/inc/functions_image.php
+++ b/inc/functions_image.php
@@ -33,7 +33,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 	$imgheight = $imgdesc[1];
 	$imgtype = $imgdesc[2];
 	$imgattr = $imgdesc[3];
-	$imgbits = $imgdesc['bits'];
+	$imgbits = isset($imgdesc['bits']) ? $imgdesc['bits'] : null;
 	$imgchan = isset($imgdesc['channels']) ? $imgdesc['channels'] : null;
 
 	if($imgwidth == 0 || $imgheight == 0)


### PR DESCRIPTION
Implement check if the index bits exist in the array returned by getimagesize(), where channel and bits is not always returned depending on the file type.

Resolves #4254 