### PR TITLE
PHP 8 - Fix undefined variables in `modcp.php`

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -3672,6 +3672,7 @@ if($mybb->input['action'] == "ipsearch")
 		// Searching post IP addresses
 		if(isset($mybb->input['search_posts']))
 		{
+			$post_ip_sql = '';
 			if($ip_range)
 			{
 				if(!is_array($ip_range))
@@ -3766,6 +3767,7 @@ if($mybb->input['action'] == "ipsearch")
 		// Searching user IP addresses
 		if(isset($mybb->input['search_users']))
 		{
+			$user_ip_sql = '';
 			if($ip_range)
 			{
 				if(!is_array($ip_range))


### PR DESCRIPTION
Entering non-valid IP addresses results in "/modcp.php?action=ipsearch" results in `$user_ip_sql` and/or `$post_ip_sql` variables returning undefined notices.

