### PR TITLE
Fix #4468 Collapse issues after rabase

### DIFF
--- a/global.php
+++ b/global.php
@@ -1078,26 +1078,17 @@ if($mybb->user['uid'] && is_banned_email($mybb->user['email']) && $mybb->setting
 
 // work out which items the user has collapsed
 $colcookie = '';
-if(!empty($mybb->cookies['collapsed']))
-{
+if (!empty($mybb->cookies['collapsed'])) {
 	$colcookie = $mybb->cookies['collapsed'];
 }
 
-$collapse = $collapsed = $collapsedimg = array();
-
-if($colcookie)
-{
+$collapsed = [];
+if ($colcookie) {
 	$col = explode("|", $colcookie);
-	if(!is_array($col))
-	{
-		$col[0] = $colcookie; // only one item
-	}
-	unset($collapsed);
-	foreach($col as $key => $val)
-	{
-		$collapsed[$val."_e"] = "display: none;";
-		$collapsedimg[$val] = "_collapsed";
-		$collapsedthead[$val] = " thead_collapsed";
+	if (is_array($col)) {
+		foreach ($col as $key => $val) {
+			$collapsed[$val . "_e"] = true;
+		}
 	}
 }
 

--- a/inc/views/base/forumbit/depth_1/cat.twig
+++ b/inc/views/base/forumbit/depth_1/cat.twig
@@ -1,16 +1,12 @@
-{% if collapsed['cat_' ~ forum.fid ~ '_c'] == 'display: show;' %}
-    {% set expcolhead = ' thead_collapsed' %}
-    {% set expdisplay = 'display: none;' %}
-{% endif %}
-<section class="block collapse {% if collapsed['cat_' ~ forum.fid ~ '_c'] == 'display: show;' %}collapse--collapsed{% else %}collapse--not-collapsed{% endif %}" id="cat__{{ forum.fid }}_img">
+<section class="block collapse {% if collapsed['cat__' ~ forum.fid ~ '_e'] %}collapse--collapsed{% else %}collapse--not-collapsed{% endif %}" id="cat__{{ forum.fid }}">
     <div class="title title--major title--nested">
         <h2 class="title__name"><a href="{{ forum.url }}">{{ forum.name }}</a></h2>
         {% if forum.description %}
             <p class="title__description">{{ forum.description|raw }}</p>
         {% endif %}
         <span class="collapse__toggle">
-            {{ include('partials/icon.twig', {icon: 'minus-square', class: 'collapse__icon collapse__icon--collapse'}, with_context = false) }}
-            {{ include('partials/icon.twig', {icon: 'plus-square', class: 'collapse__icon collapse__icon--expand'}, with_context = false) }}
+            {{ include('partials/icon.twig', {icon: 'minus-square', class: 'collapse__icon collapse__icon--collapse', title: lang.expcol_collapse}, with_context = false) }}
+            {{ include('partials/icon.twig', {icon: 'plus-square', class: 'collapse__icon collapse__icon--expand', title: lang.expcol_expand}, with_context = false) }}
         </span>
     </div>
     <div class="forum-list forum-list--full-width collapse__content">

--- a/inc/views/base/misc/help.twig
+++ b/inc/views/base/misc/help.twig
@@ -10,13 +10,13 @@
             <h1 class="title title--page">{{ lang.help_docs }}</h1>
         </header>
         {% for section in sections %}
-            <section class="block collapse {% if section.expdisplay == 'display: show;' %}collapse--collapsed{% else %}collapse--not-collapsed{% endif %}" id="sid_{{ section.sid }}_img">
+            <section class="block collapse {% if section.collapsed %}collapse--collapsed{% else %}collapse--not-collapsed{% endif %}" id="sid_{{ section.sid }}">
                 <div class="title title--major title--nested">
                     <h1 class="title__name">{{ section.name }}</h1>
                     <p class="title__description">{{ section.description }}</p>
                     <span class="collapse__toggle">
-                        {{ include('partials/icon.twig', {icon: 'minus-square', class: 'collapse__icon collapse__icon--collapse'}, with_context = false) }}
-                        {{ include('partials/icon.twig', {icon: 'plus-square', class: 'collapse__icon collapse__icon--expand'}, with_context = false) }}
+                        {{ include('partials/icon.twig', {icon: 'minus-square', class: 'collapse__icon collapse__icon--collapse', title: lang.expcol_collapse}, with_context = false) }}
+                        {{ include('partials/icon.twig', {icon: 'plus-square', class: 'collapse__icon collapse__icon--expand', title: lang.expcol_expand}, with_context = false) }}
                     </span>
                 </div>
                 <div class="collapse__content">

--- a/jscripts/general.js
+++ b/jscripts/general.js
@@ -11,7 +11,7 @@ var MyBB = {
 
 	pageLoaded: function()
 	{
-		Collapsible.init();
+		expandables.init();
 
 		/* Create the Check All feature */
 		$('[name="allbox"]').each(function(key, value) {
@@ -650,48 +650,42 @@ var Cookie = {
 var expandables = {
 	init: function()
 	{
-		var expanders = $(".expcolimage .expander");
+		var expanders = $(".collapse");
 		if(expanders.length)
 		{
 			expanders.each(function()
 			{
-        		var expander = $(this);
+        var expander = $(this);
 				if(!expander || expander.attr("id") == false)
 				{
 					return;
 				}
 
-				expander.on('click', function()
+				var toggle = $(expander.find('.collapse__toggle')[0]);
+				toggle.on('click', function()
 				{
-					expandables.expandCollapse($(this));
+					expandables.expandCollapse(expander);
 				});
-
-				expander.css("cursor", MyBB.browser == "ie" ? "hand" : "pointer");
 			});
 		}
 	},
 
 	expandCollapse: function(element)
 	{
-		var controls = element.attr("id").replace("_img", ""),
-			expandedItem = $("#"+controls+"_e");
-
-		if(expandedItem.length)
+		var expState = + !element.hasClass("collapse--collapsed");
+		if(expState)
 		{
-			var expState = + !expandedItem.is(":hidden"),
-				expcolImg = element.attr("src"),
-				expText = [lang.expcol_collapse, lang.expcol_expand];
-
-			expandedItem.toggle("fast", this.expCallback(controls, expState));
-
-			element.attr({
-				"alt": expText[expState],
-				"title": expText[expState],
-				"src": expState ? expcolImg.replace('collapse.', 'collapse_collapsed.') : expcolImg.replace('collapse_collapsed.', 'collapse.')
-			})
-			.parents(':eq(1)').toggleClass(element.parents(':eq(1)').hasClass('thead') ? 'thead_collapsed' : 'tcat_collapse_collapsed');
-			this.saveCollapsed(controls, expState);
+			element.removeClass('collapse--not-collapsed');
+			element.addClass('collapse--collapsed');
 		}
+		else
+		{
+			element.removeClass('collapse--collapsed');
+			element.addClass('collapse--not-collapsed');
+		}
+		var id = element.attr('id');
+		this.saveCollapsed(id, expState);
+
 		return true;
 	},
 

--- a/misc.php
+++ b/misc.php
@@ -476,20 +476,7 @@ elseif($mybb->input['action'] == "help")
 						}
 					}
 					$sname = "sid_".$section['sid']."_e";
-					if(isset($collapsed[$sname]) && $collapsed[$sname] == "display: none;")
-					{
-						$section['expcolimage'] = "collapse_collapsed.png";
-						$section['expdisplay'] = "display: none;";
-						$section['expthead'] = " thead_collapsed";
-						$section['expaltext'] = $lang->expcol_expand;
-					}
-					else
-					{
-						$section['expcolimage'] = "collapse.png";
-						$section['expthead'] = '';
-						$section['expdisplay'] = '';
-						$section['expaltext'] = $lang->expcol_collapse;
-					}
+					$section['collapsed'] = isset($collapsed[$sname]) && $collapsed[$sname];
 				}
 
 				$sections[] = $section;


### PR DESCRIPTION
Resolves #4468
Fixes collapses implemented in 1.9 theme.

There are some places in 1.8 theme that use collapses but they are not implemented in twig templates (search for eg. `$collapsedimg`). Idk if we will not use collapses in that places or they are waiting for implementation in templates. If not, we should clean up code from collapses.

