### PR TITLE
Add `Sec-Fetch-Site` header check as alternative to anti-CSRF token verification on login

### DIFF
--- a/member.php
+++ b/member.php
@@ -1732,7 +1732,12 @@ $do_captcha = $correct = false;
 $inline_errors = "";
 if($mybb->input['action'] == "do_login" && $mybb->request_method == "post")
 {
-    verify_post_check($mybb->get_input('my_post_key'));
+	if(
+		!verify_post_check($mybb->get_input('my_post_key'), true) &&
+		!(isset($_SERVER['HTTP_SEC_FETCH_SITE']) && $_SERVER['HTTP_SEC_FETCH_SITE'] === 'same-origin')
+	) {
+		error($lang->invalid_post_code);
+	}
 
 	$errors = array();
 


### PR DESCRIPTION
Extend the check involving `my_post_key` token verification for `member.php?action=do_login` to also accept requests with the [`Sec-Fetch-Site`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site) header set to `same-origin`.