### PR TITLE
Fix extra `</li>` in `postParser::mycode_parse_list()`

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1718,8 +1718,12 @@ class postParser
 			$message = "[*]{$message}";
 		}
 
-		$message = preg_replace("#[^\S\n\r]*\[\*\]\s*#", "</li>\n<li>", $message);
-		$message .= "</li>";
+		$message = preg_split("#[^\S\n\r]*\[\*\]\s*#", $message);
+		if(isset($message[0]) && trim($message[0]) == '')
+		{
+			array_shift($message);
+		}
+		$message = '<li>'.implode("</li>\n<li>", $message)."</li>\n";
 
 		if($type)
 		{


### PR DESCRIPTION
Resolves #3128 for the 1.9 branch

Applies changes introduced via https://github.com/mybb/mybb/commit/9c6d509021b3772ffdc4a0c51f77c5ba94e4e7cc, likely missed in a rebase



