### PR TITLE
Resolves #2058/#1758 - Can view/reply only own threads and guests #2

### DIFF
--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -755,8 +755,19 @@ $(function() {
 			'cansearch' => 'misc',
 		);
 
+		$hidefields = array();
+			if($usergroup['gid'] == 1)
+			{
+				$hidefields = array('canonlyviewownthreads', 'canonlyreplyownthreads', 'caneditposts', 'candeleteposts', 'candeletethreads', 'caneditattachments', 'canviewdeletetionnotice');
+			}
+
 		$groups = $plugins->run_hooks("admin_forum_management_permission_groups", $groups);
 
+		foreach($hidefields as $field)
+		{
+			unset($groups[$field]);
+		}
+		
 		$tabs = array();
 		foreach(array_unique(array_values($groups)) as $group)
 		{
@@ -777,7 +788,7 @@ $(function() {
 		$fields_array = $db->show_fields_from("forumpermissions");
 		foreach($fields_array as $field)
 		{
-			if(strpos($field['Field'], 'can') !== false || strpos($field['Field'], 'mod') !== false)
+			if(!in_array($field['field'], $hidefields) && (strpos($field['Field'], 'can') !== false || strpos($field['Field'], 'mod') !== false))
 			{
 				if(array_key_exists($field['Field'], $groups))
 				{

--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -1134,15 +1134,19 @@ if($mybb->input['action'] == "edit")
 	);
 	$form_container->output_row($lang->attachment_options, "", "<div class=\"group_settings_bit\">".implode("</div><div class=\"group_settings_bit\">", $attachment_options)."</div>");
 
-	$editing_options = array(
-		$form->generate_check_box("caneditposts", 1, $lang->can_edit_posts, array("checked" => $mybb->input['caneditposts'])),
-		$form->generate_check_box("candeleteposts", 1, $lang->can_delete_posts, array("checked" => $mybb->input['candeleteposts'])),
-		$form->generate_check_box("candeletethreads", 1, $lang->can_delete_threads, array("checked" => $mybb->input['candeletethreads'])),
-		$form->generate_check_box("caneditattachments", 1, $lang->can_edit_attachments, array("checked" => $mybb->input['caneditattachments'])),
-		$form->generate_check_box("canviewdeletionnotice", 1, $lang->can_view_deletion_notices, array("checked" => $mybb->input['canviewdeletionnotice'])),
-		"{$lang->edit_time_limit}<br /><small class=\"input\">{$lang->edit_time_limit_desc}</small><br />".$form->generate_numeric_field('edittimelimit', $mybb->input['edittimelimit'], array('id' => 'edittimelimit', 'class' => 'field50', 'min' => 0))
-	);
-	$form_container->output_row($lang->editing_deleting_options, "", "<div class=\"group_settings_bit\">".implode("</div><div class=\"group_settings_bit\">", $editing_options)."</div>");
+	// Remove these options if the group being editied is Guest (GID=1)
+	if($usergroup['gid'] != 1) 
+	{
+		$editing_options = array(
+			$form->generate_check_box("caneditposts", 1, $lang->can_edit_posts, array("checked" => $mybb->input['caneditposts'])),
+			$form->generate_check_box("candeleteposts", 1, $lang->can_delete_posts, array("checked" => $mybb->input['candeleteposts'])),
+			$form->generate_check_box("candeletethreads", 1, $lang->can_delete_threads, array("checked" => $mybb->input['candeletethreads'])),
+			$form->generate_check_box("caneditattachments", 1, $lang->can_edit_attachments, array("checked" => $mybb->input['caneditattachments'])),
+			$form->generate_check_box("canviewdeletionnotice", 1, $lang->can_view_deletion_notices, array("checked" => $mybb->input['canviewdeletionnotice'])),
+			"{$lang->edit_time_limit}<br /><small class=\"input\">{$lang->edit_time_limit_desc}</small><br />".$form->generate_numeric_field('edittimelimit', $mybb->input['edittimelimit'], array('id' => 'edittimelimit', 'class' => 'field50', 'min' => 0))
+		);
+		$form_container->output_row($lang->editing_deleting_options, "", "<div class=\"group_settings_bit\">".implode("</div><div class=\"group_settings_bit\">", $editing_options)."</div>");
+	}
 
 	$form_container->end();
 	echo "</div>";

--- a/install/resources/upgrade52.php
+++ b/install/resources/upgrade52.php
@@ -44,7 +44,15 @@ function upgrade51_dbchanges()
 	}
 
 	// Change default values for these settings for the guest group only
-	$db->update_colum("UPDATE ".TABLE_PREFIX."usergroups SET can editposts = 0, candeleteposts = 0, candeletethreads = 0, caneditattachments = 0, canviewdeletionnotice = 0 WHERE gid = 1 ");
+	$db->update_query('usergroups', array(
+		'editposts' => 0,
+		'candeleteposts' => 0,
+		'candeletethreads' => 0,
+		'caneditattachments' => 0,
+		'canviewdeletionnotice' => 0
+	), "gid = 1");
+
+	$cache->update_usergroups();
   
 	$added_tasks = sync_tasks();
 

--- a/install/resources/upgrade52.php
+++ b/install/resources/upgrade52.php
@@ -45,7 +45,7 @@ function upgrade51_dbchanges()
 
 	// Change default values for these settings for the guest group only
 	$db->update_query('usergroups', array(
-		'editposts' => 0,
+		'caneditposts' => 0,
 		'candeleteposts' => 0,
 		'candeletethreads' => 0,
 		'caneditattachments' => 0,

--- a/install/resources/upgrade52.php
+++ b/install/resources/upgrade52.php
@@ -42,6 +42,9 @@ function upgrade51_dbchanges()
 			$db->add_column("attachtypes", "forcedownload", "tinyint(1) NOT NULL default '0' AFTER enabled");
 			break;
 	}
+
+	// Change default values for these settings for the guest group only
+	$db->update_colum("UPDATE ".TABLE_PREFIX."usergroups SET can editposts = 0, candeleteposts = 0, candeletethreads = 0, caneditattachments = 0, canviewdeletionnotice = 0 WHERE gid = 1 ");
   
 	$added_tasks = sync_tasks();
 


### PR DESCRIPTION
Apply changes from #4072 4072 and upgrade script code. Previous branch was becoming a mess so recreated PR which should hopefully be finished.

This PR will remove the following options from the guest usergroup since they currently have no effect if they are either disabled or enabled.

Editing/Deleting Options
Can edit own posts?
Can delete own posts?
Can delete own threads?
Can update own attachments?

Resolves #2058 & #1758 

