### PR TITLE
Add postParser output validation

### DIFF
--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -147,9 +147,10 @@ class errorHandler {
 	 * @param string $message The error message
 	 * @param string $file The error file
 	 * @param integer $line The error line
+	 * @param boolean $allow_output Whether or not output is permitted
 	 * @return boolean True if parsing was a success, otherwise assume a error
 	 */
-	function error($type, $message, $file=null, $line=0)
+	function error($type, $message, $file=null, $line=0, $allow_output=true)
 	{
 		global $mybb;
 
@@ -202,38 +203,41 @@ class errorHandler {
 			$this->email_error($type, $message, $file, $line);
 		}
 
-		// SQL Error
-		if($type == MYBB_SQL)
+		if($allow_output === true)
 		{
-			$this->output_error($type, $message, $file, $line);
-		}
-		else
-		{
-			// Do we have a PHP error?
-			if(my_strpos(my_strtolower($this->error_types[$type]), 'warning') === false)
+			// SQL Error
+			if($type == MYBB_SQL)
 			{
 				$this->output_error($type, $message, $file, $line);
 			}
-			// PHP Error
 			else
 			{
-				if($mybb->settings['errortypemedium'] == "none" || $mybb->settings['errortypemedium'] == "error")
+				// Do we have a PHP error?
+				if(my_strpos(my_strtolower($this->error_types[$type]), 'warning') === false)
 				{
-					echo "<div class=\"php_warning\">MyBB Internal: One or more warnings occurred. Please contact your administrator for assistance.</div>";
+					$this->output_error($type, $message, $file, $line);
 				}
+				// PHP Error
 				else
 				{
-					global $templates;
-
-					$warning = "<strong>{$this->error_types[$type]}</strong> [$type] $message - Line: $line - File: $file PHP ".PHP_VERSION." (".PHP_OS.")<br />\n";
-					if(is_object($templates) && method_exists($templates, "get") && !defined("IN_ADMINCP"))
+					if($mybb->settings['errortypemedium'] == "none" || $mybb->settings['errortypemedium'] == "error")
 					{
-						$this->warnings .= $warning;
-						$this->warnings .= $this->generate_backtrace();
+						echo "<div class=\"php_warning\">MyBB Internal: One or more warnings occurred. Please contact your administrator for assistance.</div>";
 					}
 					else
 					{
-						echo "<div class=\"php_warning\">{$warning}".$this->generate_backtrace()."</div>";
+						global $templates;
+
+						$warning = "<strong>{$this->error_types[$type]}</strong> [$type] $message - Line: $line - File: $file PHP ".PHP_VERSION." (".PHP_OS.")<br />\n";
+						if(is_object($templates) && method_exists($templates, "get") && !defined("IN_ADMINCP"))
+						{
+							$this->warnings .= $warning;
+							$this->warnings .= $this->generate_backtrace();
+						}
+						else
+						{
+							echo "<div class=\"php_warning\">{$warning}".$this->generate_backtrace()."</div>";
+						}
 					}
 				}
 			}

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1977,6 +1977,7 @@ class postParser
 		);
 
 		libxml_use_internal_errors(true);
+		@libxml_disable_entity_loader(true);
 
 		simplexml_load_string('<root>'.$output.'</root>', 'SimpleXMLElement', 524288 /* LIBXML_PARSEHUGE */);
 

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -98,17 +98,28 @@ class postParser
 	public $clear_needed = false;
 
 	/**
+	 * Don't validate parser output
+	 */
+	const VALIDATION_DISABLE = 0;
+
+	/**
+	 * Validate parser output and log errors
+	 */
+	const VALIDATION_REPORT_ONLY = 1;
+
+	/**
+	 * Validate parser output, log errors, and block output on failure
+	 */
+	const VALIDATION_REQUIRE = 2;
+
+	/**
 	 * Whether to validate the parser's HTML output when `allow_html` is disabled.
 	 * Validation errors will be logged/sent/displayed according to board settings.
 	 *
-	 * 0 - skip validation
-	 * 1 - validate and log errors
-	 * 2 - validate and log errors; block output on failure
-	 *
 	 * @access public
-	 * @var int
+	 * @var self::VALIDATION_*
 	 */
-	public $output_validation_policy = 1;
+	public $output_validation_policy = self::VALIDATION_REPORT_ONLY;
 
 	/**
 	 * Parses a message with the specified options.
@@ -1925,7 +1936,7 @@ class postParser
 	 */
 	function output_allowed($source, $output)
 	{
-		if($this->output_validation_policy === 0 || !empty($this->options['allow_html']))
+		if($this->output_validation_policy === self::VALIDATION_DISABLE || !empty($this->options['allow_html']))
 		{
 			return true;
 		}
@@ -1933,7 +1944,7 @@ class postParser
 		{
 			$output_valid = $this->validate_output($source, $output);
 
-			if($this->output_validation_policy === 1)
+			if($this->output_validation_policy === self::VALIDATION_REPORT_ONLY)
 			{
 				return true;
 			}

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1957,7 +1957,7 @@ class postParser
 
 		libxml_use_internal_errors(true);
 
-		simplexml_load_string('<root>'.$output.'</root>');
+		simplexml_load_string('<root>'.$output.'</root>', 'SimpleXMLElement', 524288 /* LIBXML_PARSEHUGE */);
 
 		$errors = libxml_get_errors();
 

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -928,7 +928,7 @@ class postParser
 
 		if($delete_quote)
 		{
-			$username = my_substr($username, 0, my_strlen($username)-1);
+			$username = my_substr($username, 0, my_strlen($username)-1, true);
 		}
 
 		if(!empty($this->options['allow_html']))

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1253,6 +1253,7 @@ class postParser
 			$alt = my_substr($alt, 0, 40).'...'.my_substr($alt, -10);
 		}
 		$alt = $this->encode_url($alt);
+		$alt = preg_replace("#&(?!\#[0-9]+;)#si", "&amp;", $alt); // fix & but allow unicode
 
 		$alt = $lang->sprintf($lang->posted_image, $alt);
 		$width = $height = '';

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1955,6 +1955,13 @@ class postParser
 	{
 		global $mybb, $error_handler;
 
+		$ignored_error_codes = array(
+			'XML_ERR_INVALID_CHAR' => 9,
+			'XML_ERR_UNDECLARED_ENTITY' => 26,
+			'XML_ERR_ATTRIBUTE_WITHOUT_VALUE' => 41,
+			'XML_ERR_TAG_NAME_MISMATCH' => 76, // the parser may output tags closed in different levels and siblings
+		);
+
 		libxml_use_internal_errors(true);
 
 		simplexml_load_string('<root>'.$output.'</root>', 'SimpleXMLElement', 524288 /* LIBXML_PARSEHUGE */);
@@ -1963,7 +1970,13 @@ class postParser
 
 		libxml_use_internal_errors(false);
 
-		if($errors)
+		if(
+			$errors &&
+			array_diff(
+				array_column($errors, 'code'),
+				$ignored_error_codes
+			)
+		)
 		{
 			$data = array(
 				'sourceHtmlEntities' => htmlspecialchars_uni($source),

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1935,7 +1935,7 @@ class postParser
 			{
 				return true;
 			}
-			if($this->output_validation_policy === 2)
+			elseif($this->output_validation_policy === 2)
 			{
 				return $output_valid === true || $output_valid === null;
 			}

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -98,7 +98,8 @@ class postParser
 	public $clear_needed = false;
 
 	/**
-	 * Whether to validate the parser's HTML output. Validation errors will be logged/sent/displayed according to board settings.
+	 * Whether to validate the parser's HTML output when `allow_html` is disabled.
+	 * Validation errors will be logged/sent/displayed according to board settings.
 	 *
 	 * 0 - skip validation
 	 * 1 - validate and log errors
@@ -1915,7 +1916,8 @@ class postParser
 	}
 
 	/**
-	 * Determines whether the resulting HTML syntax is acceptable for output, according to the parser's validation policy.
+	 * Determines whether the resulting HTML syntax is acceptable for output,
+	 * according to the parser's validation policy and HTML support.
 	 *
 	 * @param string $source The original MyCode.
 	 * @param string $output The output HTML code.
@@ -1923,7 +1925,7 @@ class postParser
 	 */
 	function output_allowed($source, $output)
 	{
-		if($this->output_validation_policy === 0)
+		if($this->output_validation_policy === 0 || !empty($this->options['allow_html']))
 		{
 			return true;
 		}

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1964,7 +1964,7 @@ class postParser
 	 */
 	function validate_output($source, $output)
 	{
-		global $mybb, $error_handler;
+		global $error_handler;
 
 		$ignored_error_codes = array(
 			// entities may be broken through smilie parsing; cache_smilies() method workaround doesn't cover all entities
@@ -2000,13 +2000,7 @@ class postParser
 			$error_message = "Parser output validation failed.\n";
 			$error_message .= var_export($data, true);
 
-			$original_errortypemedium = $mybb->settings['errortypemedium'];
-
-			$mybb->settings['errortypemedium'] = 'none'; // suppress output of error details
-
-			$error_handler->error(E_USER_WARNING, $error_message, __FILE__, __LINE__);
-
-			$mybb->settings['errortypemedium'] = $original_errortypemedium;
+			$error_handler->error(E_USER_WARNING, $error_message, __FILE__, __LINE__, false);
 		}
 
 		return empty($errors);

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1967,8 +1967,11 @@ class postParser
 		global $mybb, $error_handler;
 
 		$ignored_error_codes = array(
+			// entities may be broken through smilie parsing; cache_smilies() method workaround doesn't cover all entities
+			'XML_ERR_INVALID_DEC_CHARREF' => 7,
 			'XML_ERR_INVALID_CHAR' => 9,
-			'XML_ERR_UNDECLARED_ENTITY' => 26,
+
+			'XML_ERR_UNDECLARED_ENTITY' => 26, // unrecognized HTML entities
 			'XML_ERR_ATTRIBUTE_WITHOUT_VALUE' => 41,
 			'XML_ERR_TAG_NAME_MISMATCH' => 76, // the parser may output tags closed in different levels and siblings
 		);

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -13756,15 +13756,15 @@ if(use_xmlhttprequest == "1")
 				<td class="{$alt_bg}" align="center">{$issuedby}</td>
 	</tr>]]></template>
 		<template name="usercp_warnings_warning_post" version="1800"><![CDATA[<br /><small>{$lang->warning_for_post} <a href="{$warning['postlink']}">{$warning['post_subject']}</a></small>]]></template>
-		<template name="video_metacafe_embed" version="1807"><![CDATA[<iframe src="http://www.metacafe.com/embed/{$id}/" width="440" height="248" allowFullScreen frameborder=0></iframe>]]></template>
-		<template name="video_dailymotion_embed" version="1807"><![CDATA[<iframe frameborder="0" width="480" height="270" src="//www.dailymotion.com/embed/video/{$id}" allowfullscreen></iframe>]]></template>
+		<template name="video_metacafe_embed" version="1827"><![CDATA[<iframe src="http://www.metacafe.com/embed/{$id}/" width="440" height="248" allowfullscreen="true" frameborder=0></iframe>]]></template>
+		<template name="video_dailymotion_embed" version="1827"><![CDATA[<iframe frameborder="0" width="480" height="270" src="//www.dailymotion.com/embed/video/{$id}" allowfullscreen="true"></iframe>]]></template>
 		<template name="video_facebook_embed" version="1800"><![CDATA[<iframe src="https://www.facebook.com/video/embed?video_id={$id}" width="625" height="350" frameborder="0"></iframe>]]></template>
-		<template name="video_liveleak_embed" version="1811"><![CDATA[<iframe width="500" height="300" src="https://www.liveleak.com/ll_embed?i={$id}" frameborder="0" allowfullscreen></iframe>]]></template>
-		<template name="video_myspacetv_embed" version="1807"><![CDATA[<iframe width="480" height="270" src="//media.myspace.com/play/video/{$id}" frameborder="0" allowtransparency="true" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>]]></template>
-		<template name="video_youtube_embed" version="1827"><![CDATA[<iframe width="560" height="315" src="//www.youtube-nocookie.com/embed/{$id}" frameborder="0" allowfullscreen></iframe>]]></template>
+		<template name="video_liveleak_embed" version="1827"><![CDATA[<iframe width="500" height="300" src="https://www.liveleak.com/ll_embed?i={$id}" frameborder="0" allowfullscreen="true"></iframe>]]></template>
+		<template name="video_myspacetv_embed" version="1827"><![CDATA[<iframe width="480" height="270" src="//media.myspace.com/play/video/{$id}" frameborder="0" allowtransparency="true" allowfullscreen="true"></iframe>]]></template>
+		<template name="video_youtube_embed" version="1827"><![CDATA[<iframe width="560" height="315" src="//www.youtube-nocookie.com/embed/{$id}" frameborder="0" allowfullscreen="true"></iframe>]]></template>
 		<template name="video_mixer_embed" version="1818"><![CDATA[<iframe allowfullscreen="true" src="https://mixer.com/embed/player/{$id}?disableLowLatency=1" width="620" height="349"></iframe>]]></template>
-		<template name="video_vimeo_embed" version="1807"><![CDATA[<iframe src="//player.vimeo.com/video/{$id}" width="500" height="375" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>]]></template>
-		<template name="video_yahoo_embed" version="1807"><![CDATA[<iframe width="640" height="360" scrolling="no" frameborder="0" src="//{$local}screen.yahoo.com/{$id}?format=embed" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" allowtransparency="true"></iframe>]]></template>
+		<template name="video_vimeo_embed" version="1827"><![CDATA[<iframe src="//player.vimeo.com/video/{$id}" width="500" height="375" frameborder="0" allowfullscreen="true"></iframe>]]></template>
+		<template name="video_yahoo_embed" version="1827"><![CDATA[<iframe width="640" height="360" scrolling="no" frameborder="0" src="//{$local}screen.yahoo.com/{$id}?format=embed" allowfullscreen="true" allowtransparency="true"></iframe>]]></template>
 		<template name="video_twitch_embed" version="1813"><![CDATA[<iframe src="https://player.twitch.tv/?{$id}&amp;autoplay=false" frameborder="0" scrolling="no" height="378" width="620"></iframe>]]></template>
 		<template name="warnings" version="1400"><![CDATA[<html>
 <head>


### PR DESCRIPTION
Calls `simplexml_load_string()` and captures LibXML errors.

The errors, depending on the validation policy, may display a warning and be logged by the error handler or, additionally, suppress output. The policy is currently set to `VALIDATION_REPORT_ONLY` to alert administrators but limit breaking functionality, and should be changed to `VALIDATION_REQUIRE` in subsequent versions.

The logged source and output is escaped to prevent serious malformation of the XML error log file.

Related new Docs: https://github.com/mybb/docs.mybb.com/pull/201/files

Resolves #4305