### PR TITLE
PHP 8 - Fix `announcements` errors

### DIFF
--- a/admin/modules/forum/announcements.php
+++ b/admin/modules/forum/announcements.php
@@ -589,11 +589,11 @@ if($mybb->input['action'] == "edit")
 		}
 
 		// Gather start and end date data
-		$startday = $mybb->input['starttime_day'];
+		$startday = $mybb->get_input('starttime_day', MyBB::INPUT_INT);
 		$start_time = $mybb->input['starttime_time'];
-		$startmonth = $mybb->input['starttime_month'];
+		$startmonth = $mybb->get_input('starttime_month', MyBB::INPUT_INT);
 		$startmonthsel[$startmonth] = 'selected="selected"';
-		$startdateyear = $mybb->input['starttime_year'];
+		$startdateyear = $mybb->get_input('starttime_year', MyBB::INPUT_INT);
 
 		if($mybb->input['endtime_type'] == 1)
 		{
@@ -601,11 +601,11 @@ if($mybb->input['action'] == "edit")
 			$endtime_checked[1] = 'checked="checked"';
 			$endtime_checked[2] = '';
 
-			$endday = $mybb->input['endtime_day'];
+			$endday = $endmonth = $mybb->get_input('endtime_day', MyBB::INPUT_INT);
 			$endtime = $mybb->input['endtime_time'];
-			$endmonth = $mybb->input['endtime_month'];
+			$endmonth = $mybb->get_input('endtime_month', MyBB::INPUT_INT);
 			$endmonthsel[$endmonth] = 'selected';
-			$enddateyear = $mybb->input['endtime_year'];
+			$enddateyear = $mybb->get_input('endtime_year', MyBB::INPUT_INT);
 		}
 		else
 		{

--- a/admin/modules/forum/announcements.php
+++ b/admin/modules/forum/announcements.php
@@ -601,7 +601,7 @@ if($mybb->input['action'] == "edit")
 			$endtime_checked[1] = 'checked="checked"';
 			$endtime_checked[2] = '';
 
-			$endday = $endmonth = $mybb->get_input('endtime_day', MyBB::INPUT_INT);
+			$endday = $mybb->get_input('endtime_day', MyBB::INPUT_INT);
 			$endtime = $mybb->input['endtime_time'];
 			$endmonth = $mybb->get_input('endtime_month', MyBB::INPUT_INT);
 			$endmonthsel[$endmonth] = 'selected';

--- a/modcp.php
+++ b/modcp.php
@@ -1490,13 +1490,13 @@ if($mybb->input['action'] == "do_edit_announcement")
 
 	// Basic error checking
 	$mybb->input['title'] = $mybb->get_input('title');
-	if(!trim($mybb->input['title']))
+	if(!trim_blank_chrs($mybb->input['title']))
 	{
 		$errors[] = $lang->error_missing_title;
 	}
 
 	$mybb->input['message'] = $mybb->get_input('message');
-	if(!trim($mybb->input['message']))
+	if(!trim_blank_chrs($mybb->input['message']))
 	{
 		$errors[] = $lang->error_missing_message;
 	}


### PR DESCRIPTION
1. Fix empty `title` and `message`
2. Fix the potentially fatal error by incorrect data type entered in the form.
