### PR TITLE
Reworks `fetch_forum_permissions()` to ensure no forum permissions are missing in the returned array

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1681,47 +1681,32 @@ function fetch_forum_permissions($fid, $gid, $groupperms)
 
 	$groups = explode(",", $gid);
 
-	if(empty($fpermcache[$fid])) // This forum has no custom or inherited permissions so lets just return the group permissions
-	{
-		return $groupperms;
-	}
-
 	$current_permissions = array();
 	$only_view_own_threads = 1;
 	$only_reply_own_threads = 1;
 
-	foreach($groups as $gid)
+	if(empty($fpermcache[$fid])) // This forum has no custom or inherited permissions so lets just return the group permissions
 	{
-		if(!empty($groupscache[$gid]))
+		$current_permissions = $groupperms;
+	}
+	else
+	{
+		foreach($groups as $gid)
 		{
-			$level_permissions = array();
-
-			// If our permissions arn't inherited we need to figure them out
-			if(empty($fpermcache[$fid][$gid]))
-			{
-				$parents = explode(',', $forum_cache[$fid]['parentlist']);
-				rsort($parents);
-				if(!empty($parents))
-				{
-					foreach($parents as $parent_id)
-					{
-						if(!empty($fpermcache[$parent_id][$gid]))
-						{
-							$level_permissions = $fpermcache[$parent_id][$gid];
-							break;
-						}
-					}
-				}
-			}
-			else
+			// If this forum has custom or inherited permissions for the currently looped group.
+			if(!empty($fpermcache[$fid][$gid]))
 			{
 				$level_permissions = $fpermcache[$fid][$gid];
 			}
-
-			// If we STILL don't have forum permissions we use the usergroup itself
-			if(empty($level_permissions))
+			// Or, use the group permission instead, if available. Some forum permissions not existing here will be added back later.
+			else if(!empty($groupscache[$gid]))
 			{
 				$level_permissions = $groupscache[$gid];
+			}
+			// No permission is available for the currently looped group, probably we have bad data here.
+			else
+			{
+				continue;
 			}
 
 			foreach($level_permissions as $permission => $access)
@@ -1742,24 +1727,25 @@ function fetch_forum_permissions($fid, $gid, $groupperms)
 				$only_reply_own_threads = 0;
 			}
 		}
+
+		if(count($current_permissions) == 0)
+		{
+			$current_permissions = $groupperms;
+		}
 	}
 
 	// Figure out if we can view more than our own threads
-	if($only_view_own_threads == 0)
+	if($only_view_own_threads == 0 || !isset($current_permissions["canonlyviewownthreads"]))
 	{
 		$current_permissions["canonlyviewownthreads"] = 0;
 	}
 
 	// Figure out if we can reply more than our own threads
-	if($only_reply_own_threads == 0)
+	if($only_reply_own_threads == 0 || !isset($current_permissions["canonlyreplyownthreads"]))
 	{
 		$current_permissions["canonlyreplyownthreads"] = 0;
 	}
 
-	if(count($current_permissions) == 0)
-	{
-		$current_permissions = $groupperms;
-	}
 	return $current_permissions;
 }
 


### PR DESCRIPTION
Resolves #4632.

The function is also refactored for better understanding how forum permissions are worked out for multiple usergroups.