### PR TITLE
Ability to suspend private messaging ability

### DIFF
--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -730,7 +730,7 @@ if($mybb->input['action'] == "edit")
 				}
 			}
 
-			// Moderator "Options" (suspend signature, suspend/moderate posting)
+			// Moderator "Options" (suspend signature, suspend/moderate posting, suspend private messaging)
 			$moderator_options = array(
 				1 => array(
 					"action" => "suspendsignature", // The moderator action we're performing
@@ -752,6 +752,13 @@ if($mybb->input['action'] == "edit")
 					"time" => "suspost_time",
 					"update_field" => "suspendposting",
 					"update_length" => "suspensiontime"
+				),
+				4 => array(
+					"action" => "suspendprivatemessaging",
+					"period" => "suspm_period",
+					"time" => "suspm_time",
+					"update_field" => "suspendpm",
+					"update_length" => "pmsuspensiontime"
 				)
 			);
 
@@ -814,7 +821,7 @@ if($mybb->input['action'] == "edit")
 				}
 			}
 
-			if(!empty($extra_user_updates['moderateposts']) && !empty($extra_user_updates['suspendposting']))
+			if(!empty($extra_user_updates['moderateposts']) && !empty($extra_user_updates['suspendposting']) && !empty($extra_user_updates['suspendpm']))
 			{
 				$errors[] = $lang->suspendmoderate_error;
 			}
@@ -1679,6 +1686,45 @@ EOF;
 	$lang->suspend_posts_info = $lang->sprintf($lang->suspend_posts_info, htmlspecialchars_uni($user['username']));
 	$form_container->output_row($form->generate_check_box("suspendposting", 1, $lang->suspend_posts, array("id" => "suspendposting", "onclick" => "toggleBox('suspost');", "checked" => $mybb->get_input('suspendposting'))), $lang->suspend_posts_info, $suspost_div);
 
+	// Suspend private messaging
+	// Generate check box
+	$suspm_options = $form->generate_select_box('suspm_period', $periods, $mybb->get_input('suspm_period'), array('id' => 'suspm_period'));
+
+	// Do we have any existing suspensions here?
+	if($user['suspendpm'] || ($mybb->get_input('suspendpm') && !empty($errors)))
+	{
+		$mybb->input['suspendpm'] = 1;
+
+		if($user['pmsuspensiontime'] == 0 || $mybb->get_input('suspm_period') == "never")
+		{
+			$existing_info = $lang->suspended_perm;
+		}
+		else
+		{
+			$remaining = $user['pmsuspensiontime']-TIME_NOW;
+			$suspm_date = nice_time($remaining, array('seconds' => false));
+
+			$color = 'inherit';
+			if($remaining < 3600)
+			{
+				$color = 'red';
+			}
+			elseif($remaining < 86400)
+			{
+				$color = 'maroon';
+			}
+			elseif($remaining < 604800)
+			{
+				$color = 'green';
+			}
+
+			$existing_info = $lang->sprintf($lang->suspend_length, $suspm_date, $color);
+		}
+	}
+
+	$suspm_div = '<div id="suspm">'.$existing_info.''.$lang->suspend_for.' '.$form->generate_numeric_field("suspm_time", $mybb->get_input('suspm_time'), array('style' => 'width: 3em;', 'min' => 0)).' '.$suspm_options.'</div>';
+	$lang->suspend_pm_info = $lang->sprintf($lang->suspend_pm_info, htmlspecialchars_uni($user['username']));
+	$form_container->output_row($form->generate_check_box("suspendprivatemessaging", 1, $lang->suspend_privatemessaging, array("id" => "suspendprivatemessaging", "onclick" => "toggleBox('suspm');", "checked" => $mybb->get_input('suspendpm'))), $lang->suspend_pm_info, $suspm_div);
 
 	$form_container->end();
 	$plugins->run_hooks("admin_user_users_edit_moderator_options");
@@ -1724,6 +1770,20 @@ function toggleBox(action)
 			$("#suspost").hide();
 		}
 	}
+	else if(action == "suspm")
+	{
+		$("#suspendprivatemessaging").attr("checked", false);
+		$("#suspm").hide();
+
+		if($("#suspendprivatemessaging").is(":checked") == true)
+		{
+			$("#suspm").show();
+		}
+		else if($("#suspendprivatemessaging").is(":checked") == false)
+		{
+			$("#suspm").hide();
+		}
+	}
 }
 
 if($("#moderateposting").is(":checked") == false)
