### PR TITLE
Add escaping to Setting names, Group titles in ACP's Settings module

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1404,6 +1404,8 @@ if($mybb->input['action'] == "change")
 			$groupinfo['title'] = $lang->$group_lang_var;
 		}
 
+		$groupinfo['title'] = htmlspecialchars_uni($groupinfo['title']);
+
 		// Page header
 		$page->add_breadcrumb_item($groupinfo['title']);
 		$page->output_header($lang->board_settings." - {$groupinfo['title']}");
@@ -1447,6 +1449,8 @@ if($mybb->input['action'] == "change")
 			$groupinfo['title'] = $lang->$group_lang_var;
 		}
 
+		$groupinfo['title'] = htmlspecialchars_uni($groupinfo['title']);
+
 		$form_container = new FormContainer($groupinfo['title']);
 
 		if(empty($cache_settings[$groupinfo['gid']]))
@@ -1462,6 +1466,8 @@ if($mybb->input['action'] == "change")
 
 		foreach($cache_settings[$groupinfo['gid']] as $setting)
 		{
+			$setting['name'] = htmlspecialchars_uni($setting['name']);
+
 			$options = "";
 			$type = explode("\n", $setting['optionscode']);
 			$type[0] = trim($type[0]);


### PR DESCRIPTION
Partially resolves .#3126

Not considered a vulnerability given HTML support in other fields in the same module (e.g. _Description_).

h/t @shandymen

---
To report suspected security issues, contact the MyBB Team privately: [mybb.com/security](https://mybb.com/security).