### PR TITLE
Fix #4166 Rework `show_fields_from()` for PostgreSQL and SQLite

### DIFF
--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1146,7 +1146,7 @@ class DB_PgSQL implements DB_Base
 		$primary_key = $this->fetch_field($query, 'column_name');
 
 		$query = $this->write_query("
-			SELECT column_name, data_type, is_nullable, column_default, character_maximum_length
+			SELECT column_name, data_type, is_nullable, column_default, character_maximum_length, numeric_precision, numeric_precision_radix, numeric_scale
 			FROM information_schema.columns
 			WHERE table_name = '{$this->table_prefix}{$table}'
 		");
@@ -1164,9 +1164,15 @@ class DB_PgSQL implements DB_Base
 				$field['_extra'] = '';
 			}
 
+			// bit, character, text fields.
 			if(!is_null($field['character_maximum_length']))
 			{
 				$field['data_type'] .= '('.(int)$field['character_maximum_length'].')';
+			}
+			// numeric/decimal fields.
+			else if($field['numeric_precision_radix'] == 10)
+			{
+				$field['data_type'] .= '('.(int)$field['numeric_precision'].','.(int)$field['numeric_scale'].')';
 			}
 
 			$field_info[] = array(

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1156,11 +1156,18 @@ class DB_PgSQL implements DB_Base
 			if($field['column_name'] == $primary_key)
 			{
 				$field['_key'] = 'PRI';
-				$field['_extra'] = 'auto_increment';
 			}
 			else
 			{
 				$field['_key'] = '';
+			}
+
+			if(stripos($field['column_default'], 'nextval') !== false)
+			{
+				$field['_extra'] = 'auto_increment';
+			}
+			else
+			{
 				$field['_extra'] = '';
 			}
 

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1170,7 +1170,7 @@ class DB_PgSQL implements DB_Base
 				$field['data_type'] .= '('.(int)$field['character_maximum_length'].')';
 			}
 			// numeric/decimal fields.
-			else if($field['numeric_precision_radix'] == 10)
+			else if($field['numeric_precision_radix'] == 10 && !is_null($field['numeric_precision']) && !is_null($field['numeric_scale']))
 			{
 				$field['data_type'] .= '('.(int)$field['numeric_precision'].','.(int)$field['numeric_scale'].')';
 			}

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -411,9 +411,13 @@ HTML;
 		while ($field = $this->fetch_array($query)) {
 			if($field['column_name'] == $primary_key) {
 				$field['_key'] = 'PRI';
-				$field['_extra'] = 'auto_increment';
 			} else {
 				$field['_key'] = '';
+			}
+
+			if(stripos($field['column_default'], 'nextval') !== false) {
+				$field['_extra'] = 'auto_increment';
+			} else {
 				$field['_extra'] = '';
 			}
 

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -422,7 +422,7 @@ HTML;
 				$field['data_type'] .= '('.(int)$field['character_maximum_length'].')';
 			}
 			// numeric/decimal fields.
