### PR TITLE
Fix #4752: Remove the deprecated "All rights reserved" phrase

### DIFF
--- a/admin/inc/class_form.php
+++ b/admin/inc/class_form.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/inc/class_page.php
+++ b/admin/inc/class_page.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/inc/class_table.php
+++ b/admin/inc/class_table.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/inc/functions.php
+++ b/admin/inc/functions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/inc/functions_themes.php
+++ b/admin/inc/functions_themes.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/inc/functions_view_manager.php
+++ b/admin/inc/functions_view_manager.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/attachment_types.php
+++ b/admin/modules/config/attachment_types.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/badwords.php
+++ b/admin/modules/config/badwords.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/banning.php
+++ b/admin/modules/config/banning.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/calendars.php
+++ b/admin/modules/config/calendars.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/help_documents.php
+++ b/admin/modules/config/help_documents.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/languages.php
+++ b/admin/modules/config/languages.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license
@@ -257,7 +257,7 @@ if($mybb->input['action'] == "quick_phrases")
 
 					// Lets make nice credits header in language file
 					$lang_file_credits  = "<?php\n/**\n";
-					$lang_file_credits .= " * MyBB Copyright 2014 MyBB Group, All Rights Reserved\n *\n";
+					$lang_file_credits .= " * MyBB Copyright 2014 MyBB Group\n *\n";
 					$lang_file_credits .= " * Website: https://mybb.com\n";
 					$lang_file_credits .= " * License: https://mybb.com/about/license\n *\n */\n\n";
 					$lang_file_credits .= "// ".str_repeat('-',80)."\n";
@@ -501,7 +501,7 @@ if($mybb->input['action'] == "edit")
 
 				// Lets make nice credits header in language file
 				$lang_file_credits  = "<?php\n/**\n";
-				$lang_file_credits .= " * MyBB Copyright 2014 MyBB Group, All Rights Reserved\n *\n";
+				$lang_file_credits .= " * MyBB Copyright 2014 MyBB Group\n *\n";
 				$lang_file_credits .= " * Website: https://mybb.com\n";
 				$lang_file_credits .= " * License: https://mybb.com/about/license\n *\n */\n\n";
 				$lang_file_credits .= "// ".str_repeat('-',80)."\n";

--- a/admin/modules/config/mod_tools.php
+++ b/admin/modules/config/mod_tools.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/module_meta.php
+++ b/admin/modules/config/module_meta.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/mycode.php
+++ b/admin/modules/config/mycode.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/plugins.php
+++ b/admin/modules/config/plugins.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/post_icons.php
+++ b/admin/modules/config/post_icons.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/profile_fields.php
+++ b/admin/modules/config/profile_fields.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/questions.php
+++ b/admin/modules/config/questions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/report_reasons.php
+++ b/admin/modules/config/report_reasons.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/smilies.php
+++ b/admin/modules/config/smilies.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/spiders.php
+++ b/admin/modules/config/spiders.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/thread_prefixes.php
+++ b/admin/modules/config/thread_prefixes.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/config/warning.php
+++ b/admin/modules/config/warning.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/forum/announcements.php
+++ b/admin/modules/forum/announcements.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/forum/attachments.php
+++ b/admin/modules/forum/attachments.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/forum/moderation_queue.php
+++ b/admin/modules/forum/moderation_queue.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/forum/module_meta.php
+++ b/admin/modules/forum/module_meta.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/home/index.php
+++ b/admin/modules/home/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/home/module_meta.php
+++ b/admin/modules/home/module_meta.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/home/preferences.php
+++ b/admin/modules/home/preferences.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/style/module_meta.php
+++ b/admin/modules/style/module_meta.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/style/templates.php
+++ b/admin/modules/style/templates.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/style/themes.php
+++ b/admin/modules/style/themes.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/adminlog.php
+++ b/admin/modules/tools/adminlog.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/backupdb.php
+++ b/admin/modules/tools/backupdb.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/cache.php
+++ b/admin/modules/tools/cache.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/file_verification.php
+++ b/admin/modules/tools/file_verification.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/mailerrors.php
+++ b/admin/modules/tools/mailerrors.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/maillogs.php
+++ b/admin/modules/tools/maillogs.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/modlog.php
+++ b/admin/modules/tools/modlog.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/module_meta.php
+++ b/admin/modules/tools/module_meta.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/optimizedb.php
+++ b/admin/modules/tools/optimizedb.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/php_info.php
+++ b/admin/modules/tools/php_info.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/spamlog.php
+++ b/admin/modules/tools/spamlog.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license
 

