### PR TITLE
Fixes broken pagination and unattended `page` input for pagination in various AdminCP modules

### DIFF
--- a/admin/modules/forum/moderation_queue.php
+++ b/admin/modules/forum/moderation_queue.php
@@ -309,9 +309,10 @@ if($mybb->get_input('type') == "posts" || $mybb->get_input('type') == "")
 	{
 		// Figure out if we need to display multiple pages.
 		$per_page = 15;
-		if($mybb->get_input('page') > 0)
+		$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
+		if($mybb->input['page'] > 0)
 		{
-			$current_page = $mybb->get_input('page', MyBB::INPUT_INT);
+			$current_page = $mybb->input['page'];
 			$start = ($current_page-1)*$per_page;
 			$pages = $unapproved_posts / $per_page;
 			$pages = ceil($pages);
@@ -461,9 +462,10 @@ if($mybb->get_input('type') == "attachments" || $mybb->get_input('type') == "")
 	{
 		// Figure out if we need to display multiple pages.
 		$per_page = 15;
+		$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
 		if($mybb->input['page'] > 0)
 		{
-			$current_page = $mybb->get_input('page', MyBB::INPUT_INT);
+			$current_page = $mybb->input['page'];
 			$start = ($current_page-1)*$per_page;
 			$pages = $unapproved_attachments / $per_page;
 			$pages = ceil($pages);

--- a/admin/modules/tools/mailerrors.php
+++ b/admin/modules/tools/mailerrors.php
@@ -138,9 +138,9 @@ if(!$mybb->input['action'])
 
 	$per_page = 20;
 
-	if(!empty($mybb->input['page']) && $mybb->input['page'] > 1)
+	$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
+	if($mybb->input['page'] > 1)
 	{
-		$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
 		$start = ($mybb->input['page']*$per_page)-$per_page;
 		$pages = ceil($total_rows / $per_page);
 		if($mybb->input['page'] > $pages)
@@ -251,7 +251,7 @@ if(!$mybb->input['action'])
 
 	$form->end();
 
-	echo "<br />".draw_admin_pagination($mybb->get_input('page'), $per_page, $total_rows, "index.php?module=tools-mailerrors&amp;page={page}{$additional_criteria}");
+	echo "<br />".draw_admin_pagination($mybb->input['page'], $per_page, $total_rows, "index.php?module=tools-mailerrors&amp;page={page}{$additional_criteria}");
 
 	$form = new Form("index.php?module=tools-mailerrors", "post");
 	$form_container = new FormContainer($lang->filter_system_email_log);

--- a/admin/modules/tools/maillogs.php
+++ b/admin/modules/tools/maillogs.php
@@ -134,9 +134,9 @@ if(!$mybb->input['action'])
 		$per_page = 20;
 	}
 
-	if(!empty($mybb->input['page']) && $mybb->input['page'] > 1)
+	$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
+	if($mybb->input['page'] > 1)
 	{
-		$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
 		$start = ($mybb->input['page']*$per_page)-$per_page;
 		$pages = ceil($total_rows / $per_page);
 		if($mybb->input['page'] > $pages)
@@ -400,7 +400,7 @@ if(!$mybb->input['action'])
 
 	$form->end();
 
-	echo "<br />".draw_admin_pagination($mybb->get_input('page'), $per_page, $total_rows, "index.php?module=tools-maillogs&amp;page={page}{$additional_criteria}");
+	echo "<br />".draw_admin_pagination($mybb->input['page'], $per_page, $total_rows, "index.php?module=tools-maillogs&amp;page={page}{$additional_criteria}");
 
 	$form = new Form("index.php?module=tools-maillogs", "post");
 	$form_container = new FormContainer($lang->filter_user_email_log);

--- a/admin/modules/tools/statistics.php
+++ b/admin/modules/tools/statistics.php
@@ -69,9 +69,9 @@ if(!$mybb->input['action'])
 
 	$last_dateline = 0;
 
-	if(!empty($mybb->input['page']) && $mybb->input['page'] > 1)
+	$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
+	if($mybb->input['page'] > 1)
 	{
-		$mybb->input['page'] = $mybb->get_input('page', MyBB::INPUT_INT);
 		$start = ($mybb->input['page']*$per_page)-$per_page;
 	}
 	else

--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -238,30 +238,28 @@ if($mybb->input['action'] == "join_requests")
 	$num_requests = $db->fetch_field($query, "num_requests");
 
 	$per_page = 20;
-
-	if($mybb->input['page'] > 0)
+	$pagenum = $mybb->get_input('page', MyBB::INPUT_INT);
+	if($pagenum)
 	{
-		$current_page = $mybb->get_input('page', MyBB::INPUT_INT);
-		$start = ($current_page-1)*$per_page;
-		$pages = $num_requests / $per_page;
-		$pages = ceil($pages);
-		if($current_page > $pages)
+		$start = ($pagenum - 1) * $per_page;
+		$pages = ceil($num_requests / $per_page);
+		if($pagenum > $pages)
 		{
 			$start = 0;
-			$current_page = 1;
+			$pagenum = 1;
 		}
 	}
 	else
 	{
 		$start = 0;
-		$current_page = 1;
+		$pagenum = 1;
 	}
 
 	// Do we need to construct the pagination?
 	$pagination = '';
 	if($num_requests > $per_page)
 	{
-		$pagination = draw_admin_pagination($page, $per_page, $num_requests, "index.php?module=user-groups&amp;action=join_requests&gid={$group['gid']}");
+		$pagination = draw_admin_pagination($pagenum, $per_page, $num_requests, "index.php?module=user-groups&amp;action=join_requests&gid={$group['gid']}");
 		echo $pagination;
 	}
 


### PR DESCRIPTION
Resolves #4612.

Remarks:
 - Code style has been changed to follow page number calculations in the respective module or other modules.
 - Following the current way of handling the super global `$_GET` by `class MyBB` (`./inc/class_core.php`):
   - `$mybb->get_input('page', MyBB::INPUT_INT)` would return a non-negative integer (`0, 1, ..., n`), which means the current _page number_ manipulation / calculation in AdminCP modules can be greatly optimized.
   - Operations on either one of `$mybb->get_input('page', MyBB::INPUT_INT)` or `$mybb->input['page']` may change the value of the other.