-			else if($field['numeric_precision_radix'] == 10) {
+			else if($field['numeric_precision_radix'] == 10 && !is_null($field['numeric_precision']) && !is_null($field['numeric_scale'])) {
 				$field['data_type'] .= '('.(int)$field['numeric_precision'].','.(int)$field['numeric_scale'].')';
 			}
 

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -402,7 +402,7 @@ HTML;
 		$primary_key = $this->fetch_field($query, 'column_name');
 
 		$query = $this->write_query("
-			SELECT column_name, data_type, is_nullable, column_default, character_maximum_length
+			SELECT column_name, data_type, is_nullable, column_default, character_maximum_length, numeric_precision, numeric_precision_radix, numeric_scale
 			FROM information_schema.columns
 			WHERE table_name = '{$this->table_prefix}{$table}'
 		");
@@ -417,8 +417,13 @@ HTML;
 				$field['_extra'] = '';
 			}
 
+			// bit, character, text fields.
 			if(!is_null($field['character_maximum_length'])) {
 				$field['data_type'] .= '('.(int)$field['character_maximum_length'].')';
+			}
+			// numeric/decimal fields.
+			else if($field['numeric_precision_radix'] == 10) {
+				$field['data_type'] .= '('.(int)$field['numeric_precision'].','.(int)$field['numeric_scale'].')';
 			}
 
 			$field_info[] = array(

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -409,24 +409,24 @@ HTML;
 
 		$field_info = array();
 		while ($field = $this->fetch_array($query)) {
-			if($field['column_name'] == $primary_key) {
+			if ($field['column_name'] == $primary_key) {
 				$field['_key'] = 'PRI';
 			} else {
 				$field['_key'] = '';
 			}
 
-			if(stripos($field['column_default'], 'nextval') !== false) {
+			if (stripos($field['column_default'], 'nextval') !== false) {
 				$field['_extra'] = 'auto_increment';
 			} else {
 				$field['_extra'] = '';
 			}
 
 			// bit, character, text fields.
-			if(!is_null($field['character_maximum_length'])) {
+			if (!is_null($field['character_maximum_length'])) {
 				$field['data_type'] .= '('.(int)$field['character_maximum_length'].')';
 			}
 			// numeric/decimal fields.
-			else if($field['numeric_precision_radix'] == 10 && !is_null($field['numeric_precision']) && !is_null($field['numeric_scale'])) {
+			else if ($field['numeric_precision_radix'] == 10 && !is_null($field['numeric_precision']) && !is_null($field['numeric_scale'])) {
 				$field['data_type'] .= '('.(int)$field['numeric_precision'].','.(int)$field['numeric_scale'].')';
 			}
 

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -402,18 +402,33 @@ HTML;
 		$primary_key = $this->fetch_field($query, 'column_name');
 
 		$query = $this->write_query("
-			SELECT column_name as Field, data_type as Extra
+			SELECT column_name, data_type, is_nullable, column_default, character_maximum_length
 			FROM information_schema.columns
 			WHERE table_name = '{$this->table_prefix}{$table}'
 		");
 
 		$field_info = array();
 		while ($field = $this->fetch_array($query)) {
-			if ($field['field'] == $primary_key) {
-				$field['extra'] = 'auto_increment';
+			if($field['column_name'] == $primary_key) {
+				$field['_key'] = 'PRI';
+				$field['_extra'] = 'auto_increment';
+			} else {
+				$field['_key'] = '';
+				$field['_extra'] = '';
 			}
 
-			$field_info[] = array('Extra' => $field['extra'], 'Field' => $field['field']);
+			if(!is_null($field['character_maximum_length'])) {
+				$field['data_type'] .= '('.(int)$field['character_maximum_length'].')';
+			}
+
+			$field_info[] = array(
+				'Field' => $field['column_name'],
+				'Type' => $field['data_type'],
+				'Null' => $field['is_nullable'],
+				'Key' => $field['_key'],
+				'Default' => $field['column_default'],
+				'Extra' => $field['_extra'],
+			);
 		}
 
 		return $field_info;

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -963,13 +963,10 @@ class DB_SQLite implements DB_Base
 	 */
 	function show_fields_from($table)
 	{
-		global $db;
-
-		$query = $db->write_query("PRAGMA TABLE_INFO('".$db->table_prefix.$table."')");
+		$query = $this->write_query("PRAGMA TABLE_INFO('".$this->table_prefix.$table."')");
 		$field_info = array();
-		while($field = $db->fetch_array($query))
+		while($field = $this->fetch_array($query))
 		{
-			// The pk field may not exist in early SQLite 3.x versions.
 			if(!empty($field['pk']))
 			{
 				$field['_key'] = 'PRI';
@@ -981,7 +978,7 @@ class DB_SQLite implements DB_Base
 				$field['_extra'] = '';
 			}
 
-			// SQLite allows NULLs in most PRIMARY KEY columns due to a bug in early versions, even in an INTEGER PRIMARY KEY column, read https://sqlite.org/lang_createtable.html for details. We won't fix this for consistency among other DBMS.
+			// SQLite allows NULLs in most PRIMARY KEY columns due to a bug in early versions, even in an INTEGER PRIMARY KEY column, read https://sqlite.org/lang_createtable.html for details. We won't fix this for consistency among other database engines.
 			$field['_nullable'] = $field['notnull'] ? 'NO' : 'YES';
 
 			$field_info[] = array(
@@ -993,6 +990,7 @@ class DB_SQLite implements DB_Base
 				'Extra' => $field['_extra'],
 			);
 		}
+		$query->closeCursor();
 		return $field_info;
 	}
 

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -963,25 +963,36 @@ class DB_SQLite implements DB_Base
 	 */
 	function show_fields_from($table)
 	{
-		$old_tbl_prefix = $this->table_prefix;
-		$this->set_table_prefix("");
-		$query = $this->simple_select("sqlite_master", "sql", "type = 'table' AND name = '{$old_tbl_prefix}{$table}'");
-		$this->set_table_prefix($old_tbl_prefix);
-		$table = trim(preg_replace('#CREATE\s+TABLE\s+"?'.$this->table_prefix.$table.'"?#i', '', $this->fetch_field($query, "sql")));
-		$query->closeCursor();
+		global $db;
 
-		preg_match('#\((.*)\)#s', $table, $matches);
-
+		$query = $db->write_query("PRAGMA TABLE_INFO('".$db->table_prefix.$table."')");
 		$field_info = array();
-		$table_cols = explode(',', trim($matches[1]));
-		foreach($table_cols as $declaration)
+		while($field = $db->fetch_array($query))
 		{
-			$entities = preg_split('#\s+#', trim($declaration));
-			$column_name = preg_replace('/"?([^"]+)"?/', '\1', $entities[0]);
+			// The pk field may not exist in early SQLite 3.x versions.
+			if(!empty($field['pk']))
+			{
+				$field['_key'] = 'PRI';
+				$field['_extra'] = 'auto_increment';
+			}
+			else
+			{
+				$field['_key'] = '';
+				$field['_extra'] = '';
+			}
 
-			$field_info[] = array('Extra' => $entities[1], 'Field' => $column_name);
+			// SQLite allows NULLs in most PRIMARY KEY columns due to a bug in early versions, even in an INTEGER PRIMARY KEY column, read https://sqlite.org/lang_createtable.html for details. We won't fix this for consistency among other DBMS.
+			$field['_nullable'] = $field['notnull'] ? 'NO' : 'YES';
+
+			$field_info[] = array(
+				'Field' => $field['name'],
+				'Type' => $field['type'],
+				'Null' => $field['_nullable'],
+				'Key' => $field['_key'],
+				'Default' => $field['dflt_value'],
+				'Extra' => $field['_extra'],
+			);
 		}
-
 		return $field_info;
 	}
 


### PR DESCRIPTION
Resolves #4166.
It's a work-in-progress PR but already committed changes can be reviewed. The remaining work may involve refine existing usings this function in MyBB.

In the PR, the function `show_fields_from()`'s returns for PostgreSQL and SQLite are made to have the same array keys as MySQL's, and with the following changes:
 - PostgreSQL's are fetched from `information_schema`
 - SQLite's are fetched using `PRAGMA table_info()`, primary key and auto_increment info are determined by `INTEGER PRIMARY KEY` type.
 - PostgreSQL's character varying /bit types will further have their length limit `n` appended to their types with parenthesises `(n)`.
 - PostgreSQL's numeric/decimal types will further have their precision `p` and scale `s` appended to their types with parenthesises `(p,s)`.

**Notes:**
 - The function doesn't return unified data types and default values across database engines. It just returns results from PostgreSQL's `information_schema` and SQLite's `PRAGMA table_info()` as  stated above. For example, for `VARCHAR` type, MySQL's may return `varchar` and PostgreSQL's may return `character varying`.
 - SQLite's returned data types are the same as how the `CREATE TABLE` statement defined, not the data type class or affinity explained [here](https://sqlite.org/datatype3.html).
