### PR TITLE
Add CLI support for installation & upgrades

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Application;
+use MyBB\Console\Command\InstallCommand;
+use MyBB\Console\Command\UpgradeCommand;
+
+define("IN_MYBB", 1);
+define("IN_INSTALL", 1);
+define('MINIMUM_PHP_VERSION', '8.1');
+define('MYBB_ROOT', dirname(dirname(__FILE__)) . "/");
+define("INSTALL_ROOT", MYBB_ROOT . "/install/");
+
+if (version_compare(PHP_VERSION, MINIMUM_PHP_VERSION, '<')) {
+    exit('Error: PHP &ge; ' . MINIMUM_PHP_VERSION . ' required (currently running ' . PHP_VERSION . ').');
+}
+
+require_once MYBB_ROOT . 'inc/src/Maintenance/init.php';
+
+$app = new Application('MyBB', MyBB\Application::VERSION);
+
+$app->addCommands([
+    new InstallCommand(),
+    new UpgradeCommand(),
+]);
+
+$app->run();

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "illuminate/hashing": "^9.0",
         "illuminate/routing": "^9.0",
         "laravel/helpers": "^1.6",
+        "symfony/console": "^6.2",
         "twig/twig": "^3.5"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd5fa794417646521ffbcdc169143a65",
+    "content-hash": "da16e8da6c33a7d859b4ee43084512bd",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1429,6 +1429,102 @@
             "time": "2021-10-29T13:26:27+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3e294254f2191762c1d137aed4b94e966965e985",
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.4|^6.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/lock": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-01T08:38:09+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v3.2.0",
             "source": {
@@ -2147,6 +2243,87 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
+                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.27-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-03T14:55:06+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-idn",
             "version": "v1.27.0",
             "source": {
@@ -2630,6 +2807,177 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/routing/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-01T08:38:09+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/aac98028c69df04ee77eb69b96b86ee51fbf4b75",
+                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.3-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-25T10:21:52+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.0"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
+                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -5289,183 +5637,6 @@
             "time": "2022-06-18T07:21:10+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v6.2.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "3e294254f2191762c1d137aed4b94e966965e985"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3e294254f2191762c1d137aed4b94e966965e985",
-                "reference": "3e294254f2191762c1d137aed4b94e966965e985",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.4|^6.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0|2.0|3.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/lock": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Eases the creation of beautiful and testable command line interfaces",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "command line",
-                "console",
-                "terminal"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v6.2.5"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-01-01T08:38:09+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
             "name": "symfony/process",
             "version": "v6.2.5",
             "source": {
@@ -5509,177 +5680,6 @@
             "homepage": "https://symfony.com",
             "support": {
                 "source": "https://github.com/symfony/process/tree/v6.2.5"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-01-01T08:38:09+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v3.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/aac98028c69df04ee77eb69b96b86ee51fbf4b75",
-                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^2.0"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.3-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-25T10:21:52+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v6.2.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
-                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "conflict": {
-                "symfony/translation-contracts": "<2.0"
-            },
-            "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/intl": "^6.2",
-                "symfony/translation-contracts": "^2.0|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/string/tree/v6.2.5"
             },
             "funding": [
                 {

--- a/inc/languages/english/maintenance.lang.php
+++ b/inc/languages/english/maintenance.lang.php
@@ -377,6 +377,27 @@ $l['no_theme_functions_file'] = 'No theme functions file has been found. Make su
 $l['operation_error_title'] = '{1} — Error';
 $l['operation_error_message'] = 'The operation failed. Please check error logs for details.';
 $l['operation_warning_title'] = '{1} — Warning';
+
+// navigation
+$l['retry'] = 'Retry';
+$l['retry_operation_confirm'] = 'Retry operation before proceeding?';
+$l['retry_parameter_input'] = 'Change parameter values?';
+$l['step_finish'] = 'Next';
+$l['step_final_finish'] = 'Finish';
+$l['waiting_for_operation'] = 'Waiting for {1}…';
+$l['waiting_for_operation_hidden'] = 'Waiting…';
+$l['redirecting'] = 'Redirecting…';
+#endregion
+
+#region CLI
+$l['using_env_parameter_value'] = 'Using environment variable <{3}> for {1}';
+$l['using_env_parameter_value_revealed'] = 'Using environment variable <{3}> for {1}: "{2}"';
+
+$l['using_default_parameter_value'] = 'Using default parameter value for {1}';
+$l['using_default_parameter_value_revealed'] = 'Using default parameter value for {1}: "{2}"';
+
+$l['unknown_operation'] = 'Unknown operation "{1}"';
+$l['unknown_parameter'] = 'Unknown process parameter "{1}"';
 #endregion
 
 #region fatal errors

--- a/inc/src/Console/Command/InstallCommand.php
+++ b/inc/src/Console/Command/InstallCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Console\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'install')]
+class InstallCommand extends MaintenanceProcessCommand
+{
+    protected function configure(): void
+    {
+        $this->setDescription('Installs or re-installs MyBB');
+
+        parent::configure();
+    }
+}

--- a/inc/src/Console/Command/MaintenanceProcessCommand.php
+++ b/inc/src/Console/Command/MaintenanceProcessCommand.php
@@ -1,0 +1,875 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Console\Command;
+
+use Illuminate\Support\Arr;
+use MyBB\Maintenance\Process\Helpers as ProcessHelpers;
+use MyBB\Maintenance\Process\Model;
+use MyBB\Maintenance\Process\Runtime;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @psalm-import-type ParameterValues from Model
+ * @psalm-import-type StepPlan from Runtime
+ * @psalm-import-type ParameterPlan from Runtime
+ * @psalm-import-type OperationPlan from Runtime
+ * @psalm-import-type OperationResult from Runtime
+ */
+abstract class MaintenanceProcessCommand extends Command
+{
+    final protected const STEP_SUCCESS = 2;
+    final protected const STEP_FAILURE = 4;
+    final protected const STEP_FAILURE_RETRYABLE = 8;
+
+    final protected const PARAMETER_ORIGIN_DEFAULT = 'default';
+    final protected const PARAMETER_ORIGIN_ENV = 'env';
+    final protected const PARAMETER_ORIGIN_DIRECT = 'direct';
+    final protected const PARAMETER_ORIGIN_INTERACTIVE = 'interactive';
+
+    final protected const PARAMETER_ORIGINS_BY_PRIORITY = [
+        self::PARAMETER_ORIGIN_INTERACTIVE,
+        self::PARAMETER_ORIGIN_DIRECT,
+        self::PARAMETER_ORIGIN_ENV,
+        self::PARAMETER_ORIGIN_DEFAULT,
+    ];
+
+    protected readonly Model $processModel;
+    protected readonly Runtime $processRuntime;
+
+    protected static string $applicationName = 'mybb';
+    protected float $totalOperationRunTime = 0;
+    protected array $directParameterValues;
+    protected bool $useDefaults = false;
+
+    protected \MyLanguage $lang;
+
+    protected InputInterface $input;
+    protected OutputInterface $output;
+    protected SymfonyStyle $io;
+
+    public function __construct(string $name = null)
+    {
+        $this->lang = \MyBB\app(\MyLanguage::class);
+
+        $this->lang->load('maintenance');
+
+        $processModel = Model::getByName(static::getDefaultName());
+
+        if ($processModel === null) {
+            throw new \RuntimeException('Process model file not found');
+        }
+
+        $this->processModel = $processModel;
+
+        parent::__construct($name);
+    }
+
+    /**
+     * Adapts language phrase strings, which may contain HTML, for command line output.
+     */
+    private static function format(string $phrase): string
+    {
+        $phrase = str_replace('<br>', "\n", $phrase);
+        $phrase = strip_tags($phrase);
+
+        return $phrase;
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'operations',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'Run selected operations only (comma-separated)',
+        );
+        $this->addOption(
+            'param',
+            'p',
+            InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            'Specify parameter value (--param name=value)',
+        );
+
+        foreach ($this->processModel->getFlags() as $name => $flag) {
+            $inputNameNormalized = str_replace('_', '-', $flag['inputName']);
+
+            if ($flag['type'] === 'boolean') {
+                $mode = InputOption::VALUE_NONE;
+            } else {
+                $mode = InputOption::VALUE_REQUIRED;
+            }
+
+            $this->addOption($inputNameNormalized, null, $mode, $this->lang->{'flag_' . $name});
+        }
+    }
+
+    /**
+     * @psalm-return Command::SUCCESS|Command::FAILURE
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->setupIO($input, $output);
+
+        try {
+            $this->initializeProcess();
+        } catch (\RuntimeException) {
+            return Command::FAILURE;
+        }
+
+        $result = $this->executeProcess();
+
+        if ($result === true) {
+            return Command::SUCCESS;
+        } else {
+            return Command::FAILURE;
+        }
+    }
+
+    private function setupIO(InputInterface $input, OutputInterface $output): void
+    {
+        $this->input = $input;
+        $this->output = $output;
+        $this->io = new SymfonyStyle($input, $output);
+
+        $output->getFormatter()->setStyle(
+            'meta',
+            new OutputFormatterStyle(null, null, ['bold']),
+        );
+        $output->getFormatter()->setStyle(
+            'signal',
+            new OutputFormatterStyle('cyan'),
+        );
+        $output->getFormatter()->setStyle(
+            'raw',
+            new OutputFormatterStyle('green'),
+        );
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    private function initializeProcess(): void
+    {
+        /** @psalm-suppress InaccessibleProperty (https://github.com/vimeo/psalm/issues/7608) */
+        $this->processRuntime = new Runtime($this->processModel);
+
+        $this->processRuntime->setInterfaceType('cli');
+
+        // flags
+        $this->processRuntime->initializeFlagValues();
+
+        foreach ($this->processModel->getFlags() as $name => $flag) {
+            $inputNameNormalized = str_replace('_', '-', $flag['inputName']);
+
+            $this->processRuntime->setFlagValues([
+                $name => $this->input->getOption($inputNameNormalized),
+            ]);
+        }
+
+        if ($this->processRuntime->flagDirectiveSet(Model::DIRECTIVE_USE_DEFAULTS)) {
+            $this->useDefaults = true;
+        }
+
+        // shortcut flags
+        if ($this->input->hasOption('fast') && $this->input->getOption('fast') === true) {
+            $this->processRuntime->setFlagValues([
+                'development_mode' => true,
+            ]);
+            $this->useDefaults = true;
+        }
+
+        if (!$this->input->isInteractive()) {
+            $this->useDefaults = true;
+        }
+
+        // precondition
+        $preconditionResult = $this->processRuntime->getPreconditionResult();
+
+        if ($preconditionResult !== true) {
+            $this->io->error(
+                static::format($preconditionResult['error']['message'])
+            );
+
+            throw new \RuntimeException();
+        }
+
+        // operation subset
+        /** @var ?string */
+        $operationNamesCsv = $this->input->getOption('operations');
+        $requestedOperationsNames = $this->validateRequestedOperationNamesCsv($operationNamesCsv);
+
+        if ($requestedOperationsNames !== null) {
+            $this->processRuntime->setOperationSubset($requestedOperationsNames);
+        }
+
+        // direct parameters
+        /** @var array */
+        $parameters = $this->input->getOption('param');
+
+        $this->directParameterValues = $this->validateDirectParameters($parameters);
+    }
+
+    private function executeProcess(): bool
+    {
+        $nonInteractiveParameterValueOrigins = [
+            self::PARAMETER_ORIGIN_DIRECT,
+            self::PARAMETER_ORIGIN_ENV,
+        ];
+
+        if ($this->useDefaults) {
+            $nonInteractiveParameterValueOrigins[] = self::PARAMETER_ORIGIN_DEFAULT;
+        }
+
+        $stepPlans = $this->processRuntime->getStepPlans();
+
+        foreach ($stepPlans as $stepPlan) {
+            $stepNonInteractiveParameterValueOrigins = $nonInteractiveParameterValueOrigins;
+
+            do {
+                $stepResult = $this->executeStep($stepPlan, $stepNonInteractiveParameterValueOrigins);
+
+                if ($stepResult === self::STEP_FAILURE) {
+                    return false;
+                }
+
+                // collect parameter values interactively on subsequent attempts
+                $stepNonInteractiveParameterValueOrigins = [];
+            } while ($stepResult === self::STEP_FAILURE_RETRYABLE);
+        }
+
+        $this->finishProcess();
+
+        return true;
+    }
+
+    private function finishProcess(): void
+    {
+        if ($this->processRuntime->getOperationSubset() === null) {
+            $url = $this->processRuntime->getFinishUrl();
+
+            if ($url !== null) {
+                $urlEscaped = OutputFormatter::escape($url);
+
+                $this->io->newLine();
+                $this->io->writeln([
+                    '<href=' . $urlEscaped . '>' . $urlEscaped . '</>',
+                ]);
+                $this->io->newLine();
+            }
+        }
+
+        if ($this->output->isVeryVerbose()) {
+            $timeSeconds = round($this->totalOperationRunTime, 4);
+
+            $this->io->newLine();
+            $this->output->write('<meta>∑(t) = ' . $timeSeconds . ' s</>');
+            $this->io->newLine();
+        }
+    }
+
+    /**
+     * @param StepPlan $stepPlan
+     * @param self::PARAMETER_ORIGIN_*[] $nonInteractiveParameterValueOrigins
+     * @psalm-return self::STEP_*
+     */
+    private function executeStep(array $stepPlan, array $nonInteractiveParameterValueOrigins)
+    {
+        $deferredDefaultParameterValues = [];
+        $unresolvedStepParameters = [];
+
+        $stepParameterPlans = Arr::only(
+            $this->processRuntime->getParameterPlans(),
+            $stepPlan['parameterNames'],
+        );
+
+        $resolvedNonInteractiveParameterValuesByOrigin = $this->initializeStepParameters(
+            Arr::only(
+                $stepParameterPlans,
+                array_keys(
+                    array_filter($this->processRuntime->getParameterValues(), 'is_null')
+                )
+            ),
+            $nonInteractiveParameterValueOrigins,
+            $unresolvedStepParameters,
+            $deferredDefaultParameterValues,
+        );
+
+
+        if ($this->processRuntime->getOperationSubset() === null) {
+            $this->outputStepHeadings(
+                $stepPlan,
+                $unresolvedStepParameters !== [],
+            );
+        }
+
+        $this->outputParameterNotes(
+            $stepParameterPlans,
+            $deferredDefaultParameterValues,
+            $resolvedNonInteractiveParameterValuesByOrigin,
+        );
+
+        if ($this->input->isInteractive()) {
+            $this->executeStepParameterInteraction($stepPlan, $unresolvedStepParameters);
+        }
+
+
+        foreach ($stepPlan['operationNames'] as $operationName) {
+            $operation = $this->processRuntime->getOperationPlan($operationName);
+
+            if (
+                $this->processRuntime->conditionsSatisfied(
+                    $operation,
+                    array_intersect(
+                        Model::SUPPORTED_CONDITIONS[Model::TYPE_OPERATION],
+                        Model::RUNTIME_CONDITION_TYPES,
+                    ),
+                )
+            ) {
+                do {
+                    $operationResult = $this->executeOperation($operation);
+                } while (
+                    $operationResult['success'] === true &&
+                    $operationResult['retry'] === true &&
+                    $this->processRuntime->getOperationSubset() !== [$operationName] &&
+                    $this->input->isInteractive() &&
+                    $this->io->confirm($this->lang->retry_operation_confirm, true)
+                );
+
+                if ($operationResult['success'] === false) {
+                    if ($operationResult['retry'] === true) {
+                        $this->processRuntime->setParameterValues(
+                            array_fill_keys($operation['parameterNames'], null)
+                        );
+
+                        return self::STEP_FAILURE_RETRYABLE;
+                    } else {
+                        return self::STEP_FAILURE;
+                    }
+                }
+            }
+        }
+
+
+        return self::STEP_SUCCESS;
+    }
+
+    /**
+     * @param StepPlan $stepPlan
+     */
+    private function outputStepHeadings(
+        array $stepPlan,
+        bool $instructions,
+    ): void {
+        $this->io->section(
+            $stepPlan['heading'] ?? $this->lang->{static::getDefaultName() . '_step_' . $stepPlan['name'] . '_heading'}
+        );
+
+        if (isset($stepPlan['description'])) {
+            $this->io->text(
+                $stepPlan['description']
+                ?? $this->lang->{static::getDefaultName() . '_step_' . $stepPlan['name'] . '_description'}
+            );
+            $this->io->newLine();
+        }
+
+        if ($instructions === true && isset($stepPlan['instructions'])) {
+            $this->io->text(
+                $stepPlan['instructions']
+                ?? $this->lang->{static::getDefaultName() . '_step_' . $stepPlan['name'] . '_instructions'}
+            );
+            $this->io->newLine();
+        }
+
+        if (!empty($stepPlan['definitionList'])) {
+            $definitionList = [];
+
+            foreach ($stepPlan['definitionList'] as $item) {
+                if (is_array($item['value'])) {
+                    $value = ' * ' . implode("\n * ", $item['value']);
+                } else {
+                    $value = $item['value'];
+                }
+
+                $definitionList[] = [
+                    $item['title'] => OutputFormatter::escape(static::format($value)),
+                ];
+            }
+
+            $this->io->definitionList(...$definitionList);
+        }
+    }
+
+    /**
+     * @param array<string,ParameterPlan> $parameterPlans
+     * @param ParameterValues $deferredDefaultParameterValues
+     * @param array<self::PARAMETER_ORIGIN_*,ParameterValues> $resolvedNonInteractiveParameterValuesByOrigin
+     */
+    private function outputParameterNotes(
+        array $parameterPlans,
+        array $deferredDefaultParameterValues,
+        array $resolvedNonInteractiveParameterValuesByOrigin,
+    ): void
+    {
+        $notes = [];
+
+        // list deferred default parameter value notes, in original parameter order
+        foreach ($parameterPlans as $parameterPlan) {
+            if (array_key_exists($parameterPlan['name'], $deferredDefaultParameterValues)) {
+                $note = $this->lang->{'deferred_default_parameter_note_' . $parameterPlan['name']} ?? null;
+
+                if ($note !== null) {
+                    $notes[] = '<signal>' . $note . '</>';
+                }
+            }
+        }
+
+        // list origins of implicitly resolved parameter values
+        $implicitParameterOrigins = [
+            self::PARAMETER_ORIGIN_ENV,
+            self::PARAMETER_ORIGIN_DEFAULT,
+        ];
+
+        foreach ($resolvedNonInteractiveParameterValuesByOrigin as $origin => $parameterValues) {
+            if (in_array($origin, $implicitParameterOrigins)) {
+                foreach ($parameterValues as $parameterName => $value) {
+                    $parameterPlan = $parameterPlans[$parameterName];
+
+                    $revealed = (
+                        $parameterPlan['type'] !== 'password' || !empty($parameterPlan['passwordRevealed'])
+                    );
+
+                    $notes[] =
+                        '<signal>' .
+                        $this->lang->sprintf(
+                            $this->lang->{'using_' . $origin . '_parameter_value' . ($revealed ? '_revealed' : null)},
+                            $this->lang->{'parameter_' . $parameterName . '_title'},
+                            OutputFormatter::escape($value),
+                            static::$applicationName . '_' . static::getDefaultName() . '_' . $parameterName,
+                        ) .
+                        '</signal>';
+                }
+            }
+        }
+
+        if ($notes !== []) {
+            $this->io->listing($notes);
+        }
+    }
+
+    /**
+     * @param StepPlan $stepPlan
+     * @param ParameterPlan[] $unresolvedStepParameterPlans
+     */
+    private function executeStepParameterInteraction(array $stepPlan, array $unresolvedStepParameterPlans): void
+    {
+        $firstAttempt = true;
+
+        // collect parameter values interactively with feedback
+        do {
+            if ($firstAttempt === true) {
+                $firstAttempt = false;
+            } else {
+                // resolve all parameters again, interactively (in original order), with current values as UI defaults
+
+                $stepParameterPlans = Arr::only(
+                    $this->processRuntime->getParameterPlans(),
+                    $stepPlan['parameterNames'],
+                );
+
+                $unresolvedStepParameterPlans = array_filter(
+                    $stepParameterPlans,
+                    fn ($parameterPlan) => $this->processRuntime->conditionsSatisfied(
+                        $parameterPlan,
+                        array_intersect(
+                            Model::SUPPORTED_CONDITIONS[Model::TYPE_PARAMETER],
+                            Model::RUNTIME_CONDITION_TYPES,
+                        ),
+                    ),
+                );
+
+                foreach ($unresolvedStepParameterPlans as $parameterPlan) {
+                    $unresolvedStepParameterPlans[$parameterPlan['name']]['defaultValue'] =
+                        $this->processRuntime->getParameterValue($parameterPlan['name']);
+                }
+            }
+
+            $this->resolveParameterValues($unresolvedStepParameterPlans, ['interactive']);
+
+            $parameterFeedback = $this->processRuntime->getStepParameterFeedback($stepPlan['name']);
+
+            if ($parameterFeedback !== null) {
+                foreach ($parameterFeedback as $parameterName => $feedback) {
+                    if ($feedback['status'] !== 'success') {
+                        $this->io->note(
+                            $this->lang->{'parameter_' . $parameterName . '_title'} . ': ' . $feedback['message']
+                        );
+                    }
+                }
+            } else {
+                $parameterFeedback = [];
+            }
+        } while (
+            array_intersect(['error', 'warning'], array_column($parameterFeedback, 'status')) &&
+            !(
+                // non-error feedback in development mode
+                $this->processModel->flagExists('development_mode') &&
+                $this->processRuntime->getFlagValue('development_mode') === true &&
+                !array_intersect(['error'], array_column($parameterFeedback, 'status'))
+            ) &&
+            $this->io->confirm(
+                $this->lang->retry_parameter_input,
+                false,
+            )
+        );
+    }
+
+    /**
+     * Resolves parameter values non-interactively and provides related data.
+     *
+     * @param ParameterPlan[] $parameterPlans
+     * @param self::PARAMETER_ORIGIN_*[] $origins
+     * @param array<string,ParameterPlan> $unresolvedStepParameterPlans
+     * @param ParameterValues $deferredDefaultParameterValues
+     * @return array<self::PARAMETER_ORIGIN_*,ParameterValues>
+     */
+    private function initializeStepParameters(
+        array $parameterPlans,
+        array $origins,
+        array &$unresolvedStepParameterPlans = [],
+        array &$deferredDefaultParameterValues = []
+    ): array {
+        $resolvedParameterValuesByOrigin = [];
+        $unresolvedStepParameterPlans = $parameterPlans;
+
+        foreach (self::PARAMETER_ORIGINS_BY_PRIORITY as $origin) {
+            if ($origin === self::PARAMETER_ORIGIN_INTERACTIVE) {
+                continue;
+            }
+
+            if ($origin === self::PARAMETER_ORIGIN_DEFAULT) {
+                // fetch additional parameter value suggestions
+                $deferredDefaultParameterValues = $this->processRuntime->getDeferredDefaultParameterValues(
+                    array_keys($unresolvedStepParameterPlans),
+                );
+
+                foreach ($deferredDefaultParameterValues as $parameterName => $value) {
+                    $unresolvedStepParameterPlans[$parameterName]['defaultValue'] = $value;
+                }
+            }
+
+            if (in_array($origin, $origins)) {
+                $resolvedValues = $this->resolveParameterValues(
+                    $unresolvedStepParameterPlans,
+                    [$origin],
+                    $resolvedParameterValuesByOrigin,
+                );
+
+                $unresolvedStepParameterPlans = array_filter(
+                    array_diff_key($unresolvedStepParameterPlans, $resolvedValues),
+                    fn (array $parameterPlan) => $this->processRuntime->conditionsSatisfied(
+                        $parameterPlan,
+                        array_intersect(
+                            Model::SUPPORTED_CONDITIONS[Model::TYPE_PARAMETER],
+                            Model::RUNTIME_CONDITION_TYPES,
+                        ),
+                    ),
+                );
+            }
+        }
+
+        return $resolvedParameterValuesByOrigin;
+    }
+
+    /**
+     * @param array<string,ParameterPlan> $parameterPlans
+     * @param self::PARAMETER_ORIGIN_*[] $origins
+     * @param array<self::PARAMETER_ORIGIN_*,ParameterValues> $resolvedValuesByOrigin
+     * @throws \Exception
+     */
+    private function resolveParameterValues(
+        array $parameterPlans,
+        array $origins,
+        array &$resolvedValuesByOrigin = []
+    ): array {
+        $resolvedValues = [];
+
+        foreach ($parameterPlans as $parameterName => $parameterPlan) {
+            if (
+                $this->processRuntime->conditionsSatisfied(
+                    $parameterPlan,
+                    array_intersect(
+                        Model::SUPPORTED_CONDITIONS[Model::TYPE_PARAMETER],
+                        Model::RUNTIME_CONDITION_TYPES,
+                    ),
+                )
+            ) {
+                foreach ($origins as $origin) {
+                    $resolvedValue = null;
+
+                    switch ($origin) {
+                        case self::PARAMETER_ORIGIN_DEFAULT:
+                            if (isset($parameterPlan['defaultValue'])) {
+                                $resolvedValue = $parameterPlan['defaultValue'];
+                            }
+
+                            break;
+                        case self::PARAMETER_ORIGIN_DIRECT:
+                            if (isset($this->directParameterValues[$parameterName])) {
+                                $resolvedValue = $this->directParameterValues[$parameterName];
+                            }
+
+                            break;
+                        case self::PARAMETER_ORIGIN_ENV:
+                            $value = getenv(
+                                strtoupper(
+                                    static::$applicationName . '_' .
+                                    static::getDefaultName() . '_' .
+                                    $parameterName
+                                )
+                            );
+
+                            if ($value !== false) {
+                                $resolvedValue = $value;
+                            }
+
+                            break;
+                        case self::PARAMETER_ORIGIN_INTERACTIVE:
+                            $resolvedValue = $this->collectParameterValueInteractively($parameterPlan);
+                            break;
+                    }
+
+                    if ($resolvedValue !== null) {
+                        $resolvedValues[$parameterName] = $resolvedValue;
+                        $resolvedValuesByOrigin[$origin][$parameterName] = $resolvedValue;
+
+                        // add values individually to make them available for subsequent condition checks
+                        $this->processRuntime->setParameterValues([
+                            $parameterName => $resolvedValue,
+                        ]);
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $resolvedValues;
+    }
+
+    /**
+     * @param OperationPlan $operationPlan
+     * @return OperationResult
+     */
+    private function executeOperation(array $operationPlan): array
+    {
+        if ($this->output->isVerbose()) {
+            if ($operationPlan['listed'] === true) {
+                $title = $this->lang->{'operation_' . $operationPlan['name'] . '_title'} ?? null;
+
+                if ($title !== null) {
+                    $this->io->write(
+                        ' ' .
+                        $this->lang->sprintf(
+                            $this->lang->waiting_for_operation,
+                            $this->lang->{'operation_' . $operationPlan['name'] . '_title'},
+                        )
+                    );
+                } else {
+                    $this->io->write(
+                        ' ' .
+                        $this->lang->waiting_for_operation_hidden,
+                    );
+                }
+            }
+        }
+
+        $startTime = microtime(true);
+
+        $operationResult = $this->processRuntime->runOperation($operationPlan['name']);
+
+        $endTime = microtime(true);
+
+        if ($this->output->isVeryVerbose()) {
+            $time = $endTime - $startTime;
+
+            $this->totalOperationRunTime += $time;
+
+            $timeSeconds = round($time, 4);
+
+            $this->output->write(' <meta>(' . $timeSeconds . ' s)</meta>');
+        }
+
+        if ($this->output->isVerbose()) {
+            $this->io->newLine();
+        }
+
+        $this->outputOperationAlerts($operationPlan['name'], $operationResult);
+
+        return $operationResult;
+    }
+
+    /**
+     * @param OperationResult $operationResults
+     */
+    private function outputOperationAlerts(string $operationName, array $operationResults): void
+    {
+        $operationResults = ProcessHelpers::getLocalizedOperationResult($operationName, $operationResults, $this->lang);
+
+        foreach (['error', 'warning'] as $type) {
+            if (isset($operationResults[$type])) {
+                $this->io->$type(
+                    static::format($operationResults[$type]['title'] . "\n\n" . $operationResults[$type]['message'])
+                );
+
+                if (isset($operationResults[$type]['list'])) {
+                    $this->io->listing(
+                        array_map(self::format(...), $operationResults[$type]['list'])
+                    );
+                }
+
+                if (isset($operationResults[$type]['raw']) && $this->output->isVerbose()) {
+                    $this->output->write(
+                        '<raw>' . OutputFormatter::escape($operationResults[$type]['raw']) . '</raw>'
+                    );
+                    $this->io->newLine(2);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ParameterPlan $parameterPlan
+     * @throws \InvalidArgumentException
+     */
+    private function collectParameterValueInteractively(array $parameterPlan): ?string
+    {
+        $title = $this->lang->{'parameter_' . $parameterPlan['name'] . '_title'};
+        $defaultValue = $parameterPlan['defaultValue'] ?? null;
+
+        switch ($parameterPlan['type']) {
+            case 'text':
+            case 'email':
+                $value = $this->io->ask($title, $defaultValue);
+                break;
+            case 'password':
+                if (
+                    ($parameterPlan['passwordRevealed'] ?? null) === true ||
+                    isset($parameterPlan['defaultValue'])
+                ) {
+                    $value = $this->io->ask($title, $defaultValue);
+                } else {
+                    $value = $this->io->askHidden($title);
+                }
+                break;
+            case 'select':
+                $value = $this->io->choice(
+                    $title,
+                    array_map('strval', array_keys($parameterPlan['options'])),
+                    $defaultValue,
+                );
+                break;
+            case 'checkbox':
+                $value = $this->io->confirm($title, $defaultValue == true) ? '1' : '0';
+                break;
+            default:
+                throw new \InvalidArgumentException('Unknown parameter type');
+        }
+
+        $this->io->newLine();
+
+        return $value;
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    private function validateRequestedOperationNamesCsv(?string $requestedOperationNamesCsv): ?array
+    {
+        $requestedOperationsNames = null;
+
+        if ($requestedOperationNamesCsv !== null) {
+            $requestedOperationsNames = array_unique(
+                explode(',', $requestedOperationNamesCsv)
+            );
+
+            $nonexistentOperations = array_diff(
+                $requestedOperationsNames,
+                $this->processModel->getOperationNames()
+            );
+
+            if (count($nonexistentOperations) !== 0) {
+                $this->io->error(
+                    array_map(
+                        function ($name): string {
+                            return $this->lang->sprintf(
+                                $this->lang->unknown_operation,
+                                $name,
+                            );
+                        },
+                        $nonexistentOperations,
+                    )
+                );
+
+                throw new \RuntimeException();
+            }
+        }
+
+        return $requestedOperationsNames;
+    }
+
+    /**
+     * Validates and returns parameters passed during command invocation using `--param`.
+     *
+     * @param string[] $parametersEncoded Array of parameter strings in the `name=value` format
+     * @throws \RuntimeException
+     */
+    private function validateDirectParameters(array $parametersEncoded): array
+    {
+        $parameters = [];
+
+        $nonexistentParameters = [];
+
+        $knownParameterNames = array_keys($this->processRuntime->getParameterPlans());
+
+        foreach ($parametersEncoded as $parameterEncoded) {
+            if (!str_contains($parameterEncoded, '=')) {
+                $parameterName = $parameterEncoded;
+                $parameterValue = '';
+            } else {
+                [$parameterName, $parameterValue] = explode('=', $parameterEncoded, 2);
+            }
+
+            if (!in_array($parameterName, $knownParameterNames)) {
+                $nonexistentParameters[] = $parameterName;
+            } else {
+                $parameters[$parameterName] = $parameterValue;
+            }
+        }
+
+        if (count($nonexistentParameters) !== 0) {
+            $this->io->error(
+                array_map(
+                    function ($name): string {
+                        return $this->lang->sprintf(
+                            $this->lang->unknown_parameter,
+                            $name,
+                        );
+                    },
+                    $nonexistentParameters,
+                )
+            );
+
+            throw new \RuntimeException();
+        } else {
+            return $parameters;
+        }
+    }
+}

--- a/inc/src/Console/Command/UpgradeCommand.php
+++ b/inc/src/Console/Command/UpgradeCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Console\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'upgrade')]
+class UpgradeCommand extends MaintenanceProcessCommand
+{
+    protected function configure(): void
+    {
+        $this->setDescription('Upgrades an existing MyBB board');
+
+        parent::configure();
+    }
+}


### PR DESCRIPTION
Introduces `bin/cli` executable built using [`symfony/console`](https://symfony.com/doc/current/components/console.html).

Adds commands for the `install` and `upgrade` Processes introduced in #4654.

> [...] input can be:
>- provided interactively:
>  ```
>   Board URL:
>   > https://example.net/forum
>  ```
>- passed as direct parameters with the command:
>  ```sh
>  $ bin/cli install --param bburl=https://example.net/forum
>  ```
>- picked up from environment variables:
>  ```ini
>  MYBB_INSTALL_BBURL=https://example.net/forum
>  ```
>- skipped entirely — by accepting defaults:
>  ```sh
>  $ bin/cli install --fast
>  ```
>  _(here, we rely on database discovery and an existing installation, where the URL — unavailable in CLI mode — can be retrieved from old settings)_

Depends on #4654