### PR TITLE
Fixes #4502 Sequence dropping in `drop_table()` of PostgreSQL and table prefix in `drop_table()` of PostgreSQL and SQLite

### DIFF
--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1272,7 +1272,7 @@ class DB_PgSQL implements DB_Base
 		}
 
 		$table_prefix_bak = $this->table_prefix;
-		$this->table_prefix = $table_prefix;
+		$this->table_prefix = '';
 		$fields = array_column($this->show_fields_from($table_prefix.$table), 'Field');
 
 		if($hard == false)

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1271,9 +1271,13 @@ class DB_PgSQL implements DB_Base
 			$table_prefix = $this->table_prefix;
 		}
 
+		$table_prefix_bak = $this->table_prefix;
+		$this->table_prefix = $table_prefix;
+		$fields = array_column($this->show_fields_from($table_prefix.$table), 'Field');
+
 		if($hard == false)
 		{
-			if($this->table_exists($table))
+			if($this->table_exists($table_prefix.$table))
 			{
 				$this->write_query('DROP TABLE '.$table_prefix.$table);
 			}
@@ -1283,13 +1287,30 @@ class DB_PgSQL implements DB_Base
 			$this->write_query('DROP TABLE '.$table_prefix.$table);
 		}
 
-		$query = $this->query("SELECT column_name FROM information_schema.constraint_column_usage WHERE table_name = '{$table}' and constraint_name = '{$table}_pkey' LIMIT 1");
-		$field = $this->fetch_field($query, 'column_name');
+		$this->table_prefix = $table_prefix_bak;
 
-		// Do we not have a primary field?
-		if($field)
+		if(!empty($fields))
 		{
-			$this->write_query('DROP SEQUENCE {$table}_{$field}_id_seq');
+			foreach($fields as &$field)
+			{
+				$field = "{$table_prefix}{$table}_{$field}_seq";
+			}
+			unset($field);
+
+			if(version_compare($this->get_version(), '8.2.0', '>='))
+			{
+				$fields = implode(', ', $fields);
+				$this->write_query("DROP SEQUENCE IF EXISTS {$fields}");
+			}
+			else
+			{
+				$fields = "'".implode("', '", $fields)."'";
+				$query = $this->query("SELECT sequence_name as field FROM information_schema.sequences WHERE sequence_name in ({$fields}) AND sequence_schema = 'public'");
+				while($row = $this->fetch_array($query))
+				{
+					$this->write_query("DROP SEQUENCE {$row['field']}");
+				}
+			}
 		}
 	}
 

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -471,7 +471,7 @@ HTML;
 		}
 
 		$table_prefix_bak = $this->table_prefix;
-		$this->table_prefix = $table_prefix;
+		$this->table_prefix = '';
 		$fields = array_column($this->show_fields_from($table_prefix.$table), 'Field');
 
 		if ($hard == false) {

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -1075,9 +1075,11 @@ class DB_SQLite implements DB_Base
 			$table_prefix = $this->table_prefix;
 		}
 
+		$table_prefix_bak = $this->table_prefix;
+		$this->table_prefix = '';
 		if($hard == false)
 		{
-			if($this->table_exists($table))
+			if($this->table_exists($table_prefix.$table))
 			{
 				$query = $this->query('DROP TABLE '.$table_prefix.$table);
 			}
@@ -1086,6 +1088,7 @@ class DB_SQLite implements DB_Base
 		{
 			$query = $this->query('DROP TABLE '.$table_prefix.$table);
 		}
+		$this->table_prefix = $table_prefix_bak;
 
 		if(isset($query))
 		{


### PR DESCRIPTION
Resolves #4502.

**Note:**
1. `DROP SEQUENCE IF EXISTS` only exists in PostgreSQL 8.2 and higher. When MyBB ever bumps the required PostgreSQL version, this version compare should be changed or removed.
2. The `DROP SEQUENCE` part may be removed in future versions, eventually, when the `mybb_userfields` table related operations are fixed.