### PR TITLE
Add support for `ON CONFLICT` clause in PostgreSQL PDO driver

### DIFF
--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -719,6 +719,70 @@ HTML;
 		return $fieldstring;
 	}
 
+	/**
+	 * @param string $table
+	 * @param array $array
+	 * @param bool $no_quote
+	 *
+	 * @return string
+	 */
+	protected function build_field_value_string($table, $array, $no_quote = false)
+	{
+		global $mybb;
+
+		$strings = array();
+
+		if ($no_quote == true)
+		{
+			$quote = "";
+		}
+		else
+		{
+			$quote = "'";
+		}
+
+		foreach($array as $field => $value)
+		{
+			if(!isset($mybb->binary_fields[$table][$field]) || !$mybb->binary_fields[$table][$field])
+			{
+				$value = $this->quote_val($value, $quote);
+			}
+
+			$strings[] = "{$field}={$value}";
+		}
+
+		$string = implode(', ', $strings);
+
+		return $string;
+	}
+
+	/**
+	 * @param string $table
+	 * @param array $array
+	 *
+	 * @return string
+	 */
+	protected function build_value_string($table, $array)
+	{
+		global $mybb;
+
+		$values = array();
+
+		foreach($array as $field => $value)
+		{
+			if(!isset($mybb->binary_fields[$table][$field]) || !$mybb->binary_fields[$table][$field])
+			{
+				$value = $this->quote_val($value);
+			}
+
+			$values[$field] = $value;
+		}
+
+		$string = implode(",", $values);
+
+		return $string;
+	}
+
 	public function __set($name, $value)
 	{
 		if ($name === 'type') {

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -180,22 +180,13 @@ HTML;
 
 	public function insert_query($table, $array)
 	{
-		global $mybb;
-
 		if (!is_array($array)) {
 			return false;
 		}
 
-		foreach ($array as $field => $value) {
-			if (isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
-				$array[$field] = $value;
-			} else {
-				$array[$field] = $this->quote_val($value);
-			}
-		}
+		$values = $this->build_value_string($table, $array);
 
 		$fields = implode(",", array_keys($array));
-		$values = implode(",", $array);
 		$this->write_query("
 			INSERT
 			INTO {$this->table_prefix}{$table} ({$fields})
@@ -216,8 +207,6 @@ HTML;
 
 	public function insert_query_multiple($table, $array)
 	{
-		global $mybb;
-
 		if (!is_array($array)){
 			return;
 		}
@@ -228,15 +217,7 @@ HTML;
 
 		$insert_rows = array();
 		foreach ($array as $values) {
-			foreach ($values as $field => $value) {
-				if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
-					$values[$field] = $value;
-				} else {
-					$values[$field] = $this->quote_val($value);
-				}
-			}
-
-			$insert_rows[] = "(".implode(",", $values).")";
+			$insert_rows[] = "(".$this->build_value_string($table, $values).")";
 		}
 
 		$insert_rows = implode(", ", $insert_rows);
@@ -256,25 +237,7 @@ HTML;
 			return false;
 		}
 
-		$comma = "";
-		$query = "";
-		$quote = "'";
-
-		if ($no_quote == true) {
-			$quote = "";
-		}
-
-		foreach($array as $field => $value) {
-			if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
-				$query .= "{$comma}{$field}={$value}";
-			} else {
-				$quoted_value = $this->quote_val($value, $quote);
-
-				$query .= "{$comma}{$field}={$quoted_value}";
-			}
-
-			$comma = ', ';
-		}
+		$query = $this->build_field_value_string($table, $array, $no_quote);
 
 		if(!empty($where)) {
 			$query .= " WHERE {$where}";

--- a/install/resources/pgsql_db_tables.php
+++ b/install/resources/pgsql_db_tables.php
@@ -304,7 +304,8 @@ $tables[] = "CREATE TABLE mybb_forums (
 $tables[] = "CREATE TABLE mybb_forumsread (
   fid int NOT NULL default '0',
   uid int NOT NULL default '0',
-  dateline int NOT NULL default '0'
+  dateline int NOT NULL default '0',
+  UNIQUE (fid, uid)
 );";
 
 $tables[] = "CREATE TABLE mybb_forumsubscriptions (
@@ -887,7 +888,8 @@ $tables[] = "CREATE TABLE mybb_threads (
 $tables[] = "CREATE TABLE mybb_threadsread (
   tid int NOT NULL default '0',
   uid int NOT NULL default '0',
-  dateline int NOT NULL default '0'
+  dateline int NOT NULL default '0',
+  UNIQUE (tid, uid)
 );";
 
 $tables[] = "CREATE TABLE mybb_threadsubscriptions (

--- a/install/resources/upgrade56.php
+++ b/install/resources/upgrade56.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * MyBB 1.8
+ * Copyright 2014 MyBB Group, All Rights Reserved
+ *
+ * Website: http://www.mybb.com
+ * License: http://www.mybb.com/about/license
+ *
+ */
+
+/**
+ * Upgrade Script: 1.8.32
+ */
+
+$upgrade_detail = array(
+    "revert_all_templates" => 0,
+    "revert_all_themes" => 0,
+    "revert_all_settings" => 0
+);
+
+@set_time_limit(0);
+
+function upgrade56_dbchanges()
+{
+	global $output, $cache, $db, $mybb;
+
+	$output->print_header("Updating Database");
+
+	echo "<p>Performing necessary upgrade queries...</p>";
+	flush();
+
+	// Add missing PostgreSQL indexes expected for DB_Base::replace_query()
+	if($db->type == 'pgsql')
+	{
+		$parameters = '';
+
+		if(version_compare($db->get_version(), '9.5.0', '>='))
+		{
+			$parameters = "IF NOT EXISTS";
+		}
+
+		$db->write_query("CREATE UNIQUE INDEX {$parameters} fid_uid ON ".TABLE_PREFIX."forumsread (fid, uid)");
+		$db->write_query("CREATE UNIQUE INDEX {$parameters} tid_uid ON ".TABLE_PREFIX."threadsread (tid, uid)");
+	}
+
+	$output->print_contents("<p>Click next to continue with the upgrade process.</p>");
+	$output->print_footer("56_done");
+}


### PR DESCRIPTION
Resolves #4541 for the PDO driver (`PostgresPdoDbDriver`)
Resolves #4568

The helper functions may be later moved to a common class to remove repetitive code in other drivers.

References:
- https://www.postgresql.org/docs/9.5/sql-insert.html
- https://www.postgresql.org/docs/9.5/sql-createindex.html