### PR TITLE
Use `DB_Base::escape_binary()` instead of `DB_Base::escape_string()` for IP columns

### DIFF
--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -1411,11 +1411,11 @@ class UserDataHandler extends DataHandler
 		}
 		if(isset($user['regip']))
 		{
-			$this->user_update_data['regip'] = $db->escape_string($user['regip']);
+			$this->user_update_data['regip'] = $db->escape_binary($user['regip']);
 		}
 		if(isset($user['lastip']))
 		{
-			$this->user_update_data['lastip'] = $db->escape_string($user['lastip']);
+			$this->user_update_data['lastip'] = $db->escape_binary($user['lastip']);
 		}
 		if(isset($user['language']))
 		{


### PR DESCRIPTION
Resolves #4484