@@ -1742,6 +1802,15 @@ if($("#suspendposting").is(":checked") == false)
 else
 {
 	$("#suspost").show();
+}
+
+if($("#suspendprivatemessaging").is(":checked") == false)
+{
+	$("#suspm").hide();
+}
+else
+{
+	$("#suspm").show();
 }
 
 // -->

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -821,7 +821,7 @@ if($mybb->input['action'] == "edit")
 				}
 			}
 
-			if(!empty($extra_user_updates['moderateposts']) && !empty($extra_user_updates['suspendposting']) && !empty($extra_user_updates['suspendpm']))
+			if(!empty($extra_user_updates['moderateposts']) && !empty($extra_user_updates['suspendposting']))
 			{
 				$errors[] = $lang->suspendmoderate_error;
 			}

--- a/inc/datahandlers/pm.php
+++ b/inc/datahandlers/pm.php
@@ -315,7 +315,7 @@ class PMDataHandler extends DataHandler
 				}
 
 				// Can the recipient actually receive private messages based on their permissions or user setting?
-				if(($user['receivepms'] == 0 || $recipient_permissions['canusepms'] == 0) && empty($pm['saveasdraft']))
+				if(($user['receivepms'] == 0 || $recipient_permissions['canusepms'] == 0 || $user['suspendpm']) && empty($pm['saveasdraft']))
 				{
 					$this->set_error("recipient_pms_disabled", array(htmlspecialchars_uni($user['username'])));
 					return false;

--- a/inc/languages/english/admin/user_users.lang.php
+++ b/inc/languages/english/admin/user_users.lang.php
@@ -254,6 +254,9 @@ $l['suspend_for'] = "Suspend for:";
 $l['suspended_perm'] = "<p><small>Suspended permanently.<br />Enter a new time below to change or untick this option to remove this suspension.</small></p>";
 $l['suspend_length'] = "<p><small>Remaining Suspension: <span style=\"color: {2};\">{1}</span>.<br />Enter a new time below to change or untick this option to remove this suspension.</small></p>";
 
+$l['suspend_privatemessaging'] = "Suspend Private Messaging";
+$l['suspend_pm_info'] = "Suspend {1} from sending/receiving private messages.";
+
 $l['suspendsignature_error'] = "You selected to suspend this user's signature, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['moderateposting_error'] = "You selected to moderate this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendposting_error'] = "You selected to suspend this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";

--- a/inc/languages/english/modcp.lang.php
+++ b/inc/languages/english/modcp.lang.php
@@ -250,16 +250,20 @@ $l['suspend_posts'] = "Suspend this user's posting privileges";
 $l['suspend_pm'] = "Suspend this user's private messaging privileges";
 $l['modpost_length'] = "Moderate for:";
 $l['suspost_length'] = "Suspend for:";
+$l['suspm_length'] = "Suspend for:";
 
 $l['moderateposts_for'] = "Moderated until {1}.<br />Untick this option to remove, or extend below.";
 $l['suspendposting_for'] = "Suspended until {1}.<br />Untick this option to remove, or extend below.";
 $l['suspendsignature_for'] = "Suspended until {1}.<br />Untick this option to remove, or extend below.";
+$l['suspendpm_for'] = "Suspended until {1}.<br />Untick this option to remove, or extend below.";
 $l['suspendposting_perm'] = "Suspended permanently.<br />Untick this option to remove, or change below.";
 $l['moderateposts_perm'] = "Moderated permanently.<br />Untick this option to remove, or change below.";
 $l['suspendsignature_perm'] = "Suspended permanently.<br />Untick this option to remove, or change below.";
+$l['suspendpm_perm'] = "Suspended permanently.<br />Untick this option to remove, or change below.";
 $l['suspendsignature_error'] = "You selected to suspend this user's signature, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['moderateposting_error'] = "You selected to moderate this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendposting_error'] = "You selected to suspend this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
+$l['suspendpm_error'] = "You selected to suspend this user's private messaging, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendmoderate_error'] = "You've selected to suspend and moderate the user's posts. Please select only one type of moderation.";
 
 $l['expire_hours'] = "hour(s)";

--- a/inc/languages/english/modcp.lang.php
+++ b/inc/languages/english/modcp.lang.php
@@ -247,6 +247,7 @@ $l['mod_notes'] = "Moderator Notes";
 $l['moderation'] = "Moderator Options";
 $l['moderate_posts'] = "Moderate this user's posts";
 $l['suspend_posts'] = "Suspend this user's posting privileges";
+$l['suspend_pm'] = "Suspend this user's private messaging privileges";
 $l['modpost_length'] = "Moderate for:";
 $l['suspost_length'] = "Suspend for:";
 

--- a/inc/tasks/usercleanup.php
+++ b/inc/tasks/usercleanup.php
@@ -19,7 +19,7 @@ function task_usercleanup($task)
 	$warningshandler->expire_warnings();
 
 	// Expire any post moderation or suspension limits
-	$query = $db->simple_select("users", "uid, moderationtime, suspensiontime", "(moderationtime!=0 AND moderationtime<".TIME_NOW.") OR (suspensiontime!=0 AND suspensiontime<".TIME_NOW.")");
+	$query = $db->simple_select("users", "uid, moderationtime, suspensiontime, pmsuspensiontime", "(moderationtime!=0 AND moderationtime<".TIME_NOW.") OR (suspensiontime!=0 AND suspensiontime<".TIME_NOW.") OR (pmsuspensiontime!=0 AND pmsuspensiontime<".TIME_NOW.")");
 	while($user = $db->fetch_array($query))
 	{
 		$updated_user = array();
@@ -32,6 +32,11 @@ function task_usercleanup($task)
 		{
 			$updated_user['suspendposting'] = 0;
 			$updated_user['suspensiontime'] = 0;
+		}
+		if($user['pmsuspensiontime'] != 0 && $user['pmsuspensiontime'] < TIME_NOW)
+		{
+			$updated_user['suspendpm'] = 0;
+			$updated_user['pmsuspensiontime'] = 0;
 		}
 		$db->update_query("users", $updated_user, "uid='{$user['uid']}'");
 	}

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -6926,34 +6926,51 @@ if(use_xmlhttprequest == "1")
 									<table cellspacing="0" cellpadding="{$theme['tablespace']}" width="100%">
 										<tr>
 											<td>
-<dl style="margin-top: 0; margin-bottom: 0;">
-<dt><label><input type="checkbox" name="moderateposting" value="1" {$modpost_checked} class="checkbox" onclick="toggleSuspend('modposts');" id="modpost" /> {$lang->moderate_posts}</label></dt>
-<dd style="margin-top: 4px;" id="modposts_action">
-<table cellpadding="4">
-{$moderateposts_info}
-	<tr>
-		<td width="35%">{$lang->modpost_length}</td>
-		<td><input type="text" name="modpost_time" value="{$modpost_time}" class="textbox" style="width: 2em;" /> {$modpost_options}</td>
-	</tr>
-</table>
-</dd>
-</dl>
+												<dl style="margin-top: 0; margin-bottom: 0;">
+													<dt><label><input type="checkbox" name="moderateposting" value="1" {$modpost_checked} class="checkbox" onclick="toggleSuspend('modposts');" id="modpost" /> {$lang->moderate_posts}</label></dt>
+													<dd style="margin-top: 4px;" id="modposts_action">
+														<table cellpadding="4">
+														{$moderateposts_info}
+															<tr>
+																<td width="35%">{$lang->modpost_length}</td>
+																<td><input type="text" name="modpost_time" value="{$modpost_time}" class="textbox" style="width: 2em;" /> {$modpost_options}</td>
+															</tr>
+														</table>
+													</dd>
+												</dl>
 											</td>
 										</tr>
 										<tr>
 											<td>
-<dl style="margin-top: 0; margin-bottom: 0;">
-<dt><label><input type="checkbox" name="suspendposting" value="1" {$suspost_checked} class="checkbox" onclick="toggleSuspend('susposts');" id="suspost" /> {$lang->suspend_posts}</label></dt>
-<dd style="margin-top: 4px;" id="susposts_action">
-<table cellpadding="4">
-{$suspendposting_info}
-	<tr>
-		<td width="35%">{$lang->suspost_length}</td>
-		<td><input type="text" name="suspost_time" value="{$suspost_time}" class="textbox" style="width: 2em;" /> {$suspost_options}</td>
-	</tr>
-</table>
-</dd>
-</dl></td>
+												<dl style="margin-top: 0; margin-bottom: 0;">
+													<dt><label><input type="checkbox" name="suspendposting" value="1" {$suspost_checked} class="checkbox" onclick="toggleSuspend('susposts');" id="suspost" /> {$lang->suspend_posts}</label></dt>
+													<dd style="margin-top: 4px;" id="susposts_action">
+														<table cellpadding="4">
+														{$suspendposting_info}
+															<tr>
+																<td width="35%">{$lang->suspost_length}</td>
+																<td><input type="text" name="suspost_time" value="{$suspost_time}" class="textbox" style="width: 2em;" /> {$suspost_options}</td>
+															</tr>
+														</table>
+													</dd>
+												</dl>
+											</td>
+										</tr>
+										<tr>
+											<td>
+												<dl style="margin-top: 0; margin-bottom: 0;">
+													<dt><label><input type="checkbox" name="suspendprivatemessaging" value="1" {$suspm_checked} class="checkbox" onclick="toggleSuspend('suspm');" id="suspm" /> {$lang->suspend_pm}</label></dt>
+													<dd style="margin-top: 4px;" id="suspm_action">
+														<table cellpadding="4">
+														{$suspendpm_info}
+															<tr>
+																<td width="35%">{$lang->suspost_length}</td>
+																<td><input type="text" name="suspm_time" value="{$suspost_time}" class="textbox" style="width: 2em;" /> {$suspm_options}</td>
+															</tr>
+														</table>
+													</dd>
+												</dl>
+											</td>
 										</tr>
 									</table>
 								</fieldset>
@@ -7008,6 +7025,11 @@ if(use_xmlhttprequest == "1")
 		$("#susposts_action").hide();
 	}
 
