### PR TITLE
Fix #4522: Banned users see only "Unknown" and "Never"

### DIFF
--- a/global.php
+++ b/global.php
@@ -725,6 +725,8 @@ if(isset($lang->settings['charset']) && $lang->settings['charset'])
 $bannedwarning = '';
 if($mybb->usergroup['isbannedgroup'] == 1)
 {
+	$query = $db->simple_select('banned', '*', "uid='{$mybb->user['uid']}'");
+	$ban = $db->fetch_array($query);
 	// Format their ban lift date and reason appropriately
 	if(!empty($mybb->user['banned']))
 	{


### PR DESCRIPTION
Resolves #4522.

A missing query means that the only reason ever shown to a banned user for the ban
is "Unknown", and the only ban lifting time shown is "Never".

This PR supplies the missing query.

[Unfortunately, I committed this as fixing issue 4552 instead of issue 4522. Apologies for the mix-up.]