### PR TITLE
#4618: delete unnecessary punctuation

### DIFF
--- a/inc/themes/core.default/frontend/templates/member/profile.twig
+++ b/inc/themes/core.default/frontend/templates/member/profile.twig
@@ -349,7 +349,7 @@
                         {% endif %}
                         {% for customfield in contactfields %}
                             <li class="list__item">
-                                <span class="list__field">{{ customfield.name }}:</span>
+                                <span class="list__field">{{ customfield.name }}</span>
                                 <span class="list__value">
                                     {% if customfield.ismulti %}
                                         <ul style="margin: 0; padding-left: 15px;">


### PR DESCRIPTION
Resolves #4618 

The colon is already implemented in the list__field class. 

`.list--stats .list__field:after {
  content: ":";
}`

So I deleted it from the code.