--- a/admin/modules/tools/statistics.php
+++ b/admin/modules/tools/statistics.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/system_health.php
+++ b/admin/modules/tools/system_health.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/tasks.php
+++ b/admin/modules/tools/tasks.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/tools/warninglog.php
+++ b/admin/modules/tools/warninglog.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/admin_permissions.php
+++ b/admin/modules/user/admin_permissions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/awaiting_activation.php
+++ b/admin/modules/user/awaiting_activation.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/banning.php
+++ b/admin/modules/user/banning.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/group_promotions.php
+++ b/admin/modules/user/group_promotions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/mass_mail.php
+++ b/admin/modules/user/mass_mail.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/module_meta.php
+++ b/admin/modules/user/module_meta.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/titles.php
+++ b/admin/modules/user/titles.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/announcements.php
+++ b/announcements.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/archive/global.php
+++ b/archive/global.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/archive/index.php
+++ b/archive/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/attachment.php
+++ b/attachment.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/calendar.php
+++ b/calendar.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/captcha.php
+++ b/captcha.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/contact.php
+++ b/contact.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/css.php
+++ b/css.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/editpost.php
+++ b/editpost.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/global.php
+++ b/global.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/AbstractPdoDbDriver.php
+++ b/inc/AbstractPdoDbDriver.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2020 MyBB Group, All Rights Reserved
+ * Copyright 2020 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/adminfunctions_templates.php
+++ b/inc/adminfunctions_templates.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/apc.php
+++ b/inc/cachehandlers/apc.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/apcu.php
+++ b/inc/cachehandlers/apcu.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2020 MyBB Group, All Rights Reserved
+ * Copyright 2020 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/disk.php
+++ b/inc/cachehandlers/disk.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/eaccelerator.php
+++ b/inc/cachehandlers/eaccelerator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/interface.php
+++ b/inc/cachehandlers/interface.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/memcache.php
+++ b/inc/cachehandlers/memcache.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/memcached.php
+++ b/inc/cachehandlers/memcached.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/redis.php
+++ b/inc/cachehandlers/redis.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2020 MyBB Group, All Rights Reserved
+ * Copyright 2020 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/cachehandlers/xcache.php
+++ b/inc/cachehandlers/xcache.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_captcha.php
+++ b/inc/class_captcha.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_core.php
+++ b/inc/class_core.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_custommoderation.php
+++ b/inc/class_custommoderation.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_datacache.php
+++ b/inc/class_datacache.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_feedgeneration.php
+++ b/inc/class_feedgeneration.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_feedparser.php
+++ b/inc/class_feedparser.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_graph.php
+++ b/inc/class_graph.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_language.php
+++ b/inc/class_language.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_mailhandler.php
+++ b/inc/class_mailhandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_moderation.php
+++ b/inc/class_moderation.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_plugins.php
+++ b/inc/class_plugins.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license
  */

