### PR TITLE
Allow shutdown functions/queries to run after non-critical errors

### DIFF
--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -180,7 +180,10 @@ class errorHandler {
 
 		$file = str_replace(MYBB_ROOT, "", $file);
 
-		$this->has_errors = true;
+		if($type == MYBB_SQL || strpos(strtolower($this->error_types[$type]), 'warning') === false)
+		{
+			$this->has_errors = true;
+		}
 
 		// For some reason in the installer this setting is set to "<"
 		$accepted_error_types = array('both', 'error', 'warning', 'none');


### PR DESCRIPTION
Uses the same conditions used in the method code to determine error type.

Resolves #4530
Resolves #4637
Resolves #4678