### PR TITLE
Set `SameSite=Strict` for ACP authentication cookie

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -296,7 +296,7 @@ elseif($mybb->input['do'] == "login")
 			$db->update_query("adminoptions", array("loginattempts" => 0, "loginlockoutexpiry" => 0), "uid='{$mybb->user['uid']}'");
 		}
 
-		my_setcookie("adminsid", $sid, '', true, "lax");
+		my_setcookie("adminsid", $sid, '', true, "strict");
 		my_setcookie('acploginattempts', 0);
 		$post_verify = false;
 

--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1283,7 +1283,7 @@ if($mybb->input['action'] == "change")
 		{
 			my_unsetcookie("adminsid");
 			$mybb->settings['cookieprefix'] = $mybb->input['upsetting']['cookieprefix'];
-			my_setcookie("adminsid", $admin_session['sid'], '', true, "lax");
+			my_setcookie("adminsid", $admin_session['sid'], '', true, "strict");
 		}
 
 		if(isset($mybb->input['upsetting']['statstopreferrer']) && $mybb->input['upsetting']['statstopreferrer'] != $mybb->settings['statstopreferrer'])


### PR DESCRIPTION
Resolves #4543

