### PR TITLE
Check `fopen()` result before writing lock file

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -2485,11 +2485,16 @@ function install_done()
 	if(is_writable('./'))
 	{
 		$lock = @fopen('./lock', 'w');
-		$written = @fwrite($lock, '1');
-		@fclose($lock);
-		if($written)
+
+		if($lock !== false)
 		{
-			echo $lang->done_step_locked;
+			$written = @fwrite($lock, '1');
+			@fclose($lock);
+
+			if($written)
+			{
+				echo $lang->done_step_locked;
+			}
 		}
 	}
 	if(!$written)


### PR DESCRIPTION
Resolves possible error:
```
Fatal error: Uncaught TypeError: fwrite(): Argument #1 ($stream) must be of type resource, false given
```