### PR TITLE
PHP 8 - Undefined variable `$option_list` - Line: 1754

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1704,6 +1704,7 @@ if($mybb->input['action'] == "change")
 					$multivalue = explode(',', $setting['value']);
 				}
 
+				$option_list = array();
 				for($i = 0; $i < $typecount; $i++)
 				{
 					$optionsexp = explode("=", $type[$i]);
@@ -1758,7 +1759,6 @@ if($mybb->input['action'] == "change")
 						$setting_code .= $form->generate_hidden_field("isvisible_{$setting['name']}", 1);
 					}
 				}
-				$option_list = array();
 			}
 
 			// Do we have a custom language variable for this title or description?


### PR DESCRIPTION
Move `$option_list` to the appropriate position to prevent potential fatal error with implode on line 1754 when plugin optionlist has the wrong value.

(Was hard to debug as the stack trace doesn't show from where the error originated)