+	if(susp_pm == 0)
+	{
+		$("#suspm_action").hide();
+	}
+
 	function toggleSuspend(action)
 	{
 		if(action == "modposts")
@@ -7041,6 +7063,20 @@ if(use_xmlhttprequest == "1")
 			{
 				$("#suspost").attr("checked", true);
 				$("#susposts_action").show();
+			}
+		}
+
+		if(action == "suspm")
+		{
+			if($("#suspm").prop("checked") == false)
+			{
+				$("#suspm").attr("checked", false);
+				$("#suspm_action").hide();
+			}
+			else
+			{
+				$("#suspm").attr("checked", true);
+				$("#suspm_action").show();
 			}
 		}
 	}

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -6779,7 +6779,7 @@ if(use_xmlhttprequest == "1")
 </tr>]]></template>
 		<template name="modcp_banuser_lift" version="1801"><![CDATA[<div class="float_right"><a href="modcp.php?action=liftban&amp;uid={$banned['uid']}&amp;my_post_key={$mybb->post_code}">{$lang->lift_ban}</a></div>]]></template>
 		<template name="modcp_banuser_liftlist" version="1800"><![CDATA[<option value="{$time}"{$selected}>{$title}{$thattime}</option>]]></template>
-		<template name="modcp_editprofile" version="1822"><![CDATA[<html>
+		<template name="modcp_editprofile" version="1827"><![CDATA[<html>
 <head>
 <title>{$mybb->settings['bbname']} - {$lang->edit_profile}</title>
 {$headerinclude}

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -6787,6 +6787,7 @@ if(use_xmlhttprequest == "1")
 <!--
 	var mod_posts = '{$modpost_check}';
 	var susp_posts = '{$suspost_check}';
+	var susp_pm = '{$suspm_check}';
 // -->
 </script>
 </head>
@@ -6982,13 +6983,13 @@ if(use_xmlhttprequest == "1")
 								<fieldset class="trow1">
 									<legend><strong>{$lang->signature}</strong></legend>
 									<table cellspacing="0" cellpadding="{$theme['tablespace']}">
-<tr>
-<td class="trow1" width="80%">
-<textarea rows="15" cols="70" id="signature" name="signature">{$user['signature']}</textarea>
-{$codebuttons}
-</td>
-</tr>
-{$suspend_signature}
+										<tr>
+											<td class="trow1" width="80%">
+												<textarea rows="15" cols="70" id="signature" name="signature">{$user['signature']}</textarea>
+												{$codebuttons}
+											</td>
+										</tr>
+										{$suspend_signature}
 									</table>
 								</fieldset>
 							</td>

--- a/install/resources/mysql_db_tables.php
+++ b/install/resources/mysql_db_tables.php
@@ -1128,7 +1128,7 @@ $tables[] = "CREATE TABLE mybb_users (
   suspendsignature tinyint(1) NOT NULL default '0',
   suspendsigtime int unsigned NOT NULL default '0',
   suspendpm tinyint(1) NOT NULL default '0',
-	pmsuspensiontime int unsigned NOT NULL default '0',
+  pmsuspensiontime int unsigned NOT NULL default '0',
   coppauser tinyint(1) NOT NULL default '0',
   classicpostbit tinyint(1) NOT NULL default '0',
   loginattempts smallint(2) unsigned NOT NULL default '0',
@@ -1184,5 +1184,4 @@ $tables[] = "CREATE TABLE mybb_warnings (
 	KEY uid (uid),
 	PRIMARY KEY (wid)
 ) ENGINE=MyISAM;";
-
 

--- a/install/resources/mysql_db_tables.php
+++ b/install/resources/mysql_db_tables.php
@@ -1127,6 +1127,8 @@ $tables[] = "CREATE TABLE mybb_users (
   suspensiontime int unsigned NOT NULL default '0',
   suspendsignature tinyint(1) NOT NULL default '0',
   suspendsigtime int unsigned NOT NULL default '0',
+  suspendpm tinyint(1) NOT NULL default '0',
+	pmsuspensiontime int unsigned NOT NULL default '0',
   coppauser tinyint(1) NOT NULL default '0',
   classicpostbit tinyint(1) NOT NULL default '0',
   loginattempts smallint(2) unsigned NOT NULL default '0',

--- a/install/resources/pgsql_db_tables.php
+++ b/install/resources/pgsql_db_tables.php
@@ -1090,6 +1090,8 @@ $tables[] = "CREATE TABLE mybb_users (
   suspensiontime int NOT NULL default '0',
   suspendsignature smallint NOT NULL default '0',
   suspendsigtime int NOT NULL default '0',
+  suspendpm smallint NOT NULL default '0',
+  pmsuspensiontime int NOT NULL default '0',
   coppauser smallint NOT NULL default '0',
   classicpostbit smallint NOT NULL default '0',
   loginattempts smallint NOT NULL default '0',

--- a/install/resources/sqlite_db_tables.php
+++ b/install/resources/sqlite_db_tables.php
@@ -1011,6 +1011,8 @@ $tables[] = "CREATE TABLE mybb_users (
 	suspensiontime int NOT NULL default '0',
 	suspendsignature tinyint(1) NOT NULL default '0',
 	suspendsigtime int NOT NULL default '0',
+	suspendpm tinyint(1) NOT NULL default '0',
+	pmsuspensiontime int NOT NULL default '0',
 	coppauser tinyint(1) NOT NULL default '0',
 	classicpostbit tinyint(1) NOT NULL default '0',
 	loginattempts smallint(2) NOT NULL default '0',

--- a/modcp.php
+++ b/modcp.php
@@ -2612,7 +2612,7 @@ if($mybb->input['action'] == "do_editprofile")
 			remove_avatars($user['uid']);
 		}
 
-		// Moderator "Options" (suspend signature, suspend/moderate posting)
+		// Moderator "Options" (suspend signature, suspend/moderate posting, suspend private messaging)
 		$moderator_options = array(
 			1 => array(
 				"action" => "suspendsignature", // The moderator action we're performing
@@ -2634,6 +2634,13 @@ if($mybb->input['action'] == "do_editprofile")
 				"time" => "suspost_time",
 				"update_field" => "suspendposting",
 				"update_length" => "suspensiontime"
+			),
+			4 => array(
+				"action" => "suspendprivatemessaging",
+				"period" => "suspm_period",
+				"time" => "suspm_time",
+				"update_field" => "suspendpm",
+				"update_length" => "pmsuspensiontime"
 			)
 		);
 
@@ -2700,7 +2707,7 @@ if($mybb->input['action'] == "do_editprofile")
 
 		// Those with javascript turned off will be able to select both - cheeky!
 		// Check to make sure we're not moderating AND suspending posting
-		if(isset($extra_user_updates) && !empty($extra_user_updates['moderateposts']) && !empty($extra_user_updates['suspendposting']))
+		if(isset($extra_user_updates) && !empty($extra_user_updates['moderateposts']))
 		{
 			$errors[] = $lang->suspendmoderate_error;
 		}
@@ -3151,6 +3158,18 @@ if($mybb->input['action'] == "editprofile")
 		$suspost_checked = '';
 	}
 
+	// Do we mark the suspend posts box?
+	if($user['suspendpm'] || ($mybb->get_input('suspendpm', MyBB::INPUT_INT) && !empty($errors)))
+	{
+		$suspm_check = 1;
+		$suspm_checked = "checked=\"checked\"";
+	}
+	else
+	{
+		$suspm_check = 0;
+		$suspm_checked = '';
+	}
+
 	$moderator_options = array(
 		1 => array(
 			"action" => "suspendsignature", // The input action for this option
@@ -3172,6 +3191,13 @@ if($mybb->input['action'] == "editprofile")
 			"time" => "suspost_time",
 			"length" => "suspensiontime",
 			"select_option" => "suspost"
+		),
+		4 => array(
+			"action" => "suspendprivatemessaging",
+			"option" => "suspendpm",
+			"time" => "suspm_time",
+			"length" => "pmsuspensiontime",
+			"select_option" => "suspendprivatemessaging"
 		)
 	);
 
@@ -3183,8 +3209,8 @@ if($mybb->input['action'] == "editprofile")
 		"never" => $lang->expire_permanent
 	);
 
