### PR TITLE
Rework #4342 - Relative/absolute path

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1197,17 +1197,13 @@ if($mybb->input['action'] == "change")
 					continue;
 				}
 
-				$realpath = $mybb->input['upsetting'][$field];
+				$realpath = realpath(mk_path_abs($mybb->input['upsetting'][$field]));
 
-				// Adjust a relative upload path to an absolute one
-				$iswin = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-				$char1 = my_substr($realpath, 0, 1);
-				if($char1 != '/' && !($iswin && ($char1 == '\\' || preg_match('(^[a-zA-Z]:\\\\)', $realpath))))
+				if ($realpath === false)
 				{
-					$realpath = MYBB_ROOT.$realpath;
+					unset($mybb->input['upsetting'][$field]);
+					continue;
 				}
-
-				$realpath = realpath($realpath);
 
 				foreach ($dynamic_include_directories_realpath as $forbidden_realpath)
 				{

--- a/admin/modules/forum/attachments.php
+++ b/admin/modules/forum/attachments.php
@@ -39,6 +39,8 @@ if($mybb->input['action'] == "stats" || $mybb->input['action'] == "orphans" || !
 
 $plugins->run_hooks("admin_forum_attachments_begin");
 
+$uploadspath_abs = mk_path_abs($mybb->settings['uploadspath']);
+
 if($mybb->input['action'] == "delete")
 {
 	$plugins->run_hooks("admin_forum_attachments_delete");
@@ -232,7 +234,7 @@ if($mybb->input['action'] == "delete_orphans" && $mybb->request_method == "post"
 		foreach($mybb->input['orphaned_files'] as $file)
 		{
 			$file = str_replace('..', '', $file);
-			$path = $mybb->settings['uploadspath']."/".$file;
+			$path = $uploadspath_abs."/".$file;
 			$real_path = realpath($path);
 
 			if($real_path === false || strpos(str_replace('\\', '/', $real_path), str_replace('\\', '/', realpath(MYBB_ROOT)).'/') !== 0 || $real_path == realpath(MYBB_ROOT.'install/lock'))
@@ -241,7 +243,7 @@ if($mybb->input['action'] == "delete_orphans" && $mybb->request_method == "post"
 				continue;
 			}
 
-			if(!@unlink($mybb->settings['uploadspath']."/".$file))
+			if(!@unlink($uploadspath_abs."/".$file))
 			{
 				$error_count++;
 			}
@@ -375,7 +377,7 @@ if($mybb->input['action'] == "orphans")
 		{
 			foreach($bad_attachments as $file)
 			{
-				$file_path = $mybb->settings['uploadspath']."/".$file;
+				$file_path = $uploadspath_abs."/".$file;
 
 				if(file_exists($file_path))
 				{
@@ -462,7 +464,7 @@ if($mybb->input['action'] == "orphans")
 		while($attachment = $db->fetch_array($query))
 		{
 			// Check if the attachment exists in the file system
-			if(!file_exists($mybb->settings['uploadspath']."/{$attachment['attachname']}"))
+			if(!file_exists($uploadspath_abs."/{$attachment['attachname']}"))
 			{
 				$missing_attachment_files[$attachment['aid']] = $attachment['aid'];
 			}
@@ -522,7 +524,7 @@ if($mybb->input['action'] == "orphans")
 		{
 			global $db, $mybb, $bad_attachments, $attachments_to_check;
 
-			$real_dir = $mybb->settings['uploadspath'];
+			$real_dir = $uploadspath_abs;
 			$false_dir = "";
 			if($dir)
 			{
@@ -968,7 +970,7 @@ function build_attachment_row($attachment, &$table, $use_form=false)
 	// Check if the attachment exists in the file system
 	$checked = false;
 	$title = $cell_class = '';
-	if(!file_exists($mybb->settings['uploadspath']."/{$attachment['attachname']}"))
+	if(!file_exists(mk_path_abs($mybb->settings['uploadspath'])."/{$attachment['attachname']}"))
 	{
 		$cell_class = "bad_attachment";
 		$title = $lang->error_not_found;

--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -362,7 +362,7 @@ function acp_rebuild_attachment_thumbnails()
 	$start = ($page-1) * $per_page;
 	$end = $start + $per_page;
 
-	$uploadspath = $mybb->settings['uploadspath'];
+	$uploadspath_abs = mk_path_abs($mybb->settings['uploadspath']);
 
 	require_once MYBB_ROOT."inc/functions_image.php";
 
@@ -373,7 +373,7 @@ function acp_rebuild_attachment_thumbnails()
 		if($ext == "gif" || $ext == "png" || $ext == "jpg" || $ext == "jpeg" || $ext == "jpe")
 		{
 			$thumbname = str_replace(".attach", "_thumb.$ext", $attachment['attachname']);
-			$thumbnail = generate_thumbnail($uploadspath."/".$attachment['attachname'], $uploadspath, $thumbname, $mybb->settings['attachthumbh'], $mybb->settings['attachthumbw']);
+			$thumbnail = generate_thumbnail($uploadspath_abs."/".$attachment['attachname'], $uploadspath_abs, $thumbname, $mybb->settings['attachthumbh'], $mybb->settings['attachthumbw']);
 			if($thumbnail['code'] == 4)
 			{
 				$thumbnail['filename'] = "SMALL";

--- a/admin/modules/tools/system_health.php
+++ b/admin/modules/tools/system_health.php
@@ -850,8 +850,8 @@ if(!$mybb->input['action'])
 		++$errors;
 	}
 
-	$uploadspath = $mybb->settings['uploadspath'];
-	if(is_writable($uploadspath))
+	$uploadspath_abs = mk_path_abs($mybb->settings['uploadspath']);
+	if(is_writable($uploadspath_abs))
 	{
 		$message_upload = "<span style=\"color: green;\">{$lang->writable}</span>";
 	}
@@ -861,12 +861,8 @@ if(!$mybb->input['action'])
 		++$errors;
 	}
 
-	$avataruploadpath = $mybb->settings['avataruploadpath'];
-	if(my_substr($avataruploadpath, 0, 1) == '.')
-	{
-		$avataruploadpath = MYBB_ROOT . $mybb->settings['avataruploadpath'];
-	}
-	if(is_writable($avataruploadpath))
+	$avataruploadpath_abs = mk_path_abs($mybb->settings['avataruploadpath']);
+	if(is_writable($avataruploadpath_abs))
 	{
 		$message_avatar = "<span style=\"color: green;\">{$lang->writable}</span>";
 	}

--- a/attachment.php
+++ b/attachment.php
@@ -120,11 +120,13 @@ if(!isset($mybb->input['thumbnail'])) // Only increment the download count if th
 // basename isn't UTF-8 safe. This is a workaround.
 $attachment['filename'] = ltrim(basename(' '.$attachment['filename']));
 
+$uploadspath_abs = mk_path_abs($mybb->settings['uploadspath']);
+
 $plugins->run_hooks("attachment_end");
 
 if(isset($mybb->input['thumbnail']))
 {
-	if(!file_exists($mybb->settings['uploadspath']."/".$attachment['thumbnail']))
+	if(!file_exists($uploadspath_abs."/".$attachment['thumbnail']))
 	{
 		error($lang->error_invalidattachment);
 	}
@@ -153,7 +155,7 @@ if(isset($mybb->input['thumbnail']))
 
 	header("Content-disposition: filename=\"{$attachment['filename']}\"");
 	header("Content-type: ".$type);
-	$thumb = $mybb->settings['uploadspath']."/".$attachment['thumbnail'];
+	$thumb = $uploadspath_abs."/".$attachment['thumbnail'];
 	header("Content-length: ".@filesize($thumb));
 	$handle = fopen($thumb, 'rb');
 	while(!feof($handle))
@@ -164,7 +166,7 @@ if(isset($mybb->input['thumbnail']))
 }
 else
 {
-	if(!file_exists($mybb->settings['uploadspath']."/".$attachment['attachname']))
+	if(!file_exists($uploadspath_abs."/".$attachment['attachname']))
 	{
 		error($lang->error_invalidattachment);
 	}
@@ -219,7 +221,7 @@ else
 
 	header("Content-length: {$attachment['filesize']}");
 	header("Content-range: bytes=0-".($attachment['filesize']-1)."/".$attachment['filesize']);
-	$handle = fopen($mybb->settings['uploadspath']."/".$attachment['attachname'], 'rb');
+	$handle = fopen($uploadspath_abs."/".$attachment['attachname'], 'rb');
 	while(!feof($handle))
 	{
 		echo fread($handle, 8192);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -9340,3 +9340,26 @@ function create_xml_parser($data)
 		return new XMLParser($data);
 	}
 }
+
+/**
+ * Make a filesystem path absolute.
+ *
+ * Returns as-is paths which are already absolute.
+ *
+ * @param string $path The input path. Can be either absolute or relative.
+ * @param string $base The absolute base to which to append $path if $path is
+ *                     relative. Must end in DIRECTORY_SEPARATOR or a forward
+ *                     slash.
+ * @return string An absolute filesystem path corresponding to the input path.
+ */
+function mk_path_abs($path, $base = MYBB_ROOT)
+{
+	$iswin = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+	$char1 = my_substr($path, 0, 1);
+	if($char1 != '/' && !($iswin && ($char1 == '\\' || preg_match('(^[a-zA-Z]:\\\\)', $path))))
+	{
+		$path = $base.$path;
+	}
+
+	return $path;
+}

--- a/inc/init.php
+++ b/inc/init.php
@@ -208,14 +208,6 @@ $settings['bbname_orig'] = $settings['bbname'];
 $settings['bbname'] = strip_tags($settings['bbname']);
 $settings['orig_bblanguage'] = $settings['bblanguage'];
 
-// Adjust a relative upload path to an absolute one
-$iswin = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-$char1 = my_substr($settings['uploadspath'], 0, 1);
-if($char1 != '/' && !($iswin && ($char1 == '\\' || preg_match('(^[a-zA-Z]:\\\\)', $settings['uploadspath']))))
-{
-	$settings['uploadspath'] = MYBB_ROOT.$settings['uploadspath'];
-}
-
 // Fix for people who for some specify a trailing slash on the board URL
 if(substr($settings['bburl'], -1) == "/")
 {

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -409,7 +409,7 @@ max=9]]></optionscode>
 		</setting>
 		<setting name="uploadspath">
 			<title>Uploads Path</title>
-			<description><![CDATA[The path used for all board uploads. It <b>must be chmod 777</b> (on *nix servers). If the path does not start with a forward slash "/" it will be converted to an absolute path. Default value: "./uploads" (relative path).]]></description>
+			<description><![CDATA[The path used for all board uploads. It <b>must be chmod 777</b> (on *nix servers). If it is a relative path then it is taken to be relative to the MyBB root directory. Default value: "./uploads" (relative path).]]></description>
 			<disporder>10</disporder>
 			<optionscode><![CDATA[text]]></optionscode>
 			<settingvalue><![CDATA[./uploads]]></settingvalue>

--- a/install/resources/upgrade35.php
+++ b/install/resources/upgrade35.php
@@ -164,12 +164,13 @@ function upgrade35_dbchanges4()
 	echo "<p>Adding index files to attachment directories...</p>";
 	flush();
 
-	$dir = @opendir($mybb->settings['uploadspath']);
+	$uploadspath_abs = mk_path_abs($mybb->settings['uploadspath']);
+	$dir = @opendir($uploadspath_abs);
 	if($dir)
 	{
 		while(($file = @readdir($dir)) !== false)
 		{
-			$filename = "{$mybb->settings['uploadspath']}/{$file}";
+			$filename = "{$uploadspath_abs}/{$file}";
 			$indexfile = "{$filename}/index.html";
 
 			if(preg_match('#^[0-9]{6}$#', $file) && @is_dir($filename) && @is_writable($filename) && !file_exists($indexfile))

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -125,12 +125,6 @@ $settings['wolcutoff'] = $settings['wolcutoffmins']*60;
 $settings['bbname_orig'] = $settings['bbname'];
 $settings['bbname'] = strip_tags($settings['bbname']);
 
-// Adjust a relative upload path to an absolute one
-if(my_substr($settings['uploadspath'], 0, 1) != "/")
-{
-	$settings['uploadspath'] = MYBB_ROOT.$settings['uploadspath'];
-}
-
 // Fix for people who for some specify a trailing slash on the board URL
 if(substr($settings['bburl'], -1) == "/")
 {


### PR DESCRIPTION
Introduce a `mk_path_abs()` function so that the `uploadspath` setting
can be "absolutised" on-demand rather than at the beginning of
processing.

Resolves the first item of #4360 without the need for manipulating the
setting's value in the proposed fix in #4361. If merged, provides the
basis for resolving the conversation[1] in that PR so that it can be
adapted a little and continue to resolve the other items of #4360.

[1] https://github.com/mybb/mybb/pull/4361/files#r617217364