--- a/inc/class_session.php
+++ b/inc/class_session.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_stopforumspamchecker.php
+++ b/inc/class_stopforumspamchecker.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_templates.php
+++ b/inc/class_templates.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_timers.php
+++ b/inc/class_timers.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_xml.php
+++ b/inc/class_xml.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/class_xmlparser.php
+++ b/inc/class_xmlparser.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/datahandler.php
+++ b/inc/datahandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/datahandlers/event.php
+++ b/inc/datahandlers/event.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/datahandlers/login.php
+++ b/inc/datahandlers/login.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/datahandlers/pm.php
+++ b/inc/datahandlers/pm.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/datahandlers/warnings.php
+++ b/inc/datahandlers/warnings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_base.php
+++ b/inc/db_base.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_mysql.php
+++ b/inc/db_mysql.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2020 MyBB Group, All Rights Reserved
+ * Copyright 2020 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_pdo.php
+++ b/inc/db_pdo.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2020 MyBB Group, All Rights Reserved
+ * Copyright 2020 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_archive.php
+++ b/inc/functions_archive.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_calendar.php
+++ b/inc/functions_calendar.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_forumlist.php
+++ b/inc/functions_forumlist.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_image.php
+++ b/inc/functions_image.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_indicators.php
+++ b/inc/functions_indicators.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_massmail.php
+++ b/inc/functions_massmail.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_modcp.php
+++ b/inc/functions_modcp.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_online.php
+++ b/inc/functions_online.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_posting.php
+++ b/inc/functions_posting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_rebuild.php
+++ b/inc/functions_rebuild.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_search.php
+++ b/inc/functions_search.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_serverstats.php
+++ b/inc/functions_serverstats.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_task.php
+++ b/inc/functions_task.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_user.php
+++ b/inc/functions_user.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/functions_warnings.php
+++ b/inc/functions_warnings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/init.php
+++ b/inc/init.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/languages/english.php
+++ b/inc/languages/english.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_attachment_types.lang.php
+++ b/inc/languages/english/admin/config_attachment_types.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_badwords.lang.php
+++ b/inc/languages/english/admin/config_badwords.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_banning.lang.php
+++ b/inc/languages/english/admin/config_banning.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_calendars.lang.php
+++ b/inc/languages/english/admin/config_calendars.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_help_documents.lang.php
+++ b/inc/languages/english/admin/config_help_documents.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_languages.lang.php
+++ b/inc/languages/english/admin/config_languages.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_mod_tools.lang.php
+++ b/inc/languages/english/admin/config_mod_tools.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_module_meta.lang.php
+++ b/inc/languages/english/admin/config_module_meta.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_mycode.lang.php
+++ b/inc/languages/english/admin/config_mycode.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_plugins.lang.php
+++ b/inc/languages/english/admin/config_plugins.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_post_icons.lang.php
+++ b/inc/languages/english/admin/config_post_icons.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_profile_fields.lang.php
+++ b/inc/languages/english/admin/config_profile_fields.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_questions.lang.php
+++ b/inc/languages/english/admin/config_questions.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_report_reasons.lang.php
+++ b/inc/languages/english/admin/config_report_reasons.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_settings.lang.php
+++ b/inc/languages/english/admin/config_settings.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_smilies.lang.php
+++ b/inc/languages/english/admin/config_smilies.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_spiders.lang.php
+++ b/inc/languages/english/admin/config_spiders.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_thread_prefixes.lang.php
+++ b/inc/languages/english/admin/config_thread_prefixes.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/config_warning.lang.php
+++ b/inc/languages/english/admin/config_warning.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/forum_announcements.lang.php
+++ b/inc/languages/english/admin/forum_announcements.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/forum_attachments.lang.php
+++ b/inc/languages/english/admin/forum_attachments.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/forum_management.lang.php
+++ b/inc/languages/english/admin/forum_management.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/forum_moderation_queue.lang.php
+++ b/inc/languages/english/admin/forum_moderation_queue.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/forum_module_meta.lang.php
+++ b/inc/languages/english/admin/forum_module_meta.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/global.lang.php
+++ b/inc/languages/english/admin/global.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/hello.lang.php
+++ b/inc/languages/english/admin/hello.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/languages/english/admin/home_dashboard.lang.php
+++ b/inc/languages/english/admin/home_dashboard.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/home_module_meta.lang.php
+++ b/inc/languages/english/admin/home_module_meta.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/home_preferences.lang.php
+++ b/inc/languages/english/admin/home_preferences.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/style_module_meta.lang.php
+++ b/inc/languages/english/admin/style_module_meta.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/style_templates.lang.php
+++ b/inc/languages/english/admin/style_templates.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/style_themes.lang.php
+++ b/inc/languages/english/admin/style_themes.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_adminlog.lang.php
+++ b/inc/languages/english/admin/tools_adminlog.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_backupdb.lang.php
+++ b/inc/languages/english/admin/tools_backupdb.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_cache.lang.php
+++ b/inc/languages/english/admin/tools_cache.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_file_verification.lang.php
+++ b/inc/languages/english/admin/tools_file_verification.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_mailerrors.lang.php
+++ b/inc/languages/english/admin/tools_mailerrors.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_maillogs.lang.php
+++ b/inc/languages/english/admin/tools_maillogs.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_modlog.lang.php
+++ b/inc/languages/english/admin/tools_modlog.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_module_meta.lang.php
+++ b/inc/languages/english/admin/tools_module_meta.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_optimizedb.lang.php
+++ b/inc/languages/english/admin/tools_optimizedb.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_php_info.lang.php
+++ b/inc/languages/english/admin/tools_php_info.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_recount_rebuild.lang.php
+++ b/inc/languages/english/admin/tools_recount_rebuild.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_spamlog.lang.php
+++ b/inc/languages/english/admin/tools_spamlog.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  */
 
 