-	$suspendsignature_info = $moderateposts_info = $suspendposting_info = '';
-	$action_options = $modpost_options = $suspost_options = '';
+	$suspendsignature_info = $moderateposts_info = $suspendposting_info = $suspendpm_info = '';
+	$action_options = $modpost_options = $suspost_options = $suspm_options = '';
 	$modopts = array();
 	foreach($moderator_options as $option)
 	{
@@ -3217,6 +3243,9 @@ if($mybb->input['action'] == "editprofile")
 				case "suspendposting":
 					eval("\$suspendposting_info = \"".$templates->get("modcp_editprofile_suspensions_info")."\";");
 					break;
+				case "suspendpm":
+					eval("\$suspendpm_info = \"".$templates->get("modcp_editprofile_suspensions_info")."\";");
+					break;
 			}
 		}
 
@@ -3248,6 +3277,9 @@ if($mybb->input['action'] == "editprofile")
 				break;
 			case "suspendposting":
 				eval("\$suspost_options = \"".$templates->get("modcp_editprofile_select")."\";");
+				break;
+			case "suspendpm":
+				eval("\$suspm_options = \"".$templates->get("modcp_editprofile_select")."\";");
 				break;
 		}
 	}

--- a/modcp.php
+++ b/modcp.php
@@ -3197,7 +3197,7 @@ if($mybb->input['action'] == "editprofile")
 			"option" => "suspendpm",
 			"time" => "suspm_time",
 			"length" => "pmsuspensiontime",
