### PR TITLE
Update QR image API URL

### DIFF
--- a/inc/3rdparty/2fa/GoogleAuthenticator.php
+++ b/inc/3rdparty/2fa/GoogleAuthenticator.php
@@ -109,7 +109,7 @@ class PHPGangsta_GoogleAuthenticator
             $urlencoded .= urlencode('&issuer='.urlencode($title));
         }
 
-        return 'https://chart.googleapis.com/chart?chs='.$width.'x'.$height.'&chld='.$level.'|0&cht=qr&chl='.$urlencoded.'';
+        return 'https://api.qrserver.com/v1/create-qr-code/?data='.$urlencoded.'&size='.$width.'x'.$height.'&ecc='.$level;
     }
 
     /**


### PR DESCRIPTION
Resolves #4796

Updates URL to one [used in the library](https://github.com/PHPGangsta/GoogleAuthenticator/blob/505c2af8337b559b33557f37cda38e5f843f3768/PHPGangsta/GoogleAuthenticator.php#L112) without the [deprecated](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation) `${}` string interpolation.