--- a/inc/languages/english/admin/tools_statistics.lang.php
+++ b/inc/languages/english/admin/tools_statistics.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_system_health.lang.php
+++ b/inc/languages/english/admin/tools_system_health.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_tasks.lang.php
+++ b/inc/languages/english/admin/tools_tasks.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/tools_warninglog.lang.php
+++ b/inc/languages/english/admin/tools_warninglog.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_admin_permissions.lang.php
+++ b/inc/languages/english/admin/user_admin_permissions.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_awaiting_activation.lang.php
+++ b/inc/languages/english/admin/user_awaiting_activation.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_banning.lang.php
+++ b/inc/languages/english/admin/user_banning.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_group_promotions.lang.php
+++ b/inc/languages/english/admin/user_group_promotions.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_groups.lang.php
+++ b/inc/languages/english/admin/user_groups.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_mass_mail.lang.php
+++ b/inc/languages/english/admin/user_mass_mail.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_module_meta.lang.php
+++ b/inc/languages/english/admin/user_module_meta.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_titles.lang.php
+++ b/inc/languages/english/admin/user_titles.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/admin/user_users.lang.php
+++ b/inc/languages/english/admin/user_users.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/announcements.lang.php
+++ b/inc/languages/english/announcements.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/archive.lang.php
+++ b/inc/languages/english/archive.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/calendar.lang.php
+++ b/inc/languages/english/calendar.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/contact.lang.php
+++ b/inc/languages/english/contact.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/customhelpdocs.lang.php
+++ b/inc/languages/english/customhelpdocs.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/customhelpsections.lang.php
+++ b/inc/languages/english/customhelpsections.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/datahandler_event.lang.php
+++ b/inc/languages/english/datahandler_event.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/datahandler_login.lang.php
+++ b/inc/languages/english/datahandler_login.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/datahandler_pm.lang.php
+++ b/inc/languages/english/datahandler_pm.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/datahandler_post.lang.php
+++ b/inc/languages/english/datahandler_post.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/datahandler_user.lang.php
+++ b/inc/languages/english/datahandler_user.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/datahandler_warnings.lang.php
+++ b/inc/languages/english/datahandler_warnings.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/editpost.lang.php
+++ b/inc/languages/english/editpost.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/forumdisplay.lang.php
+++ b/inc/languages/english/forumdisplay.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/hello.lang.php
+++ b/inc/languages/english/hello.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/languages/english/helpdocs.lang.php
+++ b/inc/languages/english/helpdocs.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/helpsections.lang.php
+++ b/inc/languages/english/helpsections.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/index.lang.php
+++ b/inc/languages/english/index.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/mailhandler.lang.php
+++ b/inc/languages/english/mailhandler.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/managegroup.lang.php
+++ b/inc/languages/english/managegroup.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/member.lang.php
+++ b/inc/languages/english/member.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/memberlist.lang.php
+++ b/inc/languages/english/memberlist.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/messages.lang.php
+++ b/inc/languages/english/messages.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/misc.lang.php
+++ b/inc/languages/english/misc.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/modcp.lang.php
+++ b/inc/languages/english/modcp.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/moderation.lang.php
+++ b/inc/languages/english/moderation.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/newreply.lang.php
+++ b/inc/languages/english/newreply.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/newthread.lang.php
+++ b/inc/languages/english/newthread.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/online.lang.php
+++ b/inc/languages/english/online.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/polls.lang.php
+++ b/inc/languages/english/polls.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/portal.lang.php
+++ b/inc/languages/english/portal.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/printthread.lang.php
+++ b/inc/languages/english/printthread.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/private.lang.php
+++ b/inc/languages/english/private.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/ratethread.lang.php
+++ b/inc/languages/english/ratethread.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/report.lang.php
+++ b/inc/languages/english/report.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/reputation.lang.php
+++ b/inc/languages/english/reputation.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/search.lang.php
+++ b/inc/languages/english/search.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/sendthread.lang.php
+++ b/inc/languages/english/sendthread.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/showteam.lang.php
+++ b/inc/languages/english/showteam.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/showthread.lang.php
+++ b/inc/languages/english/showthread.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/stats.lang.php
+++ b/inc/languages/english/stats.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/syndication.lang.php
+++ b/inc/languages/english/syndication.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/usercp.lang.php
+++ b/inc/languages/english/usercp.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/usercpnav.lang.php
+++ b/inc/languages/english/usercpnav.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/warnings.lang.php
+++ b/inc/languages/english/warnings.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/languages/english/xmlhttp.lang.php
+++ b/inc/languages/english/xmlhttp.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/inc/mailhandlers/php.php
+++ b/inc/mailhandlers/php.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/mailhandlers/smtp.php
+++ b/inc/mailhandlers/smtp.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/mybb_group.php
+++ b/inc/mybb_group.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/plugins/hello.php
+++ b/inc/plugins/hello.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/backupdb.php
+++ b/inc/tasks/backupdb.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/checktables.php
+++ b/inc/tasks/checktables.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/dailycleanup.php
+++ b/inc/tasks/dailycleanup.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/delayedmoderation.php
+++ b/inc/tasks/delayedmoderation.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/hourlycleanup.php
+++ b/inc/tasks/hourlycleanup.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/logcleanup.php
+++ b/inc/tasks/logcleanup.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/massmail.php
+++ b/inc/tasks/massmail.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/promotions.php
+++ b/inc/tasks/promotions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/recachestylesheets.php
+++ b/inc/tasks/recachestylesheets.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/sendmailqueue.php
+++ b/inc/tasks/sendmailqueue.php
@@ -2,7 +2,7 @@
 /**
  * MyBB 1.8
  *
- * Copyright 2020 MyBB Group, All Rights Reserved
+ * Copyright 2020 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/threadviews.php
+++ b/inc/tasks/threadviews.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/usercleanup.php
+++ b/inc/tasks/usercleanup.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/userpruning.php
+++ b/inc/tasks/userpruning.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/inc/tasks/versioncheck.php
+++ b/inc/tasks/versioncheck.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/index.php
+++ b/install/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/language.lang.php
+++ b/install/resources/language.lang.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8 English Language Pack
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  */
 

