### PR TITLE
Add event handler to strip [img] with data uri in SCEditor

### DIFF
--- a/jscripts/post.js
+++ b/jscripts/post.js
@@ -41,6 +41,23 @@ var Post = {
 
 			Post.fileInput.parents().eq(1).hide();
 			Post.dropZone.parents().eq(1).show();
+
+			// prevent SCEditor from inserting [img] with data URI
+			var $message = document.querySelector('#message');
+
+			if ($message !== null) {
+				new MutationObserver(function () {
+					// run once #message is hidden by SCEditor, and the MyBBEditor instance becomes available
+
+					if (typeof MyBBEditor !== 'undefined' && MyBBEditor !== null) {
+						MyBBEditor.bind('valuechanged', function () {
+							MyBBEditor.val(
+								MyBBEditor.val().replace(/\[img]data:[a-z/]+;base64,[A-Za-z0-9+\/]+={0,2}\[\/img]/, '')
+							);
+						});
+					}
+				}).observe($message, {attributes: true});
+			}
 		});
 	},
 

--- a/jscripts/post.js
+++ b/jscripts/post.js
@@ -51,9 +51,12 @@ var Post = {
 
 					if (typeof MyBBEditor !== 'undefined' && MyBBEditor !== null) {
 						MyBBEditor.bind('valuechanged', function () {
-							MyBBEditor.val(
-								MyBBEditor.val().replace(/\[img]data:[a-z/]+;base64,[A-Za-z0-9+\/]+={0,2}\[\/img]/, '')
-							);
+							var oldValue = MyBBEditor.val();
+							var newValue = oldValue.replace(/\[img]data:[a-z/]+;base64,[A-Za-z0-9+\/]+={0,2}\[\/img]/, '');
+
+							if (oldValue !== newValue) {
+								MyBBEditor.val(newValue);
+							}
 						});
 					}
 				}).observe($message, {attributes: true});


### PR DESCRIPTION
Resolves #4078

May result in `[img]data:...[/img]` fragments being deleted when quoting posts (including code fragments).