### PR TITLE
PHP 8 - Fatal error with SMTP socket connection

### DIFF
--- a/inc/mailhandlers/smtp.php
+++ b/inc/mailhandlers/smtp.php
@@ -276,7 +276,7 @@ class SmtpMail extends MailHandler
 		$this->connection = @fsockopen($this->host, $this->port, $error_number, $error_string, $this->timeout);
 
 		// DIRECTORY_SEPARATOR checks if running windows
-		if(function_exists('stream_set_timeout') && DIRECTORY_SEPARATOR != '\\')
+		if(is_resource($this->connection) && function_exists('stream_set_timeout') && DIRECTORY_SEPARATOR != '\\')
 		{
 			@stream_set_timeout($this->connection, $this->timeout, 0);
 		}


### PR DESCRIPTION
When `$this->connection` is not a valid socket resource and is bool `false` due to mail server timeout, unsuccessful connection, etc. we will get thrown a fatal error for `stream_set_timeout()`.

Potential fix for #4680 