--- a/install/resources/mysql_db_inserts.php
+++ b/install/resources/mysql_db_inserts.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/mysql_db_tables.php
+++ b/install/resources/mysql_db_tables.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/output.php
+++ b/install/resources/output.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/pgsql_db_inserts.php
+++ b/install/resources/pgsql_db_inserts.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/pgsql_db_tables.php
+++ b/install/resources/pgsql_db_tables.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/sqlite_db_tables.php
+++ b/install/resources/sqlite_db_tables.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade1.php
+++ b/install/resources/upgrade1.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade10.php
+++ b/install/resources/upgrade10.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade11.php
+++ b/install/resources/upgrade11.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade12.php
+++ b/install/resources/upgrade12.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade13.php
+++ b/install/resources/upgrade13.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade14.php
+++ b/install/resources/upgrade14.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade15.php
+++ b/install/resources/upgrade15.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade16.php
+++ b/install/resources/upgrade16.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade17.php
+++ b/install/resources/upgrade17.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade18.php
+++ b/install/resources/upgrade18.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade19.php
+++ b/install/resources/upgrade19.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade2.php
+++ b/install/resources/upgrade2.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade20.php
+++ b/install/resources/upgrade20.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade21.php
+++ b/install/resources/upgrade21.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade22.php
+++ b/install/resources/upgrade22.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade23.php
+++ b/install/resources/upgrade23.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade24.php
+++ b/install/resources/upgrade24.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade25.php
+++ b/install/resources/upgrade25.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade26.php
+++ b/install/resources/upgrade26.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade27.php
+++ b/install/resources/upgrade27.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade28.php
+++ b/install/resources/upgrade28.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade29.php
+++ b/install/resources/upgrade29.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade3.php
+++ b/install/resources/upgrade3.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade30.php
+++ b/install/resources/upgrade30.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade31.php
+++ b/install/resources/upgrade31.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade32.php
+++ b/install/resources/upgrade32.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade33.php
+++ b/install/resources/upgrade33.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade34.php
+++ b/install/resources/upgrade34.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade35.php
+++ b/install/resources/upgrade35.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade36.php
+++ b/install/resources/upgrade36.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade37.php
+++ b/install/resources/upgrade37.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade38.php
+++ b/install/resources/upgrade38.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade39.php
+++ b/install/resources/upgrade39.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade4.php
+++ b/install/resources/upgrade4.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade40.php
+++ b/install/resources/upgrade40.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade41.php
+++ b/install/resources/upgrade41.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade42.php
+++ b/install/resources/upgrade42.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade43.php
+++ b/install/resources/upgrade43.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2018 MyBB Group, All Rights Reserved
+ * Copyright 2018 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade44.php
+++ b/install/resources/upgrade44.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade45.php
+++ b/install/resources/upgrade45.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade46.php
+++ b/install/resources/upgrade46.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade47.php
+++ b/install/resources/upgrade47.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade48.php
+++ b/install/resources/upgrade48.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade49.php
+++ b/install/resources/upgrade49.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade5.php
+++ b/install/resources/upgrade5.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade50.php
+++ b/install/resources/upgrade50.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade51.php
+++ b/install/resources/upgrade51.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade52.php
+++ b/install/resources/upgrade52.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade53.php
+++ b/install/resources/upgrade53.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade54.php
+++ b/install/resources/upgrade54.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade55.php
+++ b/install/resources/upgrade55.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade56.php
+++ b/install/resources/upgrade56.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade57.php
+++ b/install/resources/upgrade57.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade6.php
+++ b/install/resources/upgrade6.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade7.php
+++ b/install/resources/upgrade7.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade8.php
+++ b/install/resources/upgrade8.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/resources/upgrade9.php
+++ b/install/resources/upgrade9.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/managegroup.php
+++ b/managegroup.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/member.php
+++ b/member.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/memberlist.php
+++ b/memberlist.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/misc.php
+++ b/misc.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/modcp.php
+++ b/modcp.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/moderation.php
+++ b/moderation.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/newreply.php
+++ b/newreply.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/newthread.php
+++ b/newthread.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/online.php
+++ b/online.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/polls.php
+++ b/polls.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/portal.php
+++ b/portal.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/printthread.php
+++ b/printthread.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/private.php
+++ b/private.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/ratethread.php
+++ b/ratethread.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/report.php
+++ b/report.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/reputation.php
+++ b/reputation.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/rss.php
+++ b/rss.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/search.php
+++ b/search.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/sendthread.php
+++ b/sendthread.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/showteam.php
+++ b/showteam.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/showthread.php
+++ b/showthread.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/stats.php
+++ b/stats.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/syndication.php
+++ b/syndication.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/task.php
+++ b/task.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/usercp.php
+++ b/usercp.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/warnings.php
+++ b/warnings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license

--- a/xmlhttp.php
+++ b/xmlhttp.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MyBB 1.8
- * Copyright 2014 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group
  *
  * Website: http://www.mybb.com
  * License: http://www.mybb.com/about/license


### PR DESCRIPTION
The phrase "All rights reserved" is not required to be granted protections, and it basically has no legal effects now. Using this phrase in a file or a project licensed under GPL/LGPL is not advisable.

See also: https://lists.debian.org/debian-legal/2007/06/msg00252.html
Resolves #4752 

