### PR TITLE
Remove wrong-context `canbeinvisible` conditions

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -307,7 +307,7 @@ if($mybb->settings['browsingthisforum'] != 0)
 		{
 			$doneusers[$user['uid']] = $user['time'];
 			++$membercount;
-			if($user['invisible'] == 1 && $mybb->usergroup['canbeinvisible'] == 1)
+			if($user['invisible'] == 1)
 			{
 				$invisiblemark = "*";
 				++$inviscount;

--- a/inc/functions_online.php
+++ b/inc/functions_online.php
@@ -1144,7 +1144,7 @@ function build_wol_row($user)
 		if($user['invisible'] != 1 || $mybb->usergroup['canviewwolinvis'] == 1 || $user['uid'] == $mybb->user['uid'])
 		{
 			// Append an invisible mark if the user is invisible
-			if($user['invisible'] == 1 && $mybb->usergroup['canbeinvisible'] == 1)
+			if($user['invisible'] == 1)
 			{
 				$invisible_mark = "*";
 			}

--- a/index.php
+++ b/index.php
@@ -116,7 +116,7 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 			if(empty($doneusers[$user['uid']]) || $doneusers[$user['uid']] < $user['time'])
 			{
 				// If the user is logged in anonymously, update the count for that.
-				if($user['invisible'] == 1 && $mybb->usergroup['canbeinvisible'] == 1)
+				if($user['invisible'] == 1)
 				{
 					++$anoncount;
 				}
@@ -124,7 +124,7 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 				if($user['invisible'] != 1 || $mybb->usergroup['canviewwolinvis'] == 1 || $user['uid'] == $mybb->user['uid'])
 				{
 					// If this usergroup can see anonymously logged-in users, mark them.
-					if($user['invisible'] == 1 && $mybb->usergroup['canbeinvisible'] == 1)
+					if($user['invisible'] == 1)
 					{
 						$invisiblemark = '*';
 					}

--- a/online.php
+++ b/online.php
@@ -75,7 +75,7 @@ if($mybb->get_input('action') == "today")
 	while($online = $db->fetch_array($query))
 	{
 		$invisiblemark = '';
-		if($online['invisible'] == 1 && $mybb->usergroup['canbeinvisible'] == 1)
+		if($online['invisible'] == 1)
 		{
 			$invisiblemark = "*";
 		}

--- a/showthread.php
+++ b/showthread.php
@@ -1560,7 +1560,7 @@ if($mybb->input['action'] == "thread")
 				$doneusers[$user['uid']] = $user['time'];
 
 				$invisiblemark = '';
-				if($user['invisible'] == 1 && $mybb->usergroup['canbeinvisible'] == 1)
+				if($user['invisible'] == 1)
 				{
 					$invisiblemark = "*";
 					++$inviscount;


### PR DESCRIPTION
Resolves #4801

Removes the additional conditions added in #4065