-			"select_option" => "suspendprivatemessaging"
+			"select_option" => "suspm"
 		)
 	);
 

--- a/modcp.php
+++ b/modcp.php
@@ -3158,7 +3158,7 @@ if($mybb->input['action'] == "editprofile")
 		$suspost_checked = '';
 	}
 
-	// Do we mark the suspend posts box?
+	// Do we mark the suspend pms box?
 	if($user['suspendpm'] || ($mybb->get_input('suspendpm', MyBB::INPUT_INT) && !empty($errors)))
 	{
 		$suspm_check = 1;

--- a/private.php
+++ b/private.php
@@ -37,7 +37,7 @@ if($mybb->settings['enablepms'] == 0)
 	error($lang->pms_disabled);
 }
 
-if($mybb->user['uid'] == '/' || $mybb->user['uid'] == 0 || $mybb->usergroup['canusepms'] == 0)
+if($mybb->user['uid'] == '/' || $mybb->user['uid'] == 0 || $mybb->usergroup['canusepms'] == 0 || $mybb->user['suspendpm'])
 {
 	error_no_permission();
 }


### PR DESCRIPTION
https://community.mybb.com/thread-195240.html

Based on the above-planned feature, the ability to suspend a user's private messaging abilities. If a user is suspended using private messaging, the user can neither send nor receive new private messages.

Options to moderate suspension of PM added both AdminCP and ModCP similar to suspend posts and moderate posts.

_Note: Should also be mentioned, this restricts access to 'private.php', similar to if a usergroup didn't have access to Private Messaging._