### PR TITLE
moderation.php: set default move forum in dropdown to current forum

### DIFF
--- a/moderation.php
+++ b/moderation.php
@@ -1020,7 +1020,7 @@ switch($mybb->input['action'])
 
 		$plugins->run_hooks("moderation_move");
 
-		$forumselect = build_forum_jump("", '', 1, '', 0, true, '', "moveto");
+		$forumselect = build_forum_jump("", $fid, 1, '', 0, true, '', "moveto");
 		eval("\$movethread = \"".$templates->get("moderation_move")."\";");
 		output_page($movethread);
 		break;


### PR DESCRIPTION
While this may sound like a silly default since it's the one place the thread will not need to be moved to, if you have a large number of forums and a common workflow is to move the thread to a sub-forum, this prevents a lot of scrolling through the dropdown to find the right forum.