### PR TITLE
PHP 8 - Fix admin language module

### DIFF
--- a/admin/modules/config/languages.php
+++ b/admin/modules/config/languages.php
@@ -20,6 +20,7 @@ $page->add_breadcrumb_item($lang->languages, "index.php?module=config-languages"
 
 $plugins->run_hooks("admin_config_languages_begin");
 
+$no_write = null;
 if($mybb->input['action'] == "edit_properties")
 {
 	$editlang = basename($mybb->input['lang']);
@@ -978,7 +979,7 @@ if($mybb->input['action'] == "edit")
 					$table->construct_cell(count($editvars_left), array("class" => "langeditor_phrases"));
 					$table->construct_cell("", array("class" => "langeditor_editfile"));
 					$table->construct_cell($icon_issues, array("class" => "langeditor_issues"));
-					$table->construct_cell("<a href=\"index.php?module=config-languages&amp;action=edit&amp;lang=".htmlspecialchars_uni($editlang)."&amp;editwith=".htmlspecialchars_uni($editwith)."&amp;file={$config['admindir']}/".htmlspecialchars_uni($file)."&amp;inadmin=1\">{$lang->edit}</a>", array("class" => "langeditor_edit"));
+					$table->construct_cell("<a href=\"index.php?module=config-languages&amp;action=edit&amp;lang=".htmlspecialchars_uni($editlang)."&amp;editwith=".htmlspecialchars_uni($editwith)."&amp;file={$mybb->config['admin_dir']}/".htmlspecialchars_uni($file)."&amp;inadmin=1\">{$lang->edit}</a>", array("class" => "langeditor_edit"));
 					$table->construct_row();
 				}
 				foreach($files_right as $key => $file)
@@ -997,7 +998,7 @@ if($mybb->input['action'] == "edit")
 					$table->construct_cell("", array("class" => "langeditor_phrases"));
 					$table->construct_cell(htmlspecialchars_uni($file), array("class" => "langeditor_editfile"));
 					$table->construct_cell($icon_issues, array("class" => "langeditor_issues"));
-					$table->construct_cell("<a href=\"index.php?module=config-languages&amp;action=edit&amp;lang=".htmlspecialchars_uni($editlang)."&amp;editwith=".htmlspecialchars_uni($editwith)."&amp;file={$config['admindir']}/".htmlspecialchars_uni($file)."&amp;inadmin=1\">{$lang->edit}</a>", array("class" => "langeditor_edit"));
+					$table->construct_cell("<a href=\"index.php?module=config-languages&amp;action=edit&amp;lang=".htmlspecialchars_uni($editlang)."&amp;editwith=".htmlspecialchars_uni($editwith)."&amp;file={$mybb->config['admin_dir']}/".htmlspecialchars_uni($file)."&amp;inadmin=1\">{$lang->edit}</a>", array("class" => "langeditor_edit"));
 					$table->construct_row();
 				}
 				foreach($files_both as $key => $file)
@@ -1031,7 +1032,7 @@ if($mybb->input['action'] == "edit")
 					}
 
 					$table->construct_cell($icon_issues, array("class" => "langeditor_issues"));
-					$table->construct_cell("<a href=\"index.php?module=config-languages&amp;action=edit&amp;lang=".htmlspecialchars_uni($editlang)."&amp;editwith=".htmlspecialchars_uni($editwith)."&amp;file={$config['admindir']}/".htmlspecialchars_uni($file)."&amp;inadmin=1\">{$lang->edit}</a>", array("class" => "langeditor_edit"));
+					$table->construct_cell("<a href=\"index.php?module=config-languages&amp;action=edit&amp;lang=".htmlspecialchars_uni($editlang)."&amp;editwith=".htmlspecialchars_uni($editwith)."&amp;file={$mybb->config['admin_dir']}/".htmlspecialchars_uni($file)."&amp;inadmin=1\">{$lang->edit}</a>", array("class" => "langeditor_edit"));
 					$table->construct_row();
 				}
 			}


### PR DESCRIPTION
- Initialize `$no_write` and prevent `Undefined variable $no_write - Line: 172 - File: admin\modules\config\languages.php`
- Replace `$config` with `$mybb->config` and set correct value `admin_dir` to prevent `Undefined array key "admindir" - Line: 1034 - File: \admin\modules\config\languages.php`

