### PR TITLE
Add MyBB 1.9 View internals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,9 @@
         "illuminate/hashing": "^10.0",
         "illuminate/routing": "^10.0",
         "laravel/helpers": "^1.7",
+        "scssphp/scssphp": "^1.12",
         "symfony/console": "^7.0",
-        "twig/twig": "^3.8"
+        "twig/twig": "^3.10"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
@@ -43,7 +44,8 @@
             "MyBB\\": "inc/src/"
         },
         "files": [
-            "inc/src/functions.php"
+            "inc/src/functions.php",
+            "inc/src/View/functions.php"
         ]
     },
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "389472cb9d662ecc07ef65539cfff683",
+    "content-hash": "a6bf828d1137b9dea4b4836b3c67d31c",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
-                "reference": "a31d3358a2a5d6ae947df1691d1f321418a5f3d5"
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/a31d3358a2a5d6ae947df1691d1f321418a5f3d5",
-                "reference": "a31d3358a2a5d6ae947df1691d1f321418a5f3d5",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
             ],
             "support": {
                 "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
-                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.1.0"
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.0"
             },
             "funding": [
                 {
@@ -73,20 +73,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-10T15:33:53+00:00"
+            "time": "2024-02-09T16:56:22+00:00"
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.8",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff"
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
                 "shasum": ""
             },
             "require": {
@@ -148,7 +148,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.8"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
             },
             "funding": [
                 {
@@ -164,7 +164,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-16T13:40:37+00:00"
+            "time": "2024-02-18T20:23:39+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -325,16 +325,16 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
-                "reference": "cb5e55e701a530222f62968086973bf70b2552e8"
+                "reference": "33993b8f54e91b03fb5000e55693e146e7370763"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/bus/zipball/cb5e55e701a530222f62968086973bf70b2552e8",
-                "reference": "cb5e55e701a530222f62968086973bf70b2552e8",
+                "url": "https://api.github.com/repos/illuminate/bus/zipball/33993b8f54e91b03fb5000e55693e146e7370763",
+                "reference": "33993b8f54e91b03fb5000e55693e146e7370763",
                 "shasum": ""
             },
             "require": {
@@ -374,20 +374,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-12-12T20:04:59+00:00"
+            "time": "2024-02-23T15:38:25+00:00"
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "8e4c4f97ea066cd6aec962ef8a6abc09dfd5e754"
+                "reference": "f9589f1063a449111dcaa1d68285b507d9483a95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/8e4c4f97ea066cd6aec962ef8a6abc09dfd5e754",
-                "reference": "8e4c4f97ea066cd6aec962ef8a6abc09dfd5e754",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/f9589f1063a449111dcaa1d68285b507d9483a95",
+                "reference": "f9589f1063a449111dcaa1d68285b507d9483a95",
                 "shasum": ""
             },
             "require": {
@@ -429,11 +429,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-11-27T14:46:52+00:00"
+            "time": "2024-03-20T20:09:13+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -479,7 +479,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -527,7 +527,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -578,16 +578,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "f6bf37a272fda164f6c451407c99f820eb1eb95b"
+                "reference": "8d7152c4a1f5d9cf7da3e8b71f23e4556f6138ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/f6bf37a272fda164f6c451407c99f820eb1eb95b",
-                "reference": "f6bf37a272fda164f6c451407c99f820eb1eb95b",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/8d7152c4a1f5d9cf7da3e8b71f23e4556f6138ac",
+                "reference": "8d7152c4a1f5d9cf7da3e8b71f23e4556f6138ac",
                 "shasum": ""
             },
             "require": {
@@ -622,20 +622,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-10-30T00:59:22+00:00"
+            "time": "2024-01-15T18:52:32+00:00"
         },
         {
             "name": "illuminate/events",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
-                "reference": "8d84d6220a6b3446a0bf3e4138e2eb0e10792bb1"
+                "reference": "a931bfa88edc6ac52c9abbfd7b769343d321d3eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/events/zipball/8d84d6220a6b3446a0bf3e4138e2eb0e10792bb1",
-                "reference": "8d84d6220a6b3446a0bf3e4138e2eb0e10792bb1",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/a931bfa88edc6ac52c9abbfd7b769343d321d3eb",
+                "reference": "a931bfa88edc6ac52c9abbfd7b769343d321d3eb",
                 "shasum": ""
             },
             "require": {
@@ -677,20 +677,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-10-30T00:59:35+00:00"
+            "time": "2024-03-04T14:41:04+00:00"
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "3b28fdd05812399d401d2bcc03b4a6abb5882979"
+                "reference": "592fb581a52fba43bf78c2e4b22db540c9f9f149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/3b28fdd05812399d401d2bcc03b4a6abb5882979",
-                "reference": "3b28fdd05812399d401d2bcc03b4a6abb5882979",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/592fb581a52fba43bf78c2e4b22db540c9f9f149",
+                "reference": "592fb581a52fba43bf78c2e4b22db540c9f9f149",
                 "shasum": ""
             },
             "require": {
@@ -721,6 +721,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "functions.php"
+                ],
                 "psr-4": {
                     "Illuminate\\Filesystem\\": ""
                 }
@@ -741,11 +744,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-12-06T15:24:58+00:00"
+            "time": "2024-03-11T21:45:53+00:00"
         },
         {
             "name": "illuminate/hashing",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/hashing.git",
@@ -793,16 +796,16 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
-                "reference": "556553a9944ee2fb4c9996804204f0c4a5f85041"
+                "reference": "0dd2ee794017c7f5e811cf8fb0dc74c646918d30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/http/zipball/556553a9944ee2fb4c9996804204f0c4a5f85041",
-                "reference": "556553a9944ee2fb4c9996804204f0c4a5f85041",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/0dd2ee794017c7f5e811cf8fb0dc74c646918d30",
+                "reference": "0dd2ee794017c7f5e811cf8fb0dc74c646918d30",
                 "shasum": ""
             },
             "require": {
@@ -849,11 +852,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-11-30T22:32:43+00:00"
+            "time": "2024-02-21T15:19:17+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -899,16 +902,16 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
-                "reference": "f2119ae9a26e420bf0ed9d5e7e7aa4548547e7b1"
+                "reference": "f802187e917a171332cc90f8c1a102939c57405d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/pipeline/zipball/f2119ae9a26e420bf0ed9d5e7e7aa4548547e7b1",
-                "reference": "f2119ae9a26e420bf0ed9d5e7e7aa4548547e7b1",
+                "url": "https://api.github.com/repos/illuminate/pipeline/zipball/f802187e917a171332cc90f8c1a102939c57405d",
+                "reference": "f802187e917a171332cc90f8c1a102939c57405d",
                 "shasum": ""
             },
             "require": {
@@ -943,20 +946,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-03-03T15:55:44+00:00"
+            "time": "2023-12-19T14:47:26+00:00"
         },
         {
             "name": "illuminate/routing",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/routing.git",
-                "reference": "260d5993fc08d668ae158cf87c01d667870f74f6"
+                "reference": "eec2466ce61f0ed24e5adfec999765efdf382a6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/routing/zipball/260d5993fc08d668ae158cf87c01d667870f74f6",
-                "reference": "260d5993fc08d668ae158cf87c01d667870f74f6",
+                "url": "https://api.github.com/repos/illuminate/routing/zipball/eec2466ce61f0ed24e5adfec999765efdf382a6c",
+                "reference": "eec2466ce61f0ed24e5adfec999765efdf382a6c",
                 "shasum": ""
             },
             "require": {
@@ -1007,20 +1010,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-12-07T19:28:35+00:00"
+            "time": "2024-03-11T21:46:09+00:00"
         },
         {
             "name": "illuminate/session",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
-                "reference": "27fe05da9e1e8f5febddbb8bb0df173f2ac9fbb8"
+                "reference": "a095707b83327e27ba292c9c4d2413888b1f517c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/session/zipball/27fe05da9e1e8f5febddbb8bb0df173f2ac9fbb8",
-                "reference": "27fe05da9e1e8f5febddbb8bb0df173f2ac9fbb8",
+                "url": "https://api.github.com/repos/illuminate/session/zipball/a095707b83327e27ba292c9c4d2413888b1f517c",
+                "reference": "a095707b83327e27ba292c9c4d2413888b1f517c",
                 "shasum": ""
             },
             "require": {
@@ -1064,20 +1067,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-11-30T22:32:43+00:00"
+            "time": "2023-12-29T21:53:12+00:00"
         },
         {
             "name": "illuminate/support",
-            "version": "v10.37.3",
+            "version": "v10.48.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "c28657bdda8014017197e2a40edd7d162ce03e8a"
+                "reference": "ee3a1aaed36d916654ce0ae09dfbd38644a4f582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/c28657bdda8014017197e2a40edd7d162ce03e8a",
-                "reference": "c28657bdda8014017197e2a40edd7d162ce03e8a",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/ee3a1aaed36d916654ce0ae09dfbd38644a4f582",
+                "reference": "ee3a1aaed36d916654ce0ae09dfbd38644a4f582",
                 "shasum": ""
             },
             "require": {
@@ -1135,7 +1138,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-12-12T19:36:09+00:00"
+            "time": "2024-04-07T17:47:33+00:00"
         },
         {
             "name": "laravel/helpers",
@@ -1196,16 +1199,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.72.1",
+            "version": "2.72.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78"
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
-                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/0c6fd108360c562f6e4fd1dedb8233b423e91c83",
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83",
                 "shasum": ""
             },
             "require": {
@@ -1299,7 +1302,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-08T23:47:49+00:00"
+            "time": "2024-01-25T10:35:09+00:00"
         },
         {
             "name": "psr/clock",
@@ -1554,17 +1557,97 @@
             "time": "2021-10-29T13:26:27+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v7.0.1",
+            "name": "scssphp/scssphp",
+            "version": "v1.12.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "cdce5c684b2f920bb1343deecdfba356ffad83d5"
+                "url": "https://github.com/scssphp/scssphp.git",
+                "reference": "394ed1e960138710a60d035c1a85d43d0bf0faeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cdce5c684b2f920bb1343deecdfba356ffad83d5",
-                "reference": "cdce5c684b2f920bb1343deecdfba356ffad83d5",
+                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/394ed1e960138710a60d035c1a85d43d0bf0faeb",
+                "reference": "394ed1e960138710a60d035c1a85d43d0bf0faeb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
+                "sass/sass-spec": "*",
+                "squizlabs/php_codesniffer": "~3.5",
+                "symfony/phpunit-bridge": "^5.1",
+                "thoughtbot/bourbon": "^7.0",
+                "twbs/bootstrap": "~5.0",
+                "twbs/bootstrap4": "4.6.1",
+                "zurb/foundation": "~6.7.0"
+            },
+            "suggest": {
+                "ext-iconv": "Can be used as fallback when ext-mbstring is not available",
+                "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv"
+            },
+            "bin": [
+                "bin/pscss"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "forward-command": false,
+                    "bin-links": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ScssPhp\\ScssPhp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthon Pang",
+                    "email": "apang@softwaredevelopment.ca",
+                    "homepage": "https://github.com/robocoder"
+                },
+                {
+                    "name": "Cédric Morin",
+                    "email": "cedric@yterium.com",
+                    "homepage": "https://github.com/Cerdic"
+                }
+            ],
+            "description": "scssphp is a compiler for SCSS written in PHP.",
+            "homepage": "http://scssphp.github.io/scssphp/",
+            "keywords": [
+                "css",
+                "less",
+                "sass",
+                "scss",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/scssphp/scssphp/issues",
+                "source": "https://github.com/scssphp/scssphp/tree/v1.12.1"
+            },
+            "time": "2024-01-13T12:36:40+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c981e0e9380ce9f146416bde3150c79197ce9986",
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986",
                 "shasum": ""
             },
             "require": {
@@ -1628,7 +1711,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.0.1"
+                "source": "https://github.com/symfony/console/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -1644,20 +1727,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T15:10:06+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.4.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
                 "shasum": ""
             },
             "require": {
@@ -1666,7 +1749,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1695,7 +1778,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -1711,20 +1794,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "80b1258be1b84c12a345d0ec3881bbf2e5270cc2"
+                "reference": "cf97429887e40480c847bfeb6c3991e1e2c086ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/80b1258be1b84c12a345d0ec3881bbf2e5270cc2",
-                "reference": "80b1258be1b84c12a345d0ec3881bbf2e5270cc2",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/cf97429887e40480c847bfeb6c3991e1e2c086ab",
+                "reference": "cf97429887e40480c847bfeb6c3991e1e2c086ab",
                 "shasum": ""
             },
             "require": {
@@ -1770,7 +1853,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.0.0"
+                "source": "https://github.com/symfony/error-handler/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -1786,20 +1869,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-20T16:35:23+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "c459b40ffe67c49af6fd392aac374c9edf8a027e"
+                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c459b40ffe67c49af6fd392aac374c9edf8a027e",
-                "reference": "c459b40ffe67c49af6fd392aac374c9edf8a027e",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/db2a7fab994d67d92356bb39c367db115d9d30f9",
+                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9",
                 "shasum": ""
             },
             "require": {
@@ -1850,7 +1933,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.0.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -1866,20 +1949,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-27T16:29:09+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.4.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df"
+                "reference": "8f93aec25d41b72493c6ddff14e916177c9efc50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/8f93aec25d41b72493c6ddff14e916177c9efc50",
+                "reference": "8f93aec25d41b72493c6ddff14e916177c9efc50",
                 "shasum": ""
             },
             "require": {
@@ -1889,7 +1972,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1926,7 +2009,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -1942,20 +2025,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.4.0",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "11d736e97f116ac375a81f96e662911a34cd50ce"
+                "reference": "511c48990be17358c23bf45c5d71ab85d40fb764"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/11d736e97f116ac375a81f96e662911a34cd50ce",
-                "reference": "11d736e97f116ac375a81f96e662911a34cd50ce",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/511c48990be17358c23bf45c5d71ab85d40fb764",
+                "reference": "511c48990be17358c23bf45c5d71ab85d40fb764",
                 "shasum": ""
             },
             "require": {
@@ -1990,7 +2073,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.0"
+                "source": "https://github.com/symfony/finder/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -2006,20 +2089,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-31T17:30:12+00:00"
+            "time": "2024-04-23T10:36:43+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.0",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "44a6d39a9cc11e154547d882d5aac1e014440771"
+                "reference": "b4db6b833035477cb70e18d0ae33cb7c2b521759"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/44a6d39a9cc11e154547d882d5aac1e014440771",
-                "reference": "44a6d39a9cc11e154547d882d5aac1e014440771",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b4db6b833035477cb70e18d0ae33cb7c2b521759",
+                "reference": "b4db6b833035477cb70e18d0ae33cb7c2b521759",
                 "shasum": ""
             },
             "require": {
@@ -2067,7 +2150,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.0"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -2083,20 +2166,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-20T16:41:16+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.1",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "2953274c16a229b3933ef73a6898e18388e12e1b"
+                "reference": "b7b5e6cdef670a0c82d015a966ffc7e855861a98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/2953274c16a229b3933ef73a6898e18388e12e1b",
-                "reference": "2953274c16a229b3933ef73a6898e18388e12e1b",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/b7b5e6cdef670a0c82d015a966ffc7e855861a98",
+                "reference": "b7b5e6cdef670a0c82d015a966ffc7e855861a98",
                 "shasum": ""
             },
             "require": {
@@ -2145,12 +2228,13 @@
                 "symfony/process": "^5.4|^6.0|^7.0",
                 "symfony/property-access": "^5.4.5|^6.0.5|^7.0",
                 "symfony/routing": "^5.4|^6.0|^7.0",
-                "symfony/serializer": "^6.3|^7.0",
+                "symfony/serializer": "^6.4.4|^7.0.4",
                 "symfony/stopwatch": "^5.4|^6.0|^7.0",
                 "symfony/translation": "^5.4|^6.0|^7.0",
                 "symfony/translation-contracts": "^2.5|^3",
                 "symfony/uid": "^5.4|^6.0|^7.0",
                 "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.4|^7.0",
                 "symfony/var-exporter": "^6.2|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
             },
@@ -2180,7 +2264,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.1"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -2196,20 +2280,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T17:02:02+00:00"
+            "time": "2024-04-29T11:24:44+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.0",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "ca4f58b2ef4baa8f6cecbeca2573f88cd577d205"
+                "reference": "decadcf3865918ecfcbfa90968553994ce935a5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/ca4f58b2ef4baa8f6cecbeca2573f88cd577d205",
-                "reference": "ca4f58b2ef4baa8f6cecbeca2573f88cd577d205",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/decadcf3865918ecfcbfa90968553994ce935a5e",
+                "reference": "decadcf3865918ecfcbfa90968553994ce935a5e",
                 "shasum": ""
             },
             "require": {
@@ -2230,6 +2314,7 @@
                 "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
                 "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.4|^7.0",
                 "symfony/property-access": "^5.4|^6.0|^7.0",
                 "symfony/property-info": "^5.4|^6.0|^7.0",
                 "symfony/serializer": "^6.3.2|^7.0"
@@ -2264,7 +2349,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.0"
+                "source": "https://github.com/symfony/mime/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -2280,20 +2365,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-17T11:49:05+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
                 "shasum": ""
             },
             "require": {
@@ -2307,9 +2392,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2346,7 +2428,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2362,20 +2444,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "875e90aeea2777b6f135677f618529449334a612"
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
-                "reference": "875e90aeea2777b6f135677f618529449334a612",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
                 "shasum": ""
             },
             "require": {
@@ -2386,9 +2468,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2427,7 +2506,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2443,20 +2522,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
+                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a287ed7475f85bf6f61890146edbc932c0fff919",
+                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919",
                 "shasum": ""
             },
             "require": {
@@ -2469,9 +2548,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2514,7 +2590,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2530,20 +2606,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:30:37+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
                 "shasum": ""
             },
             "require": {
@@ -2554,9 +2630,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2598,7 +2671,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2614,20 +2687,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
                 "shasum": ""
             },
             "require": {
@@ -2641,9 +2714,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2681,7 +2751,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2697,20 +2767,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179"
+                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/70f4aebd92afca2f865444d30a4d2151c13c3179",
-                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/861391a8da9a04cbad2d232ddd9e4893220d6e25",
+                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25",
                 "shasum": ""
             },
             "require": {
@@ -2718,9 +2788,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2757,7 +2824,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2773,20 +2840,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
                 "shasum": ""
             },
             "require": {
@@ -2794,9 +2861,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2840,7 +2904,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2856,20 +2920,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11"
+                "reference": "86fcae159633351e5fd145d1c47de6c528f8caff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
-                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/86fcae159633351e5fd145d1c47de6c528f8caff",
+                "reference": "86fcae159633351e5fd145d1c47de6c528f8caff",
                 "shasum": ""
             },
             "require": {
@@ -2878,9 +2942,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2920,7 +2981,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -2936,20 +2997,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-16T06:22:46+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.1",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "0c95c164fdba18b12523b75e64199ca3503e6d40"
+                "reference": "276e06398f71fa2a973264d94f28150f93cfb907"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/0c95c164fdba18b12523b75e64199ca3503e6d40",
-                "reference": "0c95c164fdba18b12523b75e64199ca3503e6d40",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/276e06398f71fa2a973264d94f28150f93cfb907",
+                "reference": "276e06398f71fa2a973264d94f28150f93cfb907",
                 "shasum": ""
             },
             "require": {
@@ -3003,7 +3064,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.1"
+                "source": "https://github.com/symfony/routing/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -3019,25 +3080,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T14:54:37+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.4.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^2.0"
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -3045,7 +3107,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3085,7 +3147,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -3101,20 +3163,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-30T20:28:31+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620"
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
-                "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
                 "shasum": ""
             },
             "require": {
@@ -3171,7 +3233,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.0.0"
+                "source": "https://github.com/symfony/string/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3187,20 +3249,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-29T08:40:23+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.0",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37"
+                "reference": "7495687c58bfd88b7883823747b0656d90679123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37",
-                "reference": "b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/7495687c58bfd88b7883823747b0656d90679123",
+                "reference": "7495687c58bfd88b7883823747b0656d90679123",
                 "shasum": ""
             },
             "require": {
@@ -3223,7 +3285,7 @@
                 "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.18|^5.0",
                 "psr/log": "^1|^2|^3",
                 "symfony/config": "^5.4|^6.0|^7.0",
                 "symfony/console": "^5.4|^6.0|^7.0",
@@ -3266,7 +3328,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.0"
+                "source": "https://github.com/symfony/translation/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -3282,20 +3344,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-29T08:14:36+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.4.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "dee0c6e5b4c07ce851b462530088e64b255ac9c5"
+                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/dee0c6e5b4c07ce851b462530088e64b255ac9c5",
-                "reference": "dee0c6e5b4c07ce851b462530088e64b255ac9c5",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
+                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
                 "shasum": ""
             },
             "require": {
@@ -3304,7 +3366,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3344,7 +3406,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -3360,20 +3422,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-25T15:08:44+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "cf0220fc7607476fd0d001ab3ed9e830d1fdda56"
+                "reference": "d1627b66fd87c8b4d90cabe5671c29d575690924"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cf0220fc7607476fd0d001ab3ed9e830d1fdda56",
-                "reference": "cf0220fc7607476fd0d001ab3ed9e830d1fdda56",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/d1627b66fd87c8b4d90cabe5671c29d575690924",
+                "reference": "d1627b66fd87c8b4d90cabe5671c29d575690924",
                 "shasum": ""
             },
             "require": {
@@ -3427,7 +3489,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.0.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3443,34 +3505,41 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-27T12:39:18+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.8.0",
+            "version": "v3.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
+                "reference": "67f29781ffafa520b0bbfbd8384674b42db04572"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
-                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/67f29781ffafa520b0bbfbd8384674b42db04572",
+                "reference": "67f29781ffafa520b0bbfbd8384674b42db04572",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3",
                 "symfony/polyfill-php80": "^1.22"
             },
             "require-dev": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -3503,7 +3572,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.10.3"
             },
             "funding": [
                 {
@@ -3515,7 +3584,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-21T18:54:41+00:00"
+            "time": "2024-05-16T10:04:27+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -3646,16 +3715,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.7",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
-                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
@@ -3667,8 +3736,8 @@
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.6.10",
-                "symplify/easy-coding-standard": "^12.0.8"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
             "autoload": {
@@ -3725,7 +3794,7 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-12-10T02:24:34+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3788,25 +3857,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -3814,7 +3885,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3838,26 +3909,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-03-05T20:51:40+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -3898,9 +3970,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -3955,35 +4033,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.10",
+            "version": "11.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "599109c8ca6bae97b23482d557d2874c25a65e59"
+                "reference": "7e35a2cbcabac0e6865fd373742ea432a3c34f92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/599109c8ca6bae97b23482d557d2874c25a65e59",
-                "reference": "599109c8ca6bae97b23482d557d2874c25a65e59",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e35a2cbcabac0e6865fd373742ea432a3c34f92",
+                "reference": "7e35a2cbcabac0e6865fd373742ea432a3c34f92",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^3.0",
-                "sebastian/complexity": "^3.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/lines-of-code": "^2.0",
-                "sebastian/version": "^4.0",
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.0",
+                "phpunit/php-text-template": "^4.0",
+                "sebastian/code-unit-reverse-lookup": "^4.0",
+                "sebastian/complexity": "^4.0",
+                "sebastian/environment": "^7.0",
+                "sebastian/lines-of-code": "^3.0",
+                "sebastian/version": "^5.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -3992,7 +4070,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "11.0-dev"
                 }
             },
             "autoload": {
@@ -4021,7 +4099,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.3"
             },
             "funding": [
                 {
@@ -4029,32 +4107,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-11T06:28:43+00:00"
+            "time": "2024-03-12T15:35:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "99e95c94ad9500daca992354fa09d7b99abe2210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/99e95c94ad9500daca992354fa09d7b99abe2210",
+                "reference": "99e95c94ad9500daca992354fa09d7b99abe2210",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4082,7 +4160,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4090,28 +4168,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2024-02-02T06:05:04+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "5d8d9355a16d8cc5a1305b0a85342cfa420612be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5d8d9355a16d8cc5a1305b0a85342cfa420612be",
+                "reference": "5d8d9355a16d8cc5a1305b0a85342cfa420612be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -4119,7 +4197,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4145,7 +4223,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4153,32 +4232,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2024-02-02T06:05:50+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "d38f6cbff1cdb6f40b03c9811421561668cc133e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/d38f6cbff1cdb6f40b03c9811421561668cc133e",
+                "reference": "d38f6cbff1cdb6f40b03c9811421561668cc133e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4205,7 +4284,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.0"
             },
             "funding": [
                 {
@@ -4213,32 +4292,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2024-02-02T06:06:56+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "8a59d9e25720482ee7fcdf296595e08795b84dc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8a59d9e25720482ee7fcdf296595e08795b84dc5",
+                "reference": "8a59d9e25720482ee7fcdf296595e08795b84dc5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4264,7 +4343,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.0"
             },
             "funding": [
                 {
@@ -4272,20 +4352,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2024-02-02T06:08:01+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.3",
+            "version": "11.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6fce887c71076a73f32fd3e0774a6833fc5c7f19"
+                "reference": "d475be032238173ca3b0a516f5cc291d174708ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6fce887c71076a73f32fd3e0774a6833fc5c7f19",
-                "reference": "6fce887c71076a73f32fd3e0774a6833fc5c7f19",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d475be032238173ca3b0a516f5cc291d174708ae",
+                "reference": "d475be032238173ca3b0a516f5cc291d174708ae",
                 "shasum": ""
             },
             "require": {
@@ -4298,23 +4378,22 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0",
+                "phpunit/php-file-iterator": "^5.0",
+                "phpunit/php-invoker": "^5.0",
+                "phpunit/php-text-template": "^4.0",
+                "phpunit/php-timer": "^7.0",
+                "sebastian/cli-parser": "^3.0",
+                "sebastian/code-unit": "^3.0",
+                "sebastian/comparator": "^6.0",
+                "sebastian/diff": "^6.0",
+                "sebastian/environment": "^7.0",
+                "sebastian/exporter": "^6.0",
+                "sebastian/global-state": "^7.0",
+                "sebastian/object-enumerator": "^6.0",
+                "sebastian/type": "^5.0",
+                "sebastian/version": "^5.0"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -4325,7 +4404,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -4357,7 +4436,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.1.3"
             },
             "funding": [
                 {
@@ -4373,32 +4452,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-13T07:25:23+00:00"
+            "time": "2024-04-24T06:34:25+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+                "reference": "00a74d5568694711f0222e54fb281e1d15fdf04a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/00a74d5568694711f0222e54fb281e1d15fdf04a",
+                "reference": "00a74d5568694711f0222e54fb281e1d15fdf04a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4421,7 +4500,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.1"
             },
             "funding": [
                 {
@@ -4429,32 +4509,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:15+00:00"
+            "time": "2024-03-02T07:26:58+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "6634549cb8d702282a04a774e36a7477d2bd9015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/6634549cb8d702282a04a774e36a7477d2bd9015",
+                "reference": "6634549cb8d702282a04a774e36a7477d2bd9015",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4477,7 +4557,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.0"
             },
             "funding": [
                 {
@@ -4485,32 +4566,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2024-02-02T05:50:41+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "df80c875d3e459b45c6039e4d9b71d4fbccae25d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/df80c875d3e459b45c6039e4d9b71d4fbccae25d",
+                "reference": "df80c875d3e459b45c6039e4d9b71d4fbccae25d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4532,7 +4613,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.0"
             },
             "funding": [
                 {
@@ -4540,36 +4622,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2024-02-02T05:52:17+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
+                "reference": "bd0f2fa5b9257c69903537b266ccb80fcf940db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/bd0f2fa5b9257c69903537b266ccb80fcf940db8",
+                "reference": "bd0f2fa5b9257c69903537b266ccb80fcf940db8",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4609,7 +4691,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4617,33 +4699,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-14T13:18:12+00:00"
+            "time": "2024-02-02T05:53:45+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.1.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957"
+                "reference": "88a434ad86150e11a606ac4866b09130712671f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68cfb347a44871f01e33ab0ef8215966432f6957",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/88a434ad86150e11a606ac4866b09130712671f0",
+                "reference": "88a434ad86150e11a606ac4866b09130712671f0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4667,7 +4749,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.1.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.0"
             },
             "funding": [
                 {
@@ -4675,33 +4757,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-28T11:50:59+00:00"
+            "time": "2024-02-02T05:55:19+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "ab83243ecc233de5655b76f577711de9f842e712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ab83243ecc233de5655b76f577711de9f842e712",
+                "reference": "ab83243ecc233de5655b76f577711de9f842e712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
+                "phpunit/phpunit": "^11.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4734,7 +4816,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.1"
             },
             "funding": [
                 {
@@ -4742,27 +4824,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2024-03-02T07:30:33+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.1",
+            "version": "7.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
+                "reference": "4eb3a442574d0e9d141aab209cd4aaf25701b09a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4eb3a442574d0e9d141aab209cd4aaf25701b09a",
+                "reference": "4eb3a442574d0e9d141aab209cd4aaf25701b09a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -4770,7 +4852,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -4798,7 +4880,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.1.0"
             },
             "funding": [
                 {
@@ -4806,34 +4888,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-11T05:39:26+00:00"
+            "time": "2024-03-23T08:56:34+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.1",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
+                "reference": "f291e5a317c321c0381fa9ecc796fa2d21b186da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f291e5a317c321c0381fa9ecc796fa2d21b186da",
+                "reference": "f291e5a317c321c0381fa9ecc796fa2d21b186da",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4876,7 +4958,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.0.1"
             },
             "funding": [
                 {
@@ -4884,35 +4966,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-24T13:22:09+00:00"
+            "time": "2024-03-02T07:28:20+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.1",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
+                "reference": "c3a307e832f2e69c7ef869e31fc644fde0e7cb3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c3a307e832f2e69c7ef869e31fc644fde0e7cb3e",
+                "reference": "c3a307e832f2e69c7ef869e31fc644fde0e7cb3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4931,14 +5013,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.1"
             },
             "funding": [
                 {
@@ -4946,33 +5028,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-19T07:19:23+00:00"
+            "time": "2024-03-02T07:32:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d"
+                "reference": "376c5b3f6b43c78fdc049740bca76a7c846706c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/649e40d279e243d985aa8fb6e74dd5bb28dc185d",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/376c5b3f6b43c78fdc049740bca76a7c846706c0",
+                "reference": "376c5b3f6b43c78fdc049740bca76a7c846706c0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4996,7 +5078,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.0"
             },
             "funding": [
                 {
@@ -5004,34 +5086,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T09:25:50+00:00"
+            "time": "2024-02-02T06:00:36+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "f75f6c460da0bbd9668f43a3dde0ec0ba7faa678"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f75f6c460da0bbd9668f43a3dde0ec0ba7faa678",
+                "reference": "f75f6c460da0bbd9668f43a3dde0ec0ba7faa678",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5053,7 +5135,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.0"
             },
             "funding": [
                 {
@@ -5061,32 +5144,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2024-02-02T06:01:29+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "bb2a6255d30853425fd38f032eb64ced9f7f132d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/bb2a6255d30853425fd38f032eb64ced9f7f132d",
+                "reference": "bb2a6255d30853425fd38f032eb64ced9f7f132d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5108,7 +5191,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.0"
             },
             "funding": [
                 {
@@ -5116,32 +5200,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2024-02-02T06:02:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
+                "reference": "b75224967b5a466925c6d54e68edd0edf8dd4ed4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b75224967b5a466925c6d54e68edd0edf8dd4ed4",
+                "reference": "b75224967b5a466925c6d54e68edd0edf8dd4ed4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5171,7 +5255,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.0"
             },
             "funding": [
                 {
@@ -5179,32 +5264,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:05:40+00:00"
+            "time": "2024-02-02T06:08:48+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "reference": "b8502785eb3523ca0dd4afe9ca62235590020f3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8502785eb3523ca0dd4afe9ca62235590020f3f",
+                "reference": "b8502785eb3523ca0dd4afe9ca62235590020f3f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -5227,7 +5312,8 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.0.0"
             },
             "funding": [
                 {
@@ -5235,29 +5321,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2024-02-02T06:09:34+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "13999475d2cb1ab33cb73403ba356a814fdbb001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/13999475d2cb1ab33cb73403ba356a814fdbb001",
+                "reference": "13999475d2cb1ab33cb73403ba356a814fdbb001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -5280,7 +5366,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.0"
             },
             "funding": [
                 {
@@ -5288,20 +5375,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2024-02-02T06:10:47+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
                 "shasum": ""
             },
             "require": {
@@ -5311,11 +5398,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -5368,20 +5455,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-04-23T20:25:34+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -5410,7 +5497,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -5418,7 +5505,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],

--- a/global.php
+++ b/global.php
@@ -466,6 +466,23 @@ if(!preg_match("#^(\.\.?(/|$)|([a-z0-9]+)://)#i", $theme['logo']) && substr($the
 	$theme['logo'] = $mybb->get_asset_url($theme['logo']);
 }
 
+// TODO determine package name from DB/cache; `core.default` already registered by default
+$packageName = \MyBB\View\DEFAULT_THEME_PACKAGE;
+
+\MyBB\app()->instance(
+	\MyBB\Extensions\Theme::class,
+	\MyBB\Extensions\Theme::get($packageName),
+);
+
+$view = \MyBB\app(\MyBB\View\Runtime\Runtime::class);
+
+$view->setContext([
+	'script' => basename($_SERVER['PHP_SELF']),
+	'action' => $mybb->get_input('action'),
+]);
+
+$view->setMainNamespace('frontend');
+
 // Load Main Templates and Cached Templates
 if(isset($templatelist))
 {

--- a/inc/src/Application.php
+++ b/inc/src/Application.php
@@ -150,6 +150,8 @@ class Application extends Container implements \Illuminate\Contracts\Foundation\
         $this->registerDeferredProvider(Hashing\ServiceProvider::class);
 
         $this->registerDeferredProvider(Plugins\ServiceProvider::class);
+
+        $this->registerDeferredProvider(View\ServiceProvider::class);
     }
 
     /**

--- a/inc/src/Cargo/Decorator/HierarchicalRepository.php
+++ b/inc/src/Cargo/Decorator/HierarchicalRepository.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Cargo\Decorator;
+
+use BadMethodCallException;
+use Illuminate\Support\Arr;
+use MyBB\Cargo\EntityInterface;
+use MyBB\Cargo\FileRepositoryInterface;
+use MyBB\Cargo\Repository;
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\Utilities\Hydrable\Hydrable;
+
+abstract class HierarchicalRepository extends RepositoryDecorator implements RepositoryInterface
+{
+    protected const NON_INHERITABLE_PROPERTIES = [
+        Repository::ANCESTOR_DECLARATIONS_KEY,
+    ];
+
+    public Hydrable $resolvedProperties;
+    public Hydrable $resolvedRepositories;
+
+    public function __construct()
+    {
+        $this->resolvedProperties = new Hydrable([
+            Repository::SCOPE_SHARED => [],
+            Repository::SCOPE_ENTITY => [],
+        ]);
+        $this->resolvedRepositories = new Hydrable([]);
+    }
+
+    public function getSharedProperties(): array
+    {
+        return $this->resolvedProperties->getNested([
+            Repository::SCOPE_SHARED,
+        ]);
+    }
+
+    public function getSharedProperty(string $key): mixed
+    {
+        return $this->resolvedProperties->getNested([
+            Repository::SCOPE_SHARED,
+            $key,
+        ]);
+    }
+
+    public function setSharedProperty(string $key, mixed $value): void
+    {
+        $this->getDecorated()->setSharedProperty($key, $value);
+
+        $this->resolvedProperties->build();
+    }
+
+    public function getEntityProperties(?string $key = null): array
+    {
+        if ($key === null) {
+            return $this->resolvedProperties->getNested([
+                Repository::SCOPE_ENTITY,
+            ]);
+        } else {
+            return $this->resolvedProperties->getNested([
+                Repository::SCOPE_ENTITY,
+                $key,
+            ]) ?? [];
+        }
+    }
+
+    public function setEntityProperties(string $key, array $data): void
+    {
+        $this->getDecorated()->setEntityProperties($key, $data);
+
+        $this->resolvedProperties->build();
+    }
+
+    public function getAll(...$args): array
+    {
+        if (!($this->getDecorated() instanceof FileRepositoryInterface)) {
+            throw new BadMethodCallException('`' . __FUNCTION__ . '()` can only be used on decorated Repositories implementing `' . FileRepositoryInterface::class . '`');
+        }
+
+        $results = [];
+        $disinherited = [];
+
+        foreach ($this->getAncestors() as $repository) {
+            $entities = $repository->getAll(...$args);
+
+            foreach ($entities as $key => $entity) {
+                if (!in_array($key, $disinherited)) {
+                    $results[$key] ??= $this->get($key); // use own decorated method
+                }
+            }
+
+            $disinherited = array_merge(
+                $disinherited,
+                $repository->getEntitiesDeclaredDisinherited(),
+            );
+        }
+
+        return $results;
+    }
+
+    public function getResolved(string $key): ?EntityInterface
+    {
+        return $this->getResolvedRepository($key)?->get($key);
+    }
+
+    /**
+     * Returns the entity's effective Repository using cache.
+     */
+    public function getResolvedRepository(string $key): ?RepositoryInterface
+    {
+        $repository = $this->resolvedRepositories->getNested([
+            $key,
+        ]);
+
+        if ($repository !== null) {
+            return $repository;
+        }
+
+        return $this->resolveRepository($key);
+    }
+
+    /**
+     * Returns the entity's effective Repository, and caches the result.
+     */
+    public function resolveRepository(string $key): ?RepositoryInterface
+    {
+        $repository = $this->queryRepository($key);
+
+        if ($repository !== null) {
+            $this->resolvedRepositories->setNested([
+                $key,
+            ], $repository);
+        }
+
+        return $repository;
+    }
+
+    /**
+     * Returns the entity's effective Repository.
+     */
+    public function queryRepository(string $key): ?RepositoryInterface
+    {
+        return $this->getOwnRepository()->has($key)
+            ? $this->getOwnRepository()
+            : $this->getClosestEntityAncestorRepository($key)
+        ;
+    }
+
+    public function getClosestEntityAncestorRepository(string $key): ?RepositoryInterface
+    {
+        return $this->getEntityAncestorRepositories($key)?->current();
+    }
+
+    /**
+     * @return iterable<RepositoryInterface>
+     */
+    public function getEntityAncestorRepositories(string $key): iterable
+    {
+        foreach ($this->getAncestors() as $repository) {
+            if (
+                $repository !== $this->getOwnRepository() &&
+                $repository->has($key)
+            ) {
+                yield $repository;
+            } elseif (
+                !$repository->entityDeclaredInherited($key)
+            ) {
+                break;
+            }
+        }
+    }
+
+    protected function buildResolvedProperties(&$stamp = []): array
+    {
+        $results = [
+            Repository::SCOPE_SHARED => [],
+            Repository::SCOPE_ENTITY => [],
+        ];
+
+        $disinherited = [];
+
+        foreach ($this->getAncestors() as $repository) {
+            $results[Repository::SCOPE_SHARED] = $this->getMergedProperties(
+                $repository->getSharedProperties(),
+                $results[Repository::SCOPE_SHARED],
+            );
+
+            foreach ($repository->getEntityProperties() as $identifier => $entityProperties) {
+                if (!in_array($identifier, $disinherited)) {
+                    $results[Repository::SCOPE_ENTITY][$identifier] = $this->getMergedProperties(
+                        $entityProperties,
+                        $results[Repository::SCOPE_SHARED][$identifier] ?? [],
+                    );
+
+                    if (!$repository->entityDeclaredInherited($identifier)) {
+                        $disinherited[] = $identifier;
+                    }
+                }
+            }
+
+            $stamp[$repository->getHierarchicalIdentifier()] = $repository->getStamp();
+
+            if (!$repository->declaredInherited()) {
+                break;
+            }
+        }
+
+        return $results;
+    }
+
+    protected function buildResolvedRepositories(&$stamp = []): array
+    {
+        $results = [];
+
+        foreach ($this->getAll() as $key => $entity) {
+            $repository = $this->queryRepository($key);
+
+            $results[$key] = $repository;
+
+            $stamp[$repository->getHierarchicalIdentifier()] = $repository->getStamp();
+        }
+
+        return $results;
+    }
+
+    protected function getMergedProperties(array $old, array $new): array
+    {
+        return $this->getDecorated()::getMergedProperties([
+            Arr::except(
+                $new,
+                self::NON_INHERITABLE_PROPERTIES,
+            ),
+            $old,
+        ]);
+    }
+
+    /**
+     * @return static[]
+     */
+    abstract protected function getAncestors(): array;
+
+    abstract protected function getOwnRepository(): RepositoryInterface;
+}

--- a/inc/src/Cargo/Decorator/RepositoryDecorator.php
+++ b/inc/src/Cargo/Decorator/RepositoryDecorator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Cargo\Decorator;
+
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\Utilities\Decorator;
+
+class RepositoryDecorator extends Decorator implements RepositoryInterface {}

--- a/inc/src/Cargo/EntityInterface.php
+++ b/inc/src/Cargo/EntityInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Cargo;
+
+interface EntityInterface
+{
+    public function getProperties();
+    public function setProperties(array $properties);
+    public function declaredInherited(): bool;
+    public function getRepository(): RepositoryInterface;
+    public function getRepositoryEntityKey(): string;
+}

--- a/inc/src/Cargo/EntityTrait.php
+++ b/inc/src/Cargo/EntityTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Cargo;
+
+use Illuminate\Support\Arr;
+
+trait EntityTrait
+{
+    /**
+     * Properties that can be discarded when the corresponding item is deleted.
+     */
+    private const FIRST_PARTY_PROPERTIES = [];
+
+    public function deleteFirstPartyProperties(): void
+    {
+        $this->setProperties(
+            Arr::except(
+                $this->getProperties(),
+                self::FIRST_PARTY_PROPERTIES,
+            ),
+        );
+    }
+
+    public function declaredInherited(): bool
+    {
+        return $this->getRepository()->entityDeclaredInherited(
+            $this->getRepositoryEntityKey()
+        );
+    }
+
+    public function getProperties(): array
+    {
+        $repository = $this->getRepository();
+
+        return $repository->getEntityProperties(
+            $this->getRepositoryEntityKey()
+        );
+    }
+
+    public function setProperties(array $properties): void
+    {
+        $repository = $this->getRepository();
+
+        $mergedProperties = array_merge_recursive(
+            $this->getProperties(),
+            $properties,
+        );
+
+        // normalize
+        foreach ($mergedProperties as $key => $value) {
+            if (
+                $key === Repository::ANCESTOR_DECLARATIONS_KEY &&
+                is_bool($value) &&
+                !$repository->declaredInherited()
+            ) {
+                unset($mergedProperties[$key]);
+            }
+        }
+
+        $repository->setEntityProperties(
+            $this->getRepositoryEntityKey(),
+            $mergedProperties,
+        );
+    }
+
+    abstract public function getRepository(): RepositoryInterface;
+
+    abstract protected function getRepositoryEntityKey(): string;
+}

--- a/inc/src/Cargo/FileRepositoryInterface.php
+++ b/inc/src/Cargo/FileRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Cargo;
+
+/**
+ * @method array getAll()
+ * @method bool has(string $key)
+ * @method EntityInterface getExisting(string $key, mixed $value)
+ * @method EntityInterface get(string $key)
+ * @method EntityInterface create(string $key)
+ */
+interface FileRepositoryInterface {}

--- a/inc/src/Cargo/Repository.php
+++ b/inc/src/Cargo/Repository.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Cargo;
+
+use Exception;
+use Illuminate\Support\Arr;
+use MyBB\Utilities\FileStamp;
+use RuntimeException;
+use UnexpectedValueException;
+
+use function MyBB\View\directive;
+
+/**
+ * Manages entities and related metadata in a common, human-readable format.
+ */
+abstract class Repository implements RepositoryInterface
+{
+    final public const SCOPE_SHARED = 'shared';
+    final public const SCOPE_ENTITY = 'entity';
+
+    public const ANCESTOR_DECLARATIONS_KEY = 'inherits';
+    public const INHERIT_BY_DEFAULT = true;
+
+    protected const REMOVE_NULL_PROPERTIES = true;
+    protected const REMOVE_EMPTY_PROPERTIES = true;
+
+    /**
+     * Identifier of the metadata file and the entities array.
+     */
+    public const NAME = self::NAME;
+
+    protected FileStamp $propertiesStamp;
+
+    /**
+     * @var array<self::SCOPE_*, array<string, mixed>>
+     */
+    protected array $properties = [
+        self::SCOPE_SHARED => [],
+        self::SCOPE_ENTITY => [],
+    ];
+
+    protected bool $propertiesLoaded = false;
+
+    /**
+     * Returns the resulting set of properties assigned the same entity key.
+     *
+     * @param array[] $properties
+     */
+    public static function getMergedProperties(array $properties): array
+    {
+        return array_merge_recursive(...$properties);
+    }
+
+    /**
+     * Returns properties declared at the top level.
+     */
+    public function getSharedProperties(): array
+    {
+        $this->loadProperties();
+
+        return $this->properties[self::SCOPE_SHARED];
+    }
+
+    /**
+     * Returns a property declared at the top level.
+     */
+    public function getSharedProperty(string $key): mixed
+    {
+        $this->loadProperties();
+
+        return $this->properties[self::SCOPE_SHARED][$key] ?? null;
+    }
+    /**
+     * Sets a property declared at the top level.
+     */
+    public function setSharedProperty(string $key, mixed $value): void
+    {
+        if ($key === static::NAME) {
+            throw new UnexpectedValueException('Illegal property key `' . $key . '`');
+        }
+
+        $this->properties[self::SCOPE_SHARED][$key] = $value;
+
+        $this->writeProperties();
+    }
+
+    /**
+     * Returns properties of a member entity.
+     */
+    public function getEntityProperties(?string $key = null): array
+    {
+        $this->loadProperties();
+
+        if ($key === null) {
+            return $this->properties[self::SCOPE_ENTITY];
+        } else {
+            return $this->properties[self::SCOPE_ENTITY][$key] ?? [];
+        }
+    }
+
+    /**
+     * Sets properties of member entity.
+     */
+    public function setEntityProperties(string $key, array $data): void
+    {
+        // ordinary merge to overwrite
+        $this->properties[self::SCOPE_ENTITY][$key] = array_merge(
+            $this->properties[self::SCOPE_ENTITY][$key] ?? [],
+            $data,
+        );
+
+        $this->writeProperties();
+    }
+
+    /**
+     * Whether the repository, and all member entities, are declared as inherited.
+     */
+    public function declaredInherited(): bool
+    {
+        $value = $this->getSharedProperty(self::ANCESTOR_DECLARATIONS_KEY);
+
+        return (
+             // boolean values supported
+            $value === true ||
+            (self::INHERIT_BY_DEFAULT && $value === null)
+        );
+    }
+
+    /**
+     * Whether the member entity is declared as inherited.
+     */
+    public function entityDeclaredInherited(string $key): bool
+    {
+        $value = $this->getEntityProperties($key)[self::ANCESTOR_DECLARATIONS_KEY] ?? null;
+
+        return (
+             // boolean or array values supported
+            $value === true ||
+            is_array($value) ||
+            (self::INHERIT_BY_DEFAULT && $value === null)
+        );
+    }
+
+    /**
+     * Returns member entities declared as not inherited.
+     */
+    public function getEntitiesDeclaredDisinherited(): array
+    {
+        return array_filter(
+            array_keys($this->getEntityProperties()),
+            fn (string $key) => !$this->entityDeclaredInherited($key),
+        );
+    }
+
+    public function getStamp(): ?array
+    {
+        return $this->propertiesStamp->getStamp();
+    }
+
+    public function stampValid(FileStamp $stamp): bool
+    {
+        return $stamp->isValid(
+            $this->getPropertiesFilePath(),
+            directive('hierarchy.cacheValidationType'),
+        );
+    }
+
+    protected function loadProperties(): void
+    {
+        if (!$this->propertiesLoaded) {
+            $this->properties = $this->readProperties();
+        }
+    }
+
+    protected function readProperties(): array
+    {
+        $results = [
+            self::SCOPE_SHARED => [],
+            self::SCOPE_ENTITY => [],
+        ];
+
+        $path = $this->getPropertiesFilePath();
+
+        if (file_exists($path)) {
+            $content = file_get_contents($path);
+
+            if ($content === false) {
+                throw new Exception('Could not open properties file `' . $path . '`');
+            }
+
+            $this->propertiesStamp = FileStamp::fromFile($path, $content);
+
+            $data = json_decode(
+                $content,
+                flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR,
+            );
+
+            $results[self::SCOPE_SHARED] = Arr::except($data, [static::NAME]);
+
+            if (
+                isset($data[static::NAME]) &&
+                is_array($data[static::NAME])
+            ) {
+                $results[self::SCOPE_ENTITY] = $data[static::NAME];
+            }
+        } else {
+            $this->propertiesStamp = FileStamp::fromNonexistentFile();
+        }
+
+        return $results;
+    }
+
+    protected function writeProperties(): void
+    {
+        $path = $this->getPropertiesFilePath();
+
+        // create directory
+        $directory = dirname($path);
+
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, recursive: true)) {
+                throw new RuntimeException('Failed to create directory `' . $directory . '`');
+            }
+        }
+
+        // lock
+        $fp = fopen($path, 'c+');
+
+        if ($fp === false) {
+            throw new RuntimeException('Failed to open `' . $path . '`');
+        }
+
+        if (!flock($fp, LOCK_EX)) {
+            throw new RuntimeException('Failed to acquire exclusive lock for `' . $path . '`');
+        }
+
+        try {
+            // merge
+            $currentFileData = $this->readProperties();
+
+            foreach ([self::SCOPE_SHARED, self::SCOPE_ENTITY] as $level) {
+                $this->properties[$level] = array_merge(
+                    $currentFileData[$level],
+                    $this->properties[$level],
+                );
+            }
+
+            $this->normalizeProperties();
+
+            // write
+            $newFileData = $this->properties[self::SCOPE_SHARED];
+            $newFileData[static::NAME] = $this->properties[self::SCOPE_ENTITY];
+
+            $content = json_encode($newFileData, JSON_PRETTY_PRINT);
+
+            if (
+                ftruncate($fp, 0) === false ||
+                fseek($fp, 0) === -1 ||
+                fwrite($fp, $content) === false
+            ) {
+                throw new RuntimeException('Failed to write to `' . $path . '`');
+            }
+
+            $this->propertiesStamp = FileStamp::fromFile($path, $content);
+        } finally {
+            flock($fp, LOCK_UN);
+            fclose($fp);
+        }
+    }
+
+    protected function normalizeProperties(): void
+    {
+        // shared properties
+
+        if (static::REMOVE_NULL_PROPERTIES) {
+            $this->properties[self::SCOPE_SHARED] = array_filter(
+                $this->properties[self::SCOPE_SHARED],
+                fn (array $properties) => $properties !== null,
+            );
+        }
+
+        ksort($this->properties[self::SCOPE_SHARED], SORT_NATURAL);
+
+
+        // entity properties
+
+        if (static::REMOVE_EMPTY_PROPERTIES) {
+            $this->properties[self::SCOPE_ENTITY] = array_filter(
+                $this->properties[self::SCOPE_ENTITY],
+                fn (array $properties) => $properties !== [],
+            );
+        }
+
+        if (static::REMOVE_NULL_PROPERTIES) {
+            foreach ($this->properties[self::SCOPE_ENTITY] as &$entityProperties) {
+                $entityProperties = array_filter(
+                    $entityProperties,
+                    fn(array $properties) => $properties !== null,
+                );
+            }
+        }
+
+        ksort($this->properties[self::SCOPE_ENTITY], SORT_NATURAL);
+    }
+
+    abstract protected function getPropertiesFilePath(): string;
+}

--- a/inc/src/Cargo/RepositoryInterface.php
+++ b/inc/src/Cargo/RepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Cargo;
+
+use MyBB\Utilities\FileStamp;
+
+/**
+ * @method array getSharedProperties()
+ * @method mixed getSharedProperty(string $key)
+ * @method void setSharedProperty(string $key, mixed $value)
+ * @method array getEntityProperties(?string $key = null)
+ * @method void setEntityProperties(string $key, array $data)
+ * @method bool declaredInherited()
+ * @method bool entityDeclaredInherited(string $key)
+ * @method array getEntitiesDeclaredDisinherited()
+ * @method array getStamp()
+ * @method bool stampValid(FileStamp $stamp)
+ */
+interface RepositoryInterface {}

--- a/inc/src/Extensions/Extension.php
+++ b/inc/src/Extensions/Extension.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+use Exception;
+use Illuminate\Support\Arr;
+use MyBB\Utilities\FileStamp;
+
+abstract class Extension
+{
+    final public const MANIFEST_FILE_PATH = 'manifest.json';
+    final public const CHECKSUMS_FILE_PATH = 'checksums';
+
+    public const DEFAULT_VERSION = 'dev';
+
+    /**
+     * @var array<string, array{
+     *   default: static,
+     *   versions: array<string, static>
+     * }>
+     */
+    private static array $instances = [];
+
+    /**
+     * Definitions and validation of manifest fields.
+     *
+     * @var array<string, array{
+     *   required: bool,
+     *   type: string,
+     *   value?: scalar|callable,
+     * }>
+     */
+    protected array $manifestFields = [];
+
+    protected array $manifest;
+    protected array $declaredFileChecksums;
+
+    private FileStamp $manifestStamp;
+
+    readonly private string $packageName;
+    readonly private string $version;
+
+    public static function codenameValid(string $value): bool
+    {
+        return preg_match('/[a-z_]+/', $value) === 1;
+    }
+
+    public static function get(string $packageName, ?string $version = null): static
+    {
+        if ($version === null) {
+            $instance = &static::$instances[$packageName]['default'];
+        } else {
+            $instance = &static::$instances[$packageName]['versions'][$version];
+        }
+
+        return $instance ??= new static($packageName, $version);
+    }
+
+    public function __construct(string $packageName, ?string $version = null)
+    {
+        $this->packageName = $packageName;
+
+        if ($version !== null) {
+            $this->version = $version;
+        }
+
+        $this->manifestFields = [
+            'version' => [
+                'required' => false,
+                'type' => 'string',
+                'value' => fn ($value) => preg_match('/^[A-Za-z0-9.-]+$/', $value),
+            ],
+        ];
+    }
+
+    public function getAbsolutePath(): string
+    {
+        return static::EXTENSION_TYPE_ABSOLUTE_BASE_PATH . $this->getPackageName();
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version ??=
+            $this->getManifest()['version'] ?? self::DEFAULT_VERSION;
+    }
+
+    public function getManifest(): ?array
+    {
+        if (!isset($this->manifest)) {
+            $path = $this->getManifestFilePath();
+
+            if (file_exists($path)) {
+                $content = file_get_contents($path);
+
+                if ($content === false) {
+                    throw new Exception('Could not open manifest file: ' . $path);
+                }
+
+                $this->manifestStamp = FileStamp::fromFile($path, $content);
+
+                $values = json_decode(
+                    $content, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR,
+                );
+
+                $this->validateManifestValues($values);
+
+                $this->manifest = $values;
+            } else {
+                $this->manifestStamp = FileStamp::fromNonexistentFile();
+
+                return null;
+            }
+        }
+
+        return $this->manifest;
+    }
+
+    public function getManifestFilePath(): string
+    {
+        return $this->getAbsolutePath() . '/' . static::MANIFEST_FILE_PATH;
+    }
+
+    public function validateManifestValues(array $values): void
+    {
+        foreach ($this->manifestFields as $name => $field) {
+            $error = null;
+
+            if (Arr::has($values, $name)) {
+                $value = Arr::get($values, $name);
+
+                if (gettype($value) === $field['type']) {
+                    if (isset($field['value'])) {
+                        if (
+                            (is_callable($field['value']) && !$field['value']($value)) ||
+                            (is_scalar($field['value']) && $field['value'] !== $value)
+                        ) {
+                            $error = 'value is invalid';
+                        }
+                    }
+                } else {
+                    $error = 'value must be of type ' . $field['type'];
+                }
+            } elseif ($field['required']) {
+                $error = 'not found';
+            }
+
+            if ($error) {
+                throw new Exception('Package `' . $this->getPackageName() . '` manifest field `' . $name . '` ' . $error);
+            }
+        }
+    }
+
+    public function getManifestStamp(): ?array
+    {
+        return $this->manifestStamp->getStamp();
+    }
+
+    /**
+     * @param FileStamp::TYPE_* $type
+     */
+    public function manifestStampValid(array $stamp, string $type): bool
+    {
+        return (new FileStamp($stamp))->isValid(
+            $this->getManifestFilePath(),
+            $type,
+        );
+    }
+
+    /**
+     * @return null|array<string, string[]>
+     *
+     * @see \MyBB\Maintenance\getDeclaredFileChecksums()
+     */
+    public function getDeclaredFileChecksums(): ?array
+    {
+        if (!isset($this->declaredFileChecksums)) {
+            $declaredFiles = [];
+
+            $path = $this->getAbsolutePath() . '/' . static::CHECKSUMS_FILE_PATH;
+
+            if (!file_exists($path)) {
+                return null;
+            }
+
+            $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+            if ($lines === false) {
+                throw new Exception('Could not open checksums file: ' . $path);
+            }
+
+            foreach ($lines as $line) {
+                $parts = explode(' ', $line, 2);
+
+                if (count($parts) !== 2) {
+                    continue;
+                }
+
+                $declaredChecksum = trim($parts[0]);
+                $relativePath = trim($parts[1]);
+
+                if (!isset($declaredFiles[$relativePath])) {
+                    $declaredFiles[$relativePath] = [];
+                }
+
+                $declaredFiles[$relativePath][] = $declaredChecksum;
+            }
+
+            $this->declaredFileChecksums = $declaredFiles;
+        }
+
+        return $this->declaredFileChecksums;
+    }
+
+    /**
+     * Returns a list of file checksum mismatches by type.
+     * Files not declared with checksums are ignored.
+     *
+     * @return null|array{
+     *   changed: string[],
+     *   missing: string[],
+     * }
+     *
+     * @see \MyBB\Maintenance\getFileVerificationErrors()
+     */
+    public function getFileVerificationErrors(): ?array
+    {
+        $algorithm = 'sha512';
+        $bufferLength = 8192;
+
+        $extensionAbsolutePath = $this->getAbsolutePath();
+
+        $fileChecksums = $this->getDeclaredFileChecksums();
+
+        if ($fileChecksums !== null) {
+            $results = [
+                'changed' => [],
+                'missing' => [],
+            ];
+
+            // calculate & compare checksums
+            foreach ($fileChecksums as $relativePath => $declaredChecksums) {
+                $absolutePath = $extensionAbsolutePath . $relativePath;
+
+                if (file_exists($absolutePath)) {
+                    $handle = fopen($absolutePath, 'rb');
+                    $hashingContext = hash_init($algorithm);
+
+                    while (!feof($handle)) {
+                        hash_update($hashingContext, fread($handle, $bufferLength));
+                    }
+
+                    fclose($handle);
+
+                    $localChecksum = hash_final($hashingContext);
+
+                    if (!in_array($localChecksum, $declaredChecksums, true)) {
+                        $results['changed'][] = $relativePath;
+                    }
+                } else {
+                    $results['missing'][] = $relativePath;
+                }
+            }
+
+            return $results;
+        } else {
+            return null;
+        }
+    }
+}

--- a/inc/src/Extensions/HierarchicalExtensionInterface.php
+++ b/inc/src/Extensions/HierarchicalExtensionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+interface HierarchicalExtensionInterface
+{
+    public function getInheritanceChain(): array;
+    public function getAncestors(): array;
+}

--- a/inc/src/Extensions/HierarchicalExtensionTrait.php
+++ b/inc/src/Extensions/HierarchicalExtensionTrait.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+use Exception;
+use Illuminate\Support\Arr;
+
+/**
+ * Resolves Extension inheritance.
+ */
+trait HierarchicalExtensionTrait
+{
+    private array $inheritanceChain;
+    private array $descendants;
+    private array $extensionsDeclaringAsAncestor;
+
+    /**
+     * Returns nodes sorted topologically using Kahn's algorithm.
+     *
+     * @template T scalar
+     * @param array<T, T[]> $nodes Nodes as key, and source nodes of their incoming edges.
+     * @return ?list<T>
+     */
+    private static function getLinearizedNodes(array $nodes): ?array
+    {
+        $linearized = [];
+
+        while ($nodes !== []) {
+            $headNodesFound = false;
+
+            foreach ($nodes as $targetNode => $sourceNodes) {
+                if ($sourceNodes === []) {
+                    $headNodesFound = true;
+
+                    $linearized[] = $targetNode;
+
+                    unset($nodes[$targetNode]);
+
+                    foreach ($nodes as &$sources) {
+                        unset($sources[array_search($targetNode, $sources)]);
+                    }
+                }
+            }
+
+            if (!$headNodesFound) {
+                return null;
+            }
+        }
+
+        return $linearized;
+    }
+
+    /**
+     * Returns the Extension and its ancestors from closest to furthest.
+     *
+     * @return array<string, HierarchicalExtensionInterface>
+     */
+    public function getInheritanceChain(): array
+    {
+        if (!isset($this->inheritanceChain)) {
+            $orderedNames = self::getLinearizedNodes(
+                $this->getInheritanceChainDirectDependants()
+            );
+
+            if ($orderedNames === null) {
+                throw new Exception('Circular inheritance declared involving Extension `' . $this->getPackageName() . '`');
+            }
+
+            $this->inheritanceChain = array_combine(
+                $orderedNames,
+                array_map(
+                    fn (string $packageName) => static::get($packageName),
+                    $orderedNames,
+                ),
+            );
+        }
+
+        return $this->inheritanceChain;
+    }
+
+    /**
+     * Returns ancestors in descending priority order.
+     *
+     * @return array<string, HierarchicalExtensionInterface>
+     */
+    public function getAncestors(array $dependants = []): array
+    {
+        return Arr::except(
+            $this->getInheritanceChain(),
+            $this->getPackageName(),
+        );
+    }
+
+    /**
+     * @param string[] $dependants
+     * @return array<string, HierarchicalExtensionInterface>
+     */
+    public function getDescendants(array $dependants = []): array
+    {
+        if (!isset($this->descendants)) {
+            $extensions = [];
+
+            if (in_array($this->getPackageName(), $dependants)) {
+                throw new Exception('Circular inheritance declared involving Extension `' . $this->getPackageName() . '`');
+            }
+
+            $dependants[] = $this->getPackageName();
+
+            foreach ($this->getExtensionsDeclaringAsAncestor() as $packageName => $extension) {
+                $extensions[$packageName] = $extension;
+
+                $extensions = array_merge(
+                    $extensions,
+                    $extension->getDescendants($dependants),
+                );
+            }
+
+            $this->descendants = $extensions;
+        }
+
+        return $this->descendants;
+    }
+
+    /**
+     * Returns Extensions explicitly declaring the Extension as their ancestor.
+     *
+     * @return array<string, HierarchicalExtensionInterface>
+     */
+    public function getExtensionsDeclaringAsAncestor(): array
+    {
+        if (!isset($this->extensionsDeclaringAsAncestor)) {
+            $extensions = [];
+
+            foreach (self::getAll() as $packageName => $extension) {
+                if (
+                    array_key_exists(
+                        $this->getPackageName(),
+                        $extension->getAncestorDeclarations(),
+                    )
+                ) {
+                    $extensions[$packageName] = $extension;
+                }
+            }
+
+            $this->extensionsDeclaringAsAncestor = $extensions;
+        }
+
+        return $this->extensionsDeclaringAsAncestor;
+    }
+
+    /**
+     * Returns declared package names as keys, and version strings as values.
+     *
+     * @return array<string, ?string>
+     */
+    private function getAncestorDeclarations(): array
+    {
+        $declarations = [];
+
+        $manifest = $this->getManifest();
+
+        if (
+            $manifest !== null &&
+            isset($manifest['extra']['inherits']) &&
+            is_array($manifest['extra']['inherits'])
+        ) {
+            foreach ($manifest['extra']['inherits'] as $key => $value) {
+                if (!is_string($value)) {
+                    throw new Exception('Invalid ancestor declaration for `' . $this->getPackageName() . '`');
+                }
+
+                if (is_int($key)) {
+                    $packageName = $value;
+                    $versionDeclaration = null;
+                } elseif (is_string($key)) {
+                    $packageName = $key;
+                    $versionDeclaration = $value;
+                } else {
+                    throw new Exception('Invalid ancestor declaration for `' . $this->getPackageName() . '`');
+                }
+
+                if (array_key_exists($packageName, $declarations)) {
+                    throw new Exception('Duplicate inheritance declared involving Extension `' . $packageName . '`');
+                }
+
+                $declarations[$packageName] = $versionDeclaration;
+            }
+        }
+
+        return $declarations;
+    }
+
+    private function canInheritFrom(self $extension): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns Extensions directly reliant on each Extension in the inheritance chain,
+     * represented by package name (an inverse mapping of immediate dependencies).
+     *
+     * Used to construct the final, reconciled inheritance chain.
+     *
+     * @return array<string, string[]>
+     */
+    private function getInheritanceChainDirectDependants(array $visited = []): array
+    {
+        $dependants = [];
+
+        $dependants[$this->getPackageName()] = [];
+
+        foreach ($this->getAncestorDeclarations() as $packageName => $versionDeclaration) {
+            $extension = static::get($packageName);
+
+            if (!$extension->canInheritFrom($this)) {
+                throw new Exception('Illegal inheritance declared involving Extension `' . $packageName . '`');
+            }
+
+            if (!in_array($packageName, $visited)) {
+                $dependants[$packageName][] = $this->getPackageName();
+
+                $visited[] = $packageName;
+
+                $dependants = array_merge_recursive(
+                    $dependants,
+                    $extension->getInheritanceChainDirectDependants($visited),
+                );
+            }
+        }
+
+        return $dependants;
+    }
+
+}

--- a/inc/src/Extensions/Plugin.php
+++ b/inc/src/Extensions/Plugin.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+use MyBB\View\NamespaceType;
+
+class Plugin extends Extension implements ViewExtensionInterface
+{
+    use ViewExtensionTrait;
+
+    public const EXTENSION_TYPE_ABSOLUTE_BASE_PATH = MYBB_ROOT . 'inc/plugins/';
+
+    public const PACKAGE_RELATIVE_THEMELET_PATH = 'view';
+
+    public const NAMESPACE_TYPE_ACCESS = [
+        NamespaceType::EXTENSION_OWN,
+    ];
+
+    public const THEMELET_DIRECT_NAMESPACE = true;
+
+    public function __construct(string $packageName, ?string $version = null)
+    {
+        parent::__construct($packageName, $version);
+
+        if (!self::codenameValid($packageName)) {
+            throw new \Exception('Invalid Extension package name `' . $packageName . '`');
+        }
+
+        $this->manifestFields['type'] = [
+            'required' => true,
+            'type' => 'string',
+            'value' => 'mybb-plugin',
+        ];
+    }
+
+    public function getThemeletDirectNamespace(): string
+    {
+        return NamespaceType::EXTENSION->getNamespaceFromIdentifier(
+            $this->getPackageName(),
+        );
+    }
+
+    public function getManifest(): ?array
+    {
+        return parent::getManifest() ?? $this->getLegacyManifest();
+    }
+
+    private function getLegacyManifest(): ?array
+    {
+        $absolutePath = self::EXTENSION_TYPE_ABSOLUTE_BASE_PATH . $this->getPackageName() . '.php';
+
+        if (file_exists($absolutePath)) {
+            require_once $absolutePath;
+
+            $infoFunctionName = $this->getPackageName() . '_info';
+
+            if (function_exists($infoFunctionName)) {
+                $info = $infoFunctionName();
+
+                if (is_array($info)) {
+                    $this->manifest = $info;
+
+                    return $this->manifest;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/inc/src/Extensions/Theme.php
+++ b/inc/src/Extensions/Theme.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+use FilesystemIterator;
+use MyBB\View\NamespaceType;
+use SplFileInfo;
+
+class Theme extends Extension implements ViewExtensionInterface, HierarchicalExtensionInterface
+{
+    use ViewExtensionTrait;
+    use HierarchicalExtensionTrait;
+
+    public const EXTENSION_TYPE_ABSOLUTE_BASE_PATH = MYBB_ROOT . 'inc/themes/';
+
+    public const PACKAGE_RELATIVE_THEMELET_PATH = ''; // same directory
+
+    public const NAMESPACE_TYPE_ACCESS = [
+        NamespaceType::GENERIC,
+        NamespaceType::EXTENSION,
+    ];
+
+    private readonly ThemeType $type;
+
+    /**
+     * @return array<string, self>
+     */
+    public static function getAll(): array
+    {
+        static $extensions;
+
+        if (!isset($extensions)) {
+            $directoryNames = array_keys(
+                array_filter(
+                    iterator_to_array(
+                        new FilesystemIterator(
+                            self::EXTENSION_TYPE_ABSOLUTE_BASE_PATH,
+                            FilesystemIterator::KEY_AS_FILENAME
+                            | FilesystemIterator::CURRENT_AS_FILEINFO
+                            | FilesystemIterator::SKIP_DOTS
+                        )
+                    ),
+                    fn (SplFileInfo $item) => $item->isDir(),
+                )
+            );
+
+            foreach ($directoryNames as $packageName) {
+                if (!ThemeType::tryFromPackageName($packageName)) {
+                    throw new \Exception('Invalid Extension package name `' . $packageName . '`');
+                }
+
+                $extensions[$packageName] = self::get($packageName);
+            }
+        }
+
+        return $extensions;
+    }
+
+    public function __construct(string $packageName, ?string $version = null)
+    {
+        parent::__construct($packageName, $version);
+
+        $this->type =
+            ThemeType::tryFromPackageName($packageName)
+            ?? throw new \Exception('Invalid Extension package name `' . $packageName . '`')
+        ;
+
+        $this->manifestFields['type'] = [
+            'required' => true,
+            'type' => 'string',
+            'value' => 'mybb-theme',
+        ];
+        $this->manifestFields['extra.inherits'] = [
+            'required' => false,
+            'type' => 'array',
+        ];
+    }
+
+    public function getType(): ThemeType
+    {
+        return $this->type;
+    }
+
+    public function getAbsolutePath(): string
+    {
+        return static::EXTENSION_TYPE_ABSOLUTE_BASE_PATH . $this->getPackageName();
+    }
+
+    private function canInheritFrom(self $extension): bool
+    {
+        $types = ThemeType::cases();
+
+        $ownPriority = array_search($this->getType(), $types);
+        $targetPriority = array_search($extension->getType(), $types);
+
+        return $ownPriority <= $targetPriority;
+    }
+}

--- a/inc/src/Extensions/ThemeType.php
+++ b/inc/src/Extensions/ThemeType.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+use InvalidArgumentException;
+
+enum ThemeType
+{
+    case CORE;
+    case ORIGINAL;
+    case BOARD;
+
+    public static function tryFromPackageName(string $value): ?self
+    {
+        foreach (self::cases() as $case) {
+            if ($case->packageNameValid($value)) {
+                return $case;
+            }
+        }
+
+        return null;
+    }
+
+    public function packageNameValid(string $value): bool
+    {
+        return (
+            str_starts_with($value, $this->getPrefix()) &&
+            $this->packageIdentifierValid(
+                $this->getPackageIdentifier($value)
+            )
+        );
+    }
+
+    public function getPackageIdentifier(string $value): string
+    {
+        $prefix = $this->getPrefix();
+
+        if (!str_starts_with($value, $prefix)) {
+            throw new InvalidArgumentException();
+        }
+
+        return substr($value, strlen($prefix));
+    }
+
+    public function getPrefix(): string
+    {
+        return match ($this) {
+            self::CORE => 'core.',
+            self::ORIGINAL => '',
+            self::BOARD => 'theme.',
+        };
+    }
+
+    public function getPackageNameFromIdentifier(string $identifier): string
+    {
+        return $this->getPrefix() . $identifier;
+    }
+
+    private function packageIdentifierValid(string $value): bool
+    {
+        return match ($this) {
+            self::CORE, self::ORIGINAL => Extension::codenameValid($value),
+            self::BOARD => ctype_digit($value),
+        };
+    }
+}

--- a/inc/src/Extensions/ViewExtensionInterface.php
+++ b/inc/src/Extensions/ViewExtensionInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+use MyBB\View\NamespaceType;
+use MyBB\View\Themelet\Themelet;
+
+interface ViewExtensionInterface
+{
+    /**
+     * @var NamespaceType[]
+     */
+    public const NAMESPACE_TYPE_ACCESS = [];
+
+    /**
+     * Resources are located directly in the Themelet directory,
+     * and assigned to an implied namespace.
+     *
+     * @see self::getThemeletDirectNamespace()
+     */
+    public const THEMELET_DIRECT_NAMESPACE = false;
+
+    public function getThemelet(): Themelet;
+    public function getThemeletAbsolutePath(): string;
+    public function getThemeletDirectNamespace(): string;
+}

--- a/inc/src/Extensions/ViewExtensionTrait.php
+++ b/inc/src/Extensions/ViewExtensionTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Extensions;
+
+use BadMethodCallException;
+use MyBB\View\Themelet\Themelet;
+
+trait ViewExtensionTrait
+{
+    private Themelet $themelet;
+
+    public function getThemelet(): Themelet
+    {
+        return $this->themelet ??= Themelet::fromExtension($this);
+    }
+
+    public function getThemeletAbsolutePath(): string
+    {
+        return $this->getAbsolutePath() . static::PACKAGE_RELATIVE_THEMELET_PATH;
+    }
+
+    public function getThemeletDirectNamespace(): string
+    {
+        throw new BadMethodCallException('Cannot use direct namespace with Extension type `' . static::class . '`');
+    }
+}

--- a/inc/src/Http/Controllers/DebugController.php
+++ b/inc/src/Http/Controllers/DebugController.php
@@ -9,6 +9,8 @@ use MyBB;
 use MyBB\Stopwatch\Stopwatch;
 use MyLanguage;
 
+use Twig\Profiler\Dumper\TextDumper;
+use function MyBB\app;
 use function MyBB\Maintenance\template;
 
 class DebugController
@@ -96,6 +98,15 @@ class DebugController
             ];
         }
 
+        // Twig profile
+        if (app()->has('twig.profile')) {
+            $twigProfile = (new TextDumper())->dump(
+                app()->get('twig.profile')
+            );
+        } else {
+            $twigProfile = null;
+        }
+
         // definition lists
         $data['timing'] = [
             'Page Generation Time' => format_time_duration($eventDuration['main']),
@@ -115,8 +126,12 @@ class DebugController
             'Memory Usage' => $memoryUsage,
             'Server Load' => get_server_load(),
         ];
-        $data['status'] = [
+        $data['application'] = [
             'MyBB Version' => $this->mybb->version,
+            'View Optimization Level' => app(MyBB\View\Optimization::class)->name,
+            'MyBB Root' => MYBB_ROOT,
+        ];
+        $data['server'] = [
             'PHP Version' => PHP_VERSION,
             'Database Extension' => $this->mybb->config['database']['type'],
             'GZip Encoding' => $this->mybb->settings['gzipoutput'] != 0 ? "Enabled" : "Disabled",
@@ -126,11 +141,13 @@ class DebugController
             ,
             'Xdebug' => function_exists('xdebug_info') ? implode(', ', xdebug_info('mode')) : '-',
             'Memory Limit' => @ini_get("memory_limit"),
-            'MyBB Root' => MYBB_ROOT,
         ];
 
         // cache
         $data['cache'] = $this->mybb->cache->calllist;
+        $data['cacheThemeletBuild'] = $this->stopwatch->getEvents('core.hydrable.build');
+        $data['cacheThemeletRead'] = $this->stopwatch->getEvents('core.hydrable.read');
+        $data['cacheThemeletWrite'] = $this->stopwatch->getEvents('core.hydrable.write');
 
         // database
         $data['dbConnections'] = $this->db->connections;
@@ -144,8 +161,12 @@ class DebugController
         $data['dbTemplates'] = array_keys($templates->cache);
         $data['dbTemplatesUncached'] = $templates->uncached_templates;
 
+        $data['viewHierarchicalResolution'] = $this->stopwatch->getEvents('core.view.hierarchy.resolution');
+
         $data['twigTemplateEvents'] = $this->stopwatch->getEvents('core.view.template');
+        $data['twigProfile'] = $twigProfile;
         $data['assetPublishEvents'] = $this->stopwatch->getEvents('core.view.asset.publish');
+
 
         return $data;
     }

--- a/inc/src/Twig/Extensions/ThemeExtension.php
+++ b/inc/src/Twig/Extensions/ThemeExtension.php
@@ -4,6 +4,11 @@ namespace MyBB\Twig\Extensions;
 
 use DB_Base;
 use MyBB;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\StaticLocator;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\ResourceType;
+use MyBB\View\Runtime\Runtime;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFunction;
@@ -14,40 +19,27 @@ use Twig\TwigFunction;
 class ThemeExtension extends AbstractExtension implements GlobalsInterface
 {
     /**
-     * @var \MyBB $mybb
-     */
-    private $mybb;
-
-    /**
-     * @var \DB_Base $db
-     */
-    private $db;
-
-    /**
      * @var string $altRowState
      */
     private string $altRowState;
 
     /**
      * Create a new instance of the ThemeExtension.
-     *
-     * @param \MyBB $mybb
-     * @param \DB_Base $db
      */
-    public function __construct(MyBB $mybb, DB_Base $db)
-    {
-        $this->mybb = $mybb;
-        $this->db = $db;
-
-        $this->altRowState = null;
-    }
+    public function __construct(
+        private readonly MyBB $mybb,
+        private readonly DB_Base $db,
+        private readonly Runtime $view
+    )
+    {}
 
     public function getFunctions()
     {
         return [
+            new TwigFunction('asset', [$this, 'getAsset']),
             new TwigFunction('asset_url', [$this, 'getAssetUrl']),
             new TwigFunction('alt_trow', [$this, 'altTrow']),
-            new TwigFunction('get_stylesheets', [$this, 'getStylesheets']),
+            new TwigFunction('attached_assets', [$this, 'getAttachedAssets']),
         ];
     }
 
@@ -65,17 +57,71 @@ class ThemeExtension extends AbstractExtension implements GlobalsInterface
     }
 
     /**
+     * Output an Asset HTML tag, or delegate appending it to the DOM to the application.
+     *
+     * @param string $locator The path to the Asset.
+     * @param bool $static Whether `$locatorString` is a literal path (not managed by the Theme System).
+     *
+     * @note Uses `$locator` parameter name to simplify Twig function usage
+     */
+    public function getAsset(
+        string $locator,
+        bool $static = false,
+        array $attributes = [],
+    ): void
+    {
+        if ($static) {
+            $locatorObject = StaticLocator::fromString($locator);
+        } else {
+            $locatorObject = Locator::fromString(
+                $locator,
+                [
+                    'type' => ThemeletLocator::COMPONENT_SET,
+                    'namespace' => ThemeletLocator::COMPONENT_CONTEXT,
+                ],
+                [
+                    // may differ from evoking template's namespace
+                    'namespace' => $this->view->getMainNamespace(),
+                ],
+            );
+        }
+
+        $this->view->attachAsset($locatorObject, $attributes);
+    }
+
+    /**
      * Get the path to an asset using the CDN URL if configured.
      *
-     * @param string $path The path to the file.
+     * @param string $locator The path to the file.
+     * @param bool $static Whether `$locatorString` is a literal path (not managed by the Theme System).
      * @param bool $useCdn Whether to use the configured CDN options.
      *
      * @return string The complete URL to the asset.
+     *
+     * @note Uses `$locator` parameter name to simplify Twig function usage
      */
-    public function getAssetUrl(string $path, bool $useCdn = true): string
+    public function getAssetUrl(string $locator, bool $static = false, bool $useCdn = true): string
     {
+        if ($static) {
+            $locatorObject = StaticLocator::fromString($locator);
+        } else {
+            $locatorObject = Locator::fromString(
+                $locator,
+                [
+                    'type' => ThemeletLocator::COMPONENT_SET,
+                    'namespace' => ThemeletLocator::COMPONENT_CONTEXT,
+                ],
+                [
+                    // may differ from evoking template's namespace
+                    'namespace' => $this->view->getMainNamespace(),
+                ],
+            );
+        }
+
+        $asset = $this->view->themelet->getPublishedAsset($locatorObject);
+
         // TODO: This could be smart and add cache busting query parameters to the path automatically...
-        return $this->mybb->get_asset_url($path, $useCdn);
+        return $this->view->getAssetUrl($asset, $useCdn);
     }
 
     /**
@@ -98,11 +144,19 @@ class ThemeExtension extends AbstractExtension implements GlobalsInterface
     }
 
     /**
-     * Get a list of all the stylesheets applicable for the current page.
+     * Get assets attached to the current page.
+     */
+    public function getAttachedAssets(string $type): array
+    {
+        return $this->view->getAttachedAssets(ResourceType::from($type));
+    }
+
+    /**
+     * Get a list of stylesheets applicable for the current page in the MyBB <= 1.8 format.
      *
      * @return \Generator A generator object that yields each stylesheet, as a full URL.
      */
-    public function getStylesheets() : \Generator
+    private function getLegacyStyles(): \Generator
     {
         // TODO: Optimise this function - it looks like it can be improved at a glance
         $theme = $GLOBALS['theme'];

--- a/inc/src/Twig/ServiceProvider.php
+++ b/inc/src/Twig/ServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace MyBB\Twig;
 
-use DB_Base;
 use Illuminate\Contracts\Container\Container;
 use MyBB;
 use MyBB\Twig\Extensions\CoreExtension;
@@ -10,12 +9,14 @@ use MyBB\Twig\Extensions\LangExtension;
 use MyBB\Twig\Extensions\ThemeExtension;
 use MyBB\Twig\Extensions\UrlExtension;
 use MyBB\Utilities\BreadcrumbManager;
+use MyBB\View\Runtime\Runtime;
 use MyLanguage;
 use pluginSystem;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
-use Twig\Loader\FilesystemLoader;
+use Twig\Extension\ProfilerExtension;
 use Twig\Loader\LoaderInterface;
+use Twig\Profiler\Profile;
 
 /** @property \MyBB\Application $app */
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
@@ -33,12 +34,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             );
         });
 
-        $this->app->singleton(ThemeExtension::class, function (Container $container) {
-            return new ThemeExtension(
-                $container->make(MyBB::class),
-                $container->make(DB_Base::class)
-            ) ;
-        });
+        $this->app->singleton(ThemeExtension::class);
 
         $this->app->singleton(LangExtension::class, function (Container $container) {
             return new LangExtension(
@@ -50,41 +46,25 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             return new UrlExtension();
         });
 
-        $this->app->singleton(LoaderInterface::class, function () {
-            $loader = new FilesystemLoader();
+        $this->app->singleton(LoaderInterface::class, function (Container $container) {
+            $view = $container->get(Runtime::class);
 
-            $themeName = 'core.default'; // TODO
-            $themePath = __DIR__ . '/../../themes/' . $themeName . '/';
-            $namespaceDirectories = [
-                'frontend',
-                'parser',
-            ];
-
-            $mainNamespace = 'frontend';
-
-            foreach ($namespaceDirectories as $namespaceDirectory) {
-                if ($namespaceDirectory === $mainNamespace) {
-                    $targetNamespace = FilesystemLoader::MAIN_NAMESPACE;
-                } else {
-                    $targetNamespace = $namespaceDirectory;
-                }
-
-                $path = $themePath . $namespaceDirectory . '/templates';
-
-                $loader->addPath($path, $targetNamespace);
-            }
-
-            return $loader;
+            return new ThemeletLoader($view->themelet, $view->getMainNamespace());
         });
 
-        $this->app->singleton('twig.options', function () {
+        $this->app->singleton('twig.options', function (Container $container) {
+            $mybb = $container->get(MyBB::class);
+
             return [
-                'debug' => true, // TODO: In live environments this should be false
+                'debug' => $mybb->dev_mode,
+                'auto_reload' => \MyBB\View\directive('twig.autoReload'),
                 'cache' => __DIR__ . '/../../../cache/views',
             ];
         });
 
         $this->app->singleton(Environment::class, function (Container $container) {
+            $mybb = $container->get(MyBB::class);
+
             $env = new Environment(
                 $container->make(LoaderInterface::class),
                 $container->make('twig.options')
@@ -95,8 +75,17 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             $env->addExtension($container->make(LangExtension::class));
             $env->addExtension($container->make(UrlExtension::class));
 
-            // TODO: this shouldn't be registered in live environments
-            $env->addExtension(new DebugExtension());
+            if ($mybb->dev_mode) {
+                $env->addExtension($container->make(DebugExtension::class));
+            }
+
+            if ($mybb->debug_mode && ($mybb->usergroup['cancp'] || $mybb->dev_mode)) {
+                $profile = new Profile();
+
+                $container->instance('twig.profile', $profile);
+
+                $env->addExtension(new ProfilerExtension($profile));
+            }
 
             return $env;
         });
@@ -110,6 +99,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             LangExtension::class,
             UrlExtension::class,
             LoaderInterface::class,
+            Environment::class,
         ];
     }
 }

--- a/inc/src/Twig/ThemeletLoader.php
+++ b/inc/src/Twig/ThemeletLoader.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Twig;
+
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\ThemeletInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\FilesystemLoader;
+
+/**
+ * Loads templates from the provided Themelet.
+ */
+class ThemeletLoader extends FilesystemLoader
+{
+    public function __construct(
+        private readonly ThemeletInterface $themelet,
+        private readonly ?string $mainNamespace = null,
+    ) {}
+
+    /**
+     * @return string|null
+     */
+    protected function findTemplate(string $name, bool $throw = true)
+    {
+        if (isset($this->cache[$name])) {
+            return $this->cache[$name];
+        }
+
+        if (isset($this->errorCache[$name])) {
+            if (!$throw) {
+                return null;
+            }
+
+            throw new LoaderError($this->errorCache[$name]);
+        }
+
+        $locator = ThemeletLocator::fromResourceContextString(
+            $name,
+            ResourceType::TEMPLATE,
+            $this->mainNamespace,
+        );
+
+        $path = $this->themelet->getResource($locator)?->getAbsolutePath();
+
+        if ($path !== null) {
+            $this->cache[$name] = $path;
+
+            return $path;
+        }
+
+        $this->errorCache[$name] = sprintf('Unable to find template "%s"', $name);
+
+        if (!$throw) {
+            return null;
+        }
+
+        throw new LoaderError($this->errorCache[$name]);
+    }
+}

--- a/inc/src/Utilities/Arrays.php
+++ b/inc/src/Utilities/Arrays.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Utilities;
+
+abstract class Arrays
+{
+    /**
+     * @param list<array-key> $path
+     */
+    public static function getNested(array $array, array $path): mixed
+    {
+        $target = &$array;
+
+        while ($key = array_shift($path)) {
+            if (is_array($target) && array_key_exists($key, $target)) {
+                $target = &$target[$key];
+            } else {
+                return null;
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * @param list<array-key> $path
+     */
+    public static function setNested(array &$array, array $path, mixed $value): void
+    {
+        $target = &$array;
+
+        foreach ($path as $key) {
+            if (!isset($target) || !is_array($target)) {
+                $target = [];
+            }
+
+            $target = &$target[$key];
+        }
+
+        $target = $value;
+    }
+
+    /**
+     * @param list<array-key> $path
+     */
+    public static function deleteNested(array &$array, array $path): bool
+    {
+        if ($path === []) {
+            if ($array === []) {
+                return false;
+            } else {
+                $array = [];
+
+                return true;
+            }
+        } else {
+            $targetKey = array_pop($path);
+
+            $targetArray = &$array;
+
+            foreach ($path as $pathKey) {
+                if (
+                    !isset($targetArray[$pathKey]) ||
+                    !is_array($targetArray[$pathKey])
+                ) {
+                    return false;
+                }
+
+                $targetArray = &$targetArray[$pathKey];
+            }
+
+            unset($targetArray[$targetKey]);
+
+            return true;
+        }
+    }
+}

--- a/inc/src/Utilities/Decorator.php
+++ b/inc/src/Utilities/Decorator.php
@@ -1,0 +1,505 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Utilities;
+
+use BadMethodCallException;
+use Illuminate\Container\Container;
+use InvalidArgumentException;
+use LogicException;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionProperty;
+use SplObjectStorage;
+
+/**
+ * Provides stack management functionality, helpers, and magic methods for base and concrete decorators.
+ *
+ * @template TTarget of object
+ * @template TDecorator of static
+ */
+abstract class Decorator
+{
+    /**
+     * The abstract decorator class.
+     */
+    private const TYPE_ABSTRACT = 2;
+
+    /**
+     * A general decorator class directly extending the abstract class, representing the decoration stack.
+     * Associated with, and implementing the same interface as, the innermost decorated class.
+     */
+    private const TYPE_BASE = 4;
+
+    /**
+     * A specific decorator class, extending a base decorator class.
+     */
+    private const TYPE_CONCRETE = 8;
+
+    private const MEMBER_TYPE_METHOD = 2;
+    private const MEMBER_TYPE_PROPERTY = 4;
+
+    /**
+     * Cached class type.
+     *
+     * @var self::TYPE_*
+     */
+    private readonly int $type;
+
+
+    /**
+     * The plain object to be decorated.
+     * Used in base decorator instances.
+     *
+     * @var ?TTarget
+     */
+    private readonly ?object $target;
+
+    /**
+     * The applied concrete decorator instances in descending priority order.
+     * Used in base decorator instances.
+     *
+     * @var list<TDecorator>
+     */
+    private array $decorators = [];
+
+    /**
+     * Cached public members of objects in the decoration stack.
+     * Used in base decorator instances.
+     *
+     * @var SplObjectStorage<static, array<self::MEMBER_TYPE_*, string[]>>
+     */
+    private SplObjectStorage $publicMembers;
+
+
+    /**
+     * The base decorator instance, in which the concrete decorator instance is stacked.
+     * Used in concrete decorator instances.
+     */
+    private readonly self $baseDecorator;
+
+
+    /**
+     * Decorates an object with concrete decorators.
+     *
+     * @param object<TTarget> $object
+     * @param list<TTarget|class-string<TDecorator>> $decorators
+     *   Class names or instances of concrete decorators in ascending priority order.
+     * @return TTarget&TDecorator A base decorator instance.
+     *
+     * @note Class references are initialized as objects.
+     *   The provided decorators are assigned types & bindings,
+     *   enabling correct functionality if the parent constructor (self::__construct()`) will not be called.
+     * @see self::__construct()
+     */
+    final public static function decorate(object $object, array $decorators = []): static
+    {
+        $type = static::getType();
+
+        if ($type !== self::TYPE_BASE) {
+            throw new BadMethodCallException(
+                '`' . __METHOD__ . '()` must be called on a base decorator'
+            );
+        }
+
+        if ($object instanceof self) {
+            $baseDecorator = $object->getBaseDecorator();
+        } else {
+            $baseDecorator = new static($object);
+        }
+
+        foreach ($decorators as $decorator) {
+            if (is_object($decorator)) {
+                if (!is_subclass_of($decorator, static::class)) {
+                    throw new InvalidArgumentException(
+                        'Decorator `' . $decorator::class . '` must be a subclass of the base decorator'
+                    );
+                }
+
+                if (isset($decorator->baseDecorator)) {
+                    throw new LogicException(
+                        'Decorator instance `' . $decorator::class . '` is already linked to a base decorator'
+                    );
+                }
+
+                // assign type & bindings
+
+                $decorator->type ??= self::TYPE_CONCRETE;
+                $decorator->baseDecorator ??= $baseDecorator;
+
+                $baseDecorator->addDecorator($decorator);
+            } else {
+                if (!class_exists($decorator)) {
+                    throw new InvalidArgumentException(
+                        'Decorator class `' . $decorator . '` not found'
+                    );
+                }
+
+                if (!is_subclass_of($decorator, static::class)) {
+                    throw new InvalidArgumentException(
+                        'Decorator `' . $decorator . '` must be a subclass of the base decorator'
+                    );
+                }
+
+                $container = Container::getInstance();
+
+                try {
+                    // assign type & bindings before executing the decorator's logic
+
+                    $decorator = (new ReflectionClass($decorator))->newInstanceWithoutConstructor();
+
+                    $decorator->type = self::TYPE_CONCRETE;
+                    $decorator->baseDecorator = $baseDecorator;
+
+                    $baseDecorator->addDecorator($decorator);
+
+                    $container->call(
+                        $decorator->__construct(...),
+                        [
+                            'baseDecorator' => $baseDecorator,
+                        ],
+                    );
+                } catch (ReflectionException) {
+                    $decorator = $container->make($decorator, [
+                        'baseDecorator' => $baseDecorator,
+                    ]);
+
+                    $baseDecorator->addDecorator($decorator);
+                }
+            }
+
+        }
+
+        return $baseDecorator;
+    }
+
+    /**
+     * Returns whether the concrete decorator class is in the specified decoration stack.
+     */
+    final public static function decorates(object $object): bool
+    {
+        if (static::getType() !== self::TYPE_CONCRETE) {
+            throw new BadMethodCallException('`' . __METHOD__ . '()` must be called on concrete decorator');
+        }
+
+        return (
+            is_subclass_of($object, self::class) &&
+            in_array(
+                static::class,
+                $object->getBaseDecorator()->getDecoratorClasses(),
+            )
+        );
+    }
+
+    /**
+     * Returns instance(s) of the concrete decorator class from the specified decoration stack.
+     *
+     * @return static[]
+     */
+    final public static function getInstancesDecorating(self $object): array
+    {
+        if (static::getType() !== self::TYPE_CONCRETE) {
+            throw new BadMethodCallException('`' . __METHOD__ . '()` must be called on concrete decorator');
+        }
+
+        return $object->getBaseDecorator()->getDecoratorsByClass(static::class);
+    }
+
+    protected static function decoratedCallException(): LogicException
+    {
+        $class = static::class;
+        $method = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+
+        return new LogicException('`' . $method . '()` cannot be called with `' . $class . '`');
+    }
+
+    /**
+     * @return class-string<self>
+     */
+    private static function getBaseDecoratorClass(): string
+    {
+        $class = static::class;
+
+        while (($parent = get_parent_class($class)) !== self::class) {
+            $class = $parent;
+        }
+
+        return $class;
+    }
+
+    /**
+     * @return self::TYPE_*
+     */
+    private static function getType(): int
+    {
+        $class = static::class;
+
+        if ($class === self::class) {
+            return self::TYPE_ABSTRACT;
+        } elseif (get_parent_class($class) === self::class) {
+            return self::TYPE_BASE;
+        } elseif (is_subclass_of($class, self::class)) {
+            return self::TYPE_CONCRETE;
+        } else {
+            throw new InvalidArgumentException('Class `' . $class . '` is not a subclass of `Decorator`');
+        }
+    }
+
+    /**
+     * Depending on the class, creates an instance of:
+     * - a concrete decorator, attaching it to a base decorator if one exists or can be created with the target object,
+     * - a base decorator, with the provided target object.
+     *
+     * @note The type and bindings may also have been saved externally in `self::decorate()`.
+     * @see self::decorate()
+     */
+    public function __construct(object $object = null, ?self $baseDecorator = null)
+    {
+        $this->type ??= static::getType();
+
+        if ($this->type === self::TYPE_CONCRETE) {
+            if ($baseDecorator === null && $object !== null) {
+                if ($object instanceof self) {
+                    $baseDecorator = $object->getBaseDecorator();
+                } else {
+                    $baseDecoratorClass = static::getBaseDecoratorClass();
+
+                    $baseDecorator = new $baseDecoratorClass($object);
+                }
+
+                $baseDecorator->addDecorator($this);
+            }
+
+            if ($baseDecorator !== null) {
+                $this->baseDecorator ??= $baseDecorator;
+            }
+        } elseif ($this->type === self::TYPE_BASE) {
+            if ($object === null || $object instanceof self || $baseDecorator !== null) {
+                throw new InvalidArgumentException(
+                    'Invalid arguments for base decorator constructor'
+                );
+            }
+
+            $this->target = $object;
+            $this->publicMembers = new SplObjectStorage();
+
+            $this->publicMembers->attach($object, [
+                self::MEMBER_TYPE_METHOD => [],
+                self::MEMBER_TYPE_PROPERTY => [],
+            ]);
+        }
+    }
+
+    public function __call(string $name, array $arguments): mixed
+    {
+        $object = $this->getDecoratedWithPublicMember(self::MEMBER_TYPE_METHOD, $name);
+
+        return $object->$name(...$arguments);
+    }
+
+    public function __get(string $name): mixed
+    {
+        $object = $this->getDecoratedWithPublicMember(self::MEMBER_TYPE_PROPERTY, $name);
+
+        return $object->$name;
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        $object = $this->getDecoratedWithPublicMember(self::MEMBER_TYPE_PROPERTY, $name, true);
+
+        $object->$name = $value;
+    }
+
+    public function __isset(string $name): bool
+    {
+        $object = $this->getDecoratedWithPublicMember(self::MEMBER_TYPE_PROPERTY, $name, true);
+
+        return isset($object->$name);
+    }
+
+    public function __unset(string $name): void
+    {
+        $object = $this->getDecoratedWithPublicMember(self::MEMBER_TYPE_PROPERTY, $name, true);
+
+        unset($object->$name);
+    }
+
+    /**
+     * Returns the immediate decorated object.
+     *
+     * When called on an instance of:
+     * - a concrete decorator: returns the next object in the call stack in descending priority,
+     * - a base decorator: returns the target object to be decorated.
+     */
+    final protected function getDecorated(): object
+    {
+        if ($this->type === self::TYPE_BASE) {
+            return $this->getBaseDecorator()->target;
+        } else {
+            return $this->getBaseDecorator()->callStack($this)->current();
+        }
+    }
+
+    /**
+     * Determine the object in the decoration stack to forward magic function calls to.
+     *
+     * @param self::MEMBER_TYPE_* $memberType
+     */
+    private function getDecoratedWithPublicMember(int $memberType, string $name, bool $defaultToTarget = false): object
+    {
+        [$existsCallback, $reflection] = match ($memberType) {
+            self::MEMBER_TYPE_METHOD => [
+                method_exists(...),
+                ReflectionMethod::class,
+            ],
+            self::MEMBER_TYPE_PROPERTY => [
+                property_exists(...),
+                ReflectionProperty::class,
+            ],
+        };
+
+        $baseDecorator = $this->getBaseDecorator();
+
+        // start at the top when called on a base decorator, otherwise after the called concrete decorator
+        $after = $this->type === self::TYPE_CONCRETE ? $this : null;
+
+        foreach ($baseDecorator->callStack($after) as $object) {
+            if (
+                $baseDecorator->publicMembers->contains($object) &&
+                in_array($name, $baseDecorator->publicMembers[$object][$memberType])
+            ) {
+                return $object;
+            }
+
+            if (
+                // the member exists (without magic method false positives)
+
+                /*
+                 * A class reference `$object::class` was previously necessary to prevent
+                 * instantiating ReflectionMethod, which threw for private methods
+                 * (https://github.com/php/php-src/pull/9640, https://github.com/php/php-src/pull/12127)
+                 */
+                $existsCallback($object, $name) &&
+                (new $reflection($object, $name))->isPublic()
+            ) {
+                $members = $baseDecorator->publicMembers[$object];
+
+                $members[$memberType][] = $name;
+
+                $baseDecorator->publicMembers->attach($object, $members);
+
+                return $object;
+            }
+        }
+
+        if ($defaultToTarget === true) {
+            return $baseDecorator->target;
+        } else {
+            $className = $baseDecorator->getTargetClassName();
+
+            $memberName = match ($memberType) {
+                self::MEMBER_TYPE_METHOD => 'method `' . $className . '::' . $name . '()`',
+                self::MEMBER_TYPE_PROPERTY => 'property `' . $className . '::$' . $name . '`',
+            };
+
+            throw new BadMethodCallException('Undefined ' . $memberName);
+        }
+    }
+
+    /**
+     * Returns the name of the decorated class.
+     * Used in base decorator instances.
+     *
+     * @return class-string
+     */
+    private function getTargetClassName(): string
+    {
+        return $this->target::class;
+    }
+
+    /**
+     * Returns concrete decorator instances and the innermost object to be decorated.
+     * Used in base decorator instances.
+     *
+     * @return iterable<TDecorator|TTarget>
+     */
+    private function callStack(?self $after = null): iterable
+    {
+        $consume = $after === null;
+
+        foreach ($this->decorators as $object) {
+            if ($consume === false) {
+                if ($object === $after) {
+                    $consume = true;
+                }
+
+                continue;
+            }
+
+            yield $object;
+        }
+
+        yield $this->target;
+    }
+
+    /**
+     * Adds a concrete decorator instance to the decoration stack with top priority.
+     * Used in base decorator instances.
+     */
+    private function addDecorator(self $object): void
+    {
+        array_unshift($this->decorators, $object);
+
+        $this->publicMembers->attach($object, [
+            self::MEMBER_TYPE_METHOD => [],
+            self::MEMBER_TYPE_PROPERTY => [],
+        ]);
+    }
+
+    /**
+     * Returns concrete decorator classes present in the decoration stack.
+     * Used in base decorator instances.
+     *
+     * @return class-string<static>[]
+     */
+    private function getDecoratorClasses(): array
+    {
+        return array_map('get_class', $this->decorators);
+    }
+
+    /**
+     * Returns concrete decorator instances present in the decoration stack by class.
+     * Used in base decorator instances.
+     *
+     * @param class-string<self> $class
+     * @return static[]
+     */
+    private function getDecoratorsByClass(string $class): array
+    {
+        return array_values(
+            array_filter(
+                $this->decorators,
+                fn (self $decorator) => $decorator::class === $class,
+            )
+        );
+    }
+
+    /**
+     * Returns the associated base decorator instance.
+     */
+    private function getBaseDecorator(): self
+    {
+        return match ($this->type) {
+            self::TYPE_BASE => $this,
+            self::TYPE_CONCRETE => $this->baseDecorator ?? throw new LogicException(
+                'Decorator `' . static::class . '` must be assigned to a decoration stack before usage'
+            ),
+            default => throw new BadMethodCallException(
+                '`' . __METHOD__ . '` must be called on a subclass of `Decorator`'
+            ),
+        };
+    }
+}

--- a/inc/src/Utilities/FileStamp.php
+++ b/inc/src/Utilities/FileStamp.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Utilities;
+
+use InvalidArgumentException;
+use LogicException;
+
+readonly class FileStamp
+{
+    public const TYPE_CHECKSUM = 'checksum';
+    public const TYPE_MODIFICATION_TIME = 'time';
+
+    private const HASH_ALGORITHM = 'xxh128';
+
+    /**
+     * @param ?array<self::TYPE_*, int|string> $stamp
+     */
+    public function __construct(
+        private ?array $stamp,
+    ) {}
+
+    public static function fromFile(?string $path = null, ?string $content = null): self
+    {
+        $values = [];
+
+        foreach ([self::TYPE_CHECKSUM, self::TYPE_MODIFICATION_TIME] as $type) {
+            $values[$type] = self::getValue($type, $path, $content);
+        }
+
+        return new self($values);
+    }
+
+    public static function fromNonexistentFile(): self
+    {
+        return new self(null);
+    }
+
+    /**
+     * @param self::TYPE_* $type
+     */
+    private static function getValue(string $type, ?string $path = null, ?string $content = null): mixed
+    {
+        switch ($type) {
+            case self::TYPE_CHECKSUM:
+                if ($content !== null) {
+                    $value = hash(self::HASH_ALGORITHM, $content);
+                } elseif ($path !== null && is_readable($path)) {
+                    $value = hash_file(self::HASH_ALGORITHM, $path);
+                } else {
+                    $value = null;
+                }
+
+                break;
+            case self::TYPE_MODIFICATION_TIME:
+                $value = filemtime($path);
+
+                break;
+            default:
+                throw new InvalidArgumentException();
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return ?array<self::TYPE_*, int|string> $values
+     */
+    public function getStamp(): ?array
+    {
+        return $this->stamp;
+    }
+
+    /**
+     * @param self::TYPE_* $type
+     */
+    public function isValid(string $path, string $type = self::TYPE_CHECKSUM): bool
+    {
+        if ($this->stamp === null && !file_exists($path)) {
+            return true;
+        }
+
+        if (!array_key_exists($type, $this->stamp)) {
+            throw new LogicException('Cannot validate Stamp for `' . $path . '` - type `' . $type . '` is not set');
+        }
+
+        return $this->stamp[$type] === self::getValue($type, $path);
+    }
+}

--- a/inc/src/Utilities/Hydrable/FilesystemStore.php
+++ b/inc/src/Utilities/Hydrable/FilesystemStore.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Utilities\Hydrable;
+
+use MyBB\Utilities\Arrays;
+
+class FilesystemStore implements StoreInterface
+{
+    /**
+     * @var array<string, resource>
+     */
+    private array $filePointers;
+
+    /**
+     * @var array<string, array>
+     */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly string $basePath,
+    ) {}
+
+    public function get(string $key, array $path = []): mixed
+    {
+        if (!array_key_exists($key, $this->cache)) {
+            $this->loadFile($key);
+        }
+
+        return Arrays::getNested($this->cache, [$key, ...$path]);
+    }
+
+    public function set(string $key, array $path, array $value): bool
+    {
+        if (!array_key_exists($key, $this->cache)) {
+            $this->loadFile($key);
+        }
+
+        Arrays::setNested($this->cache, [$key, ...$path], $value);
+
+        return $this->saveFile($key);
+    }
+
+    public function delete(string $key, array $path = []): void
+    {
+        Arrays::deleteNested($this->cache, [$key, ...$path]);
+
+        if ($path === []) {
+            unlink($this->getFilePath($key));
+        }
+    }
+
+    public function lock(string $key, bool $exclusive = true): bool
+    {
+        $filePath = $this->getFilePath($key);
+        $directoryPath = dirname($filePath);
+
+        if (!is_dir($directoryPath)) {
+            mkdir($directoryPath, recursive: true);
+        }
+
+        $pointer = $this->filePointers[$key] ??= fopen($filePath, 'c');
+
+        return flock($pointer, $exclusive ? LOCK_EX : LOCK_SH);
+    }
+
+    public function unlock(string $key): bool
+    {
+        if ($fp = $this->filePointers[$key]) {
+            $result = flock($fp, LOCK_UN);
+            fclose($fp);
+
+            unset($this->filePointers[$key]);
+
+            return $result;
+        } else {
+            return false;
+        }
+    }
+
+    private function loadFile(string $key): bool
+    {
+        $path = $this->getFilePath($key);
+
+        if (file_exists($path)) {
+            $content = file_get_contents($path);
+
+            if ($content === false) {
+                return false;
+            }
+
+            $decoded = json_decode($content, true);
+
+            $this->cache[$key] = $decoded;
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private function saveFile(string $key): bool
+    {
+        $path = $this->getFilePath($key);
+
+        mkdir(dirname($path), recursive: true);
+
+        return file_put_contents(
+            $path,
+            json_encode($this->cache[$key], JSON_PRETTY_PRINT),
+        ) !== false;
+    }
+
+    private function getFilePath(string $key): string
+    {
+        return $this->basePath . '/' . $key . '.json';
+    }
+}

--- a/inc/src/Utilities/Hydrable/Hydrable.php
+++ b/inc/src/Utilities/Hydrable/Hydrable.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Utilities\Hydrable;
+
+use InvalidArgumentException;
+use LogicException;
+use MyBB\Stopwatch\Stopwatch;
+use MyBB\Utilities\Arrays;
+use ReflectionFunction;
+use RuntimeException;
+
+use function MyBB\app;
+
+/**
+ * Stores data with custom initialization, serialization, and caching strategies.
+ *
+ * @template T mixed
+ */
+class Hydrable
+{
+    final public const MODE_IMMEDIATE = 2;
+    final public const MODE_DEFERRED = 4;
+    final public const MODE_PASSIVE = 8;
+
+    private const DATA_STAMP = 'stamp';
+    private const DATA_VALUE = 'value';
+
+    public ?StoreInterface $store;
+
+    /**
+     * @var array<string, array{
+     *   build: ?callable(): T,
+     *   validateStamp: ?callable,
+     * }
+     */
+    private array $closures;
+
+    /**
+     * @var array<string, array{
+     *   write: ?callable(T $data),
+     *   read: ?callable():T,
+     * }
+     */
+    private array $filters;
+
+    private bool $supportsStamping;
+
+    /**
+     * @var T
+     */
+    private mixed $value;
+
+    private mixed $stamp = null;
+
+    private bool $initialized = false;
+    private bool $pendingWrite = false;
+    private bool $stampValidated = false;
+
+    private ?Stopwatch $stopwatch;
+
+    public function __construct(
+        /**
+         * @var T
+         */
+        private readonly mixed $default,
+
+        public readonly ?string $key = null,
+        public readonly array $path = [],
+
+        ?callable $build = null,
+
+
+        ?callable $validateStamp = null,
+
+        ?callable $write = null,
+        ?callable $read = null,
+
+        /**
+         * Strategy for initializing with the default value.
+         *
+         * @var self::MODE_*
+         */
+        public int $defaultMode = self::MODE_DEFERRED,
+
+        /**
+         * Strategy for initializing with the build callback.
+         *
+         * @var self::MODE_*
+         */
+        public int $buildMode = self::MODE_DEFERRED,
+
+        /**
+         * Strategy for writing data to the store.
+         *
+         * @var self::MODE_*
+         */
+        public int $writeMode = self::MODE_DEFERRED,
+
+        /**
+         * Strategy for initializing with stored value.
+         *
+         * @var self::MODE_*
+         */
+        public int $readMode = self::MODE_DEFERRED,
+
+        /**
+         * Strategy for validating stamps when loading from the store.
+         *
+         * @var self::MODE_*
+         */
+        public int $validateStampMode = self::MODE_IMMEDIATE,
+
+        public bool $ignoreSet = false,
+    ) {
+        $this->stopwatch = app(Stopwatch::class);
+
+        $this->closures = [
+            'build' => $build,
+            'validateStamp' => $validateStamp,
+        ];
+
+        $this->filters = [
+            'write' => $write,
+            'read' => $read,
+        ];
+
+        $this->supportsStamping = is_callable($build) && self::providesStamp($build);
+
+        foreach (['default', 'read', 'build'] as $action) {
+            if (${$action . 'Mode'} === self::MODE_IMMEDIATE) {
+                $this->$action();
+            }
+        }
+    }
+
+    private static function providesStamp(callable $callable): bool
+    {
+        $reflection = new ReflectionFunction($callable);
+
+        $parameters = $reflection->getParameters();
+
+        foreach ($parameters as $parameter) {
+            if ($parameter->isPassedByReference() && $parameter->getName() === 'stamp') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function __destruct()
+    {
+        $this->commit();
+    }
+
+    public function initialize(): void
+    {
+        if ($this->readMode !== self::MODE_PASSIVE && $this->read()) {
+            return;
+        }
+
+        if ($this->buildMode !== self::MODE_PASSIVE && $this->build()) {
+            return;
+        }
+
+        if ($this->defaultMode !== self::MODE_PASSIVE) {
+            $this->default();
+            return;
+        }
+
+        throw new LogicException('Could not initialize Hydrable `' . $this->getFriendlyIdentifier() . '`');
+    }
+
+    public function initialized(): bool
+    {
+        return $this->initialized;
+    }
+
+    /**
+     * @return T
+     */
+    public function get(): mixed
+    {
+        if (!$this->initialized) {
+            $this->initialize();
+        }
+
+        return $this->value;
+    }
+
+    /**
+     * @param list<array-key> $path
+     */
+    public function getNested(array $path): mixed
+    {
+        return Arrays::getNested($this->get(), $path);
+    }
+
+    /**
+     * @param T $value
+     */
+    public function set(mixed $value, mixed $stamp = null): void
+    {
+        if (!$this->initialized) {
+            throw new LogicException('Cannot write to uninitialized Hydrable `' . $this->getFriendlyIdentifier() . '`');
+        }
+
+        if ($this->ignoreSet) {
+            return;
+        }
+
+        $this->applyValue($value, $stamp);
+    }
+
+    /**
+     * @param list<array-key> $path
+     */
+    public function setNested(array $path, mixed $value, mixed $stamp = null): void
+    {
+        $topValue = $this->get();
+
+        Arrays::setNested($topValue, $path, $value);
+
+        $this->set($topValue, $stamp);
+    }
+
+    public function delete(): void
+    {
+        $this->value = null;
+        $this->stamp = null;
+
+        $this->initialized = false;
+        $this->pendingWrite = false;
+        $this->stampValidated = false;
+
+        $this->store?->delete($this->key);
+    }
+
+    /**
+     * @param list<array-key> $path
+     */
+    public function deleteNested(array $path): void
+    {
+        $value = $this->get();
+
+        Arrays::deleteNested($value, $path);
+
+        $this->set($value);
+    }
+
+    public function default(bool $deferred = false): void
+    {
+        $this->initialized = true;
+
+        $this->applyValue($this->default, null, $deferred);
+    }
+
+    public function build(): bool
+    {
+        if ($closure = $this->closures['build']) {
+            if ($this->writeMode !== self::MODE_PASSIVE) {
+                $this->store?->lock($this->key);
+            }
+
+            $stopwatchPeriod = $this->stopwatch?->start('core.hydrable.build');
+
+            $stamp = null;
+
+            try {
+                $value = $this->supportsStamping
+                    ? $closure(stamp: $stamp)
+                    : $closure()
+                ;
+            } finally {
+                $stopwatchPeriod?->stop();
+            }
+
+            $this->initialized = true;
+
+            $this->applyValue($value, $stamp);
+
+            if ($this->writeMode !== self::MODE_PASSIVE) {
+                $this->store?->unlock($this->key);
+            }
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function write(): bool
+    {
+        if ($this->store) {
+            $stopwatchPeriod = $this->stopwatch?->start('core.hydrable.write');
+
+            try {
+                $serialized = $this->serialize();
+
+                $result = $this->store->set($this->key, $this->path, $serialized);
+
+                $this->pendingWrite = false;
+            } finally {
+                $stopwatchPeriod?->stop();
+            }
+
+            return $result;
+        }
+
+        return false;
+    }
+
+    public function read(): bool
+    {
+        if ($this->store) {
+            $stopwatchPeriod = $this->stopwatch?->start('core.hydrable.read');
+
+            try {
+                $serialized = $this->store->get($this->key, $this->path);
+
+                if (is_array($serialized)) {
+                    return $this->unserialize($serialized);
+                }
+            } catch (RuntimeException) {
+                return false;
+            } finally {
+                $stopwatchPeriod?->stop();
+            }
+        }
+
+        return false;
+    }
+
+    public function commit(): void
+    {
+        if ($this->pendingWrite) {
+            $this->write();
+        }
+    }
+
+    public function valid(): ?bool
+    {
+        if (!$this->supportsStamping) {
+            return null;
+        }
+
+        if ($this->stampValidated) {
+            return true;
+        }
+
+        $this->get();
+
+        if ($this->stampValidated) {
+            return true;
+        }
+
+        if ($this->stampValid($this->stamp)) {
+            $this->stampValidated = true;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param T $value
+     */
+    private function applyValue(mixed $value, mixed $stamp = null, bool $deferred = false): void
+    {
+        $this->value = $value;
+
+        if ($stamp !== null) {
+            $this->stamp = $stamp;
+            $this->stampValidated = true;
+        } else {
+            $this->stampValidated = false;
+        }
+
+        if ($this->writeMode !== self::MODE_PASSIVE && $this->store) {
+            if ($stamp !== null && $this->getStoredStamp() === $stamp) {
+                return;
+            }
+
+            if (
+                $deferred ||
+                (
+                    $this->writeMode === self::MODE_DEFERRED &&
+                    !$this->pendingWrite
+                )
+            ) {
+                $this->pendingWrite = true;
+            } else {
+                $this->write();
+            }
+        }
+    }
+
+    private function serialize(): array
+    {
+        if (!$this->initialized) {
+            throw new InvalidArgumentException('Cannot serialize uninitialized Hydrable `' . $this->getFriendlyIdentifier() . '`');
+        }
+
+        $value = $this->value;
+
+        if (gettype($value) !== gettype($this->default)) {
+            throw new RuntimeException('Type of Hydrable `' . $this->getFriendlyIdentifier() . '` does not match default');
+        }
+
+        $this->filterValue('write', $value);
+
+        return [
+            self::DATA_STAMP => $this->stamp,
+            self::DATA_VALUE => $value,
+        ];
+    }
+
+    private function unserialize(array $data): bool
+    {
+        if (
+            !array_key_exists(self::DATA_STAMP, $data) ||
+            !array_key_exists(self::DATA_VALUE, $data)
+        ) {
+            throw new RuntimeException('Corrupted structure for Hydrable `' . $this->getFriendlyIdentifier() . '`');
+        }
+
+        if (
+            $this->supportsStamping &&
+            $this->validateStampMode !== self::MODE_PASSIVE
+        ) {
+            $stampValidated = true;
+
+            if (!$this->stampValid($data[self::DATA_STAMP])) {
+                return false;
+            }
+        } else {
+            $stampValidated = false;
+        }
+
+        $value = $data[self::DATA_VALUE];
+
+        $this->filterValue('read', $value);
+
+        if (gettype($value) !== gettype($this->default)) {
+            throw new RuntimeException('Type of unserialized Hydrable `' . $this->getFriendlyIdentifier() . '`does not match default');
+        }
+
+        $this->value = $value;
+        $this->stamp = $data[self::DATA_STAMP];
+
+        $this->initialized = true;
+        $this->stampValidated = $stampValidated;
+
+        return true;
+    }
+
+    private function stampValid(mixed $stamp): bool
+    {
+        if ($stamp === null) {
+            return false;
+        }
+
+        if ($closure = $this->closures['validateStamp']) {
+            if (!$closure($stamp)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function getStoredStamp(): mixed
+    {
+        return $this->store->get($this->key, $this->path)[self::DATA_STAMP] ?? null;
+    }
+
+    private function filterValue(string $type, mixed &$value): void
+    {
+        if ($this->filters[$type] !== null) {
+            $value = $this->filters[$type]($value);
+        }
+    }
+
+    private function getFriendlyIdentifier(): string
+    {
+        if ($this->key !== null) {
+            return $this->key . '[' . implode(', ', $this->path) . ']';
+        } else {
+            return '';
+        }
+    }
+}

--- a/inc/src/Utilities/Hydrable/Repository.php
+++ b/inc/src/Utilities/Hydrable/Repository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Utilities\Hydrable;
+
+use InvalidArgumentException;
+use MyBB\Utilities\Arrays;
+
+class Repository
+{
+    private array $hydrables = [];
+
+    public function __construct(
+        private readonly ?StoreInterface $store = null,
+    ) {}
+
+    public function add(Hydrable $hydrable, array $path = []): Hydrable
+    {
+        $hydrable->store = $this->store;
+
+        Arrays::setNested($this->hydrables, [$hydrable->key, ...$path], $hydrable);
+
+        return $hydrable;
+    }
+
+    public function get(string $name, array $path = []): ?Hydrable
+    {
+        $value = Arrays::getNested($this->hydrables, [$name, ...$path]);
+
+        if ($value instanceof Hydrable) {
+            return $value;
+        } else {
+            throw new InvalidArgumentException();
+        }
+    }
+
+    public function delete(string $name, array $path = []): void
+    {
+        $this->store->delete($name, $path);
+    }
+
+    public function clear(): void
+    {
+        if ($this->store) {
+            foreach ($this->hydrables as $hydrable) {
+                $hydrable->delete();
+            }
+        }
+    }
+}

--- a/inc/src/Utilities/Hydrable/StoreInterface.php
+++ b/inc/src/Utilities/Hydrable/StoreInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Utilities\Hydrable;
+
+interface StoreInterface
+{
+    public function get(string $key, array $path = []): mixed;
+    public function set(string $key, array $path, array $value): bool;
+    public function delete(string $key, array $path = []): void;
+    public function lock(string $key, bool $exclusive = true): bool;
+    public function unlock(string $key): bool;
+}

--- a/inc/src/View/ARCHITECTURE.md
+++ b/inc/src/View/ARCHITECTURE.md
@@ -1,0 +1,64 @@
+# <img src="https://github.com/mybb/mybb/assets/8020837/93684b83-b1d3-4908-b46b-f753b18fae5b" height="100" align="left"> `MyBB\View` Architecture
+
+_The View domain manages the graphical user interface, themes, layout resources and assets._
+
+
+## View Extensions
+
+Plugins and Themes implement `ViewExtensionInterface`.
+
+Themes implement `HierarchicalExtensionInterface`, allowing definitions of ancestors.
+
+Theme ancestor information is loaded from Extension manifest files (`manifest.json`).
+
+
+## Themelets
+
+Interface-related information of each View Extension is stored in a _Themelet_ structure.
+
+Themelets may be divided into **namespaces**, styling separate interfaces, contexts, or independent packages.
+
+Plugins may supply Resources for their own namespace, while Themes may override Resources in any namespace.
+
+Namespace-bound entities carry inheritance information and other metadata in respective JSON files (`resources.json`, `assets.json`), and implement `NamespaceCargo`.
+
+Runtime operations of Themelet entities are handled by the following decorators.
+
+
+### Hierarchy
+
+`HierarchicalThemelet` provides **vertical resolution and merging** of entities and their properties, according to established inheritance in the following order:
+1. Themelets of active Plugins
+2. Selected Theme ancestors
+3. Selected Theme
+
+Member items inherit from ancestors declared by the Extension by default, but inheritance can be severed for items on the individual and namespace levels.
+
+### Publishing
+
+`PublishableThemelet` returns processed and published assets, and related data.
+
+### Composition
+
+`CompositeThemelet` performs **horizontal resolution and merging** from active namespaces, reconciling references to same Assets.
+
+
+## Performance
+
+MyBB performs all rendering operations server-side, beginning with hierarchical **resolution**, where individual items and their metadata is accessed according to declared inheritance. These sources are used for the **generation** of items for usage, most impactful during cache warm-up. The **execution** stage involves the execution of Twig Templates and may be further optimized through server configuration.
+
+The table below highlights the practical performance impact (a product of individual computation cost, and usual number of iterations) of these operations.
+
+Stage | Data | Building Cost | Validation Cost
+-|-|-|-
+Resolution | Extension ancestry | 🟢 Low | 🟢 Low
+Resolution | Member properties | 🟢 Low | 🟢 Low
+Resolution | Resources | 🔺 High | 🟨 Medium
+Generation | Published Assets | 🔺 High | 🟨 Medium
+Generation | Twig templates | 🔺 High | 🟨 Medium
+Execution | Twig cache opcode | 🟨 Medium | 🟨 Medium
+
+
+---
+## References
+- **Design choices & plans:** https://github.com/mybb/meta/blob/main/architecture/mybb-1.9-theme-system.md

--- a/inc/src/View/Asset/Asset.php
+++ b/inc/src/View/Asset/Asset.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Asset;
+
+use MyBB;
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\View\Themelet\NamespaceCargo\EntityTrait;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\StaticLocator;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Themelet\ThemeletInterface;
+
+use function MyBB\app;
+
+abstract class Asset
+{
+    use EntityTrait;
+
+    /**
+     * Properties to use during runtime.
+     */
+    private array $compositeProperties = [];
+
+    public static function fromLocator(
+        Locator $locator,
+        ?ThemeletInterface $themelet = null,
+        ?string $declarationNamespace = null,
+    ): static
+    {
+        return match (get_class($locator)) {
+            ThemeletLocator::class => new ThemeletAsset($locator, $themelet),
+            StaticLocator::class => new StaticAsset($locator, $themelet, $declarationNamespace),
+        };
+    }
+
+    /**
+     * @param array[] $properties
+     */
+    public static function getMergedProperties(array $properties): array
+    {
+        return array_merge_recursive(...$properties);
+    }
+
+    public function getLocator(): Locator
+    {
+        return $this->locator;
+    }
+
+    public function getThemelet(): ThemeletInterface
+    {
+        return $this->themelet;
+    }
+
+    public function getRepository(): RepositoryInterface
+    {
+        return $this->getThemelet()->getAssetRepository(
+            $this->getEntityNamespace()
+        );
+    }
+
+    public function setCompositeProperties(array $properties): void
+    {
+        $this->compositeProperties = static::getMergedProperties([
+            $this->compositeProperties,
+            $properties,
+        ]);
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->compositeProperties['attributes'] ?? [];
+    }
+
+    public function getUrl(bool $useCdn = true): string
+    {
+        // logic from MyBB::get_asset_url() may be moved to the View domain here
+
+        $url = app(MyBB::class)->get_asset_url($this->getPublicPath(), $useCdn);
+
+        return $url;
+    }
+
+    abstract protected function getEntityNamespace(): string;
+}

--- a/inc/src/View/Asset/Processor/Processor.php
+++ b/inc/src/View/Asset/Processor/Processor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Asset\Processor;
+
+use MyBB\View\Asset\Publication;
+use MyBB\View\Asset\ThemeletAsset;
+
+abstract class Processor
+{
+    readonly protected string $inputContent;
+
+    public function __construct(
+        protected Publication $publication,
+        protected ThemeletAsset $asset,
+    )
+    {}
+
+    final public function setInputContent(string $content): void
+    {
+        $this->inputContent = $content;
+    }
+
+    public function getOutputContent(): string
+    {
+        return $this->inputContent;
+    }
+}

--- a/inc/src/View/Asset/Processor/ScssProcessor.php
+++ b/inc/src/View/Asset/Processor/ScssProcessor.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Asset\Processor;
+
+use Exception;
+use Illuminate\Filesystem\Filesystem;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Resource;
+use MyBB\View\Themelet\Themelet;
+use MyBB\View\Themelet\ThemeletInterface;
+use ScssPhp\ScssPhp\Compiler;
+
+class ScssProcessor extends Processor
+{
+    /**
+     * @var ThemeletInterface[]
+     */
+    protected array $sourceThemelets = [];
+
+    /**
+     * A mapping of absolute paths to importable Resources.
+     *
+     * As ScssPhp prioritizes relative paths over provided import paths/functions,
+     * the files may be copied - according to inheritance - into a single location first.
+     *
+     * @var array<string, Resource>
+     */
+    private array $importableResourceFiles = [];
+
+    public function getOutputContent(): string
+    {
+        $importableResources = $this->getImportableResources();
+
+        $originThemelets = $this->getResourceThemelets($importableResources);
+
+        if (count($originThemelets) > 1) {
+            $this->prepareImportableResourceFiles($importableResources);
+
+            $sourcePath = $this->getImportableResourceAbsolutePath(
+                $this->asset->getResource()
+            );
+        } else {
+            $this->sourceThemelets[] = $this->asset->getResource()->getThemelet();
+
+            $sourcePath = $this->asset->getResource()->getAbsolutePath();
+        }
+
+
+        $compiler = new Compiler();
+
+        $compiler->addImportPath(
+            $this->getImportAbsolutePath(...)
+        );
+
+        $compiled = $compiler->compileString($this->inputContent, $sourcePath);
+
+        // add using actual results instead of the callback
+        $this->addSourcesFromAbsolutePaths(
+            $compiled->getIncludedFiles()
+        );
+
+        return $compiled->getCss();
+    }
+
+    private function getImportableResources(): array
+    {
+        static $resources;
+
+        return $resources ??= $this->asset->getThemelet()->getResources(
+            [$this->asset->getResource()->getNamespace()],
+            [$this->asset->getResource()->getType()],
+        );
+    }
+
+    /**
+     * @param Resource[] $resources
+     */
+    private function getResourceThemelets(array $resources): array
+    {
+        return array_unique(
+            array_map(
+                fn (Resource $resource) => $resource->getThemelet()->getIdentifier(),
+                $resources,
+            ),
+        );
+    }
+
+    /**
+     * @see https://scssphp.github.io/scssphp/docs/extending/importers.html
+     */
+    private function getImportAbsolutePath(string $path): ?string
+    {
+        if (Compiler::isCssImport($path)) {
+            return null;
+        }
+
+        try {
+            foreach ($this->getImportCandidatePaths($path) as $candidatePath) {
+                $locator = $this->asset->getLocator()->getSibling($candidatePath);
+
+                if ($this->asset->getThemelet()->hasResource($locator)) {
+                    $resource = $this->asset->getThemelet()->getExistingResource($locator);
+
+                    if (!in_array($resource->getThemelet(), $this->sourceThemelets)) {
+                        $this->sourceThemelets[] = $resource->getThemelet();
+                    }
+
+                    return $resource->getAbsolutePath();
+                }
+            }
+        } catch (Exception) {
+        }
+
+        return null;
+    }
+
+    /**
+     * @see Compiler::resolveImportPath
+     * @return string[]
+     */
+    private function getImportCandidatePaths(string $path): array
+    {
+        $candidatePaths = [];
+
+        $pathsWithExtension = [];
+
+        if (preg_match('/.s[ac]ss$/', $path)) {
+            $pathsWithExtension[] = $path;
+        } else {
+            foreach (['sass', 'scss', 'css'] as $extension) {
+                $pathsWithExtension[] = $path . '.' . $extension;
+            }
+        }
+
+        foreach ($pathsWithExtension as $pathWithExtension) {
+            $candidatePaths[] = dirname($pathWithExtension) . '/_' . basename($pathWithExtension);
+            $candidatePaths[] = $pathWithExtension;
+        }
+
+        return $candidatePaths;
+    }
+
+    /**
+     * @param string[] $paths
+     */
+    private function addSourcesFromAbsolutePaths(array $paths): void
+    {
+        foreach ($paths as $path) {
+            if (array_key_exists($path, $this->importableResourceFiles)) {
+                $resource = $this->importableResourceFiles[$path];
+
+                $this->publication->addSource($resource);
+
+                continue;
+            }
+
+            foreach ($this->sourceThemelets as $themelet) {
+                if (!str_starts_with($path, $themelet->getAbsolutePath() . '/')) {
+                    continue;
+                }
+
+                foreach ($themelet->getNamespaceAbsolutePaths() as $namespace => $namespacePaths) {
+                    foreach ($namespacePaths as $namespacePath) {
+                        if (!str_starts_with($path, $namespacePath . '/')) {
+                            continue;
+                        }
+
+                        $this->publication->addSource(
+                            $themelet->getExistingResource(
+                                ThemeletLocator::fromNamespaceRelativeIdentifier(
+                                    $namespace,
+                                    substr($path, strlen($namespacePath . '/'))
+                                )
+                            )
+                        );
+
+                        continue 4;
+                    }
+                }
+            }
+
+            throw new Exception('Unexpected Resource `' . $path . '` used for SCSS import');
+        }
+    }
+
+    /**
+     * @param Resource[] $resources
+     */
+    private function prepareImportableResourceFiles(array $resources): void
+    {
+        $filesystem = new Filesystem();
+
+        $filesystem->deleteDirectory(
+            $this->getImportableResourceDirectory(),
+            preserve: true,
+        );
+
+        foreach ($resources as $resource) {
+            $cachePath = $this->getImportableResourceAbsolutePath($resource);
+
+            $this->importableResourceFiles[$cachePath] = $resource;
+
+            if (
+                !file_exists($cachePath) ||
+                filemtime($resource->getAbsolutePath()) !== filemtime($cachePath)
+            ) {
+                mkdir(
+                    dirname($cachePath),
+                    recursive: true,
+                );
+
+                copy(
+                    $resource->getAbsolutePath(),
+                    $cachePath,
+                );
+            }
+        }
+    }
+
+    private function getImportableResourceAbsolutePath(Resource $resource): string
+    {
+        return
+            $this->getImportableResourceDirectory() .
+            '/' .
+            $resource->getIdentifierPath()
+        ;
+    }
+
+    private function getImportableResourceDirectory(): string
+    {
+        static $path;
+
+        return $path ??=
+            Themelet::CACHE_BASE_PATH .
+            $this->asset->getThemelet()->getIdentifier() .
+            '/resolvedResources'
+        ;
+    }
+}

--- a/inc/src/View/Asset/Publication.php
+++ b/inc/src/View/Asset/Publication.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Asset;
+
+use InvalidArgumentException;
+use MyBB\Stopwatch\Stopwatch;
+use MyBB\View\Asset\Processor\Processor;
+use MyBB\View\Asset\Processor\ScssProcessor;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Resource;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\ThemeletInterface;
+
+use function MyBB\app;
+
+/**
+ * Prepares Theme Assets for web usage.
+ */
+class Publication
+{
+    public const PUBLISHABLE_RESOURCE_TYPES = [
+        ResourceType::IMAGE,
+        ResourceType::STYLE,
+        ResourceType::SCRIPT,
+    ];
+
+    private readonly ThemeletAsset $asset;
+
+    /**
+     * @var Processor[]
+     */
+    private array $processors;
+
+    /**
+     * Resources declared as contributing to the converted Asset.
+     *
+     * @var array<string, array{
+     *   themelet: string,
+     *   subPath: string,
+     * }>
+     */
+    private array $sources = [];
+
+    /**
+     * @note May result in false negative for source files modified successively within 1 second.
+     */
+    public static function needsUpdate(ThemeletAsset $asset): bool
+    {
+        $path = $asset->getAbsolutePath();
+
+        $publishedFileTime = filemtime($path);
+
+        if ($publishedFileTime === false) {
+            return true;
+        }
+
+        $sourceResources = self::getPublishedAssetResources($asset);
+
+        if ($sourceResources === null) {
+            return true;
+        }
+
+        foreach ($sourceResources as $sourceResource) {
+            $resource = $asset->getThemelet()->getExistingResource(
+                $asset->getLocator()->getSibling($sourceResource['subPath'])
+            );
+
+            if (
+                $resource->getThemelet()->getIdentifier() !== $sourceResource['themelet'] ||
+                $resource->getModificationTime() > $publishedFileTime
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a list of Resources effectively used as a source for a published Asset.
+     */
+    public static function getPublishedAssetResources(ThemeletAsset $asset): ?array
+    {
+        return $asset->getThemelet()->getAssetPublicationData($asset)['sources'] ?? null;
+    }
+
+    /**
+     * Returns a list of Assets published using the provided Resource.
+     */
+    public static function getAssetsPublishedUsingResource(Resource $resource, ThemeletInterface $themelet): array
+    {
+        $assets = [];
+
+        foreach ($themelet->getAssetPublicationData() as $assetLocatorString => $assetData) {
+            $assetSourceSignatures = $assetData['sources'] ?? [];
+
+            if (in_array(self::getSourceSignature($resource), $assetSourceSignatures)) {
+                $assetLocator = ThemeletLocator::fromString($assetLocatorString);
+
+                $assets[$assetLocatorString] = new ThemeletAsset($assetLocator, $themelet);
+            }
+        }
+
+        return $assets;
+    }
+
+    public static function getSourceSignature(Resource $resource): array
+    {
+        return [
+            'themelet' => $resource->getThemelet()->getIdentifier(),
+            'subPath' => $resource->getLocator()->getSubPath(),
+        ];
+    }
+
+    public static function isPlain(ThemeletAsset $asset): bool
+    {
+        return self::getBaseProcessor($asset) === null;
+    }
+
+    public static function resourcePublishable(Resource $resource): bool
+    {
+        return in_array($resource->getType(), self::PUBLISHABLE_RESOURCE_TYPES);
+    }
+
+    /**
+     * @return ?class-string<static>
+     */
+    private static function getBaseProcessor(ThemeletAsset $asset): ?string
+    {
+        $sourceExtension = pathinfo($asset->getResource()->getFilename(), PATHINFO_EXTENSION);
+
+        return match ($sourceExtension) {
+            'sass', 'scss' => ScssProcessor::class,
+            default => null,
+        };
+    }
+
+    /**
+     * @param ThemeletAsset $asset
+     * @param Processor[] $processors
+     */
+    public function __construct(ThemeletAsset $asset, array $processors = [])
+    {
+        $this->asset = $asset;
+        $this->processors = $processors;
+
+        $baseProcessor = self::getBaseProcessor($asset);
+
+        if ($baseProcessor) {
+            array_unshift($this->processors, $baseProcessor);
+        }
+    }
+
+    public function publish(bool $force = false): bool
+    {
+        if (!$force && !static::needsUpdate($this->asset)) {
+            return false;
+        }
+
+        $fh = fopen($this->asset->getAbsolutePath(), 'c');
+
+        if (!$fh) {
+            return false;
+        }
+
+        $result = false;
+
+        if (
+            flock($fh, LOCK_EX|LOCK_NB, $wasLocked) ||
+            flock($fh, LOCK_EX)
+        ) {
+            if (
+                !$wasLocked ||
+                ($force || static::needsUpdate($this->asset))
+            ) {
+                $stopwatchPeriod = app(Stopwatch::class)->start(
+                    $this->asset->getLocator()->getString(),
+                    'core.view.asset.publish',
+                );
+
+                try {
+                    $content = $this->getProcessedContent(
+                        $this->getContent()
+                    );
+
+                    $result = $this->asset->write($content, false);
+
+                    if ($result === true) {
+                        $this->asset->getThemelet()->setAssetPublicationData($this->asset, [
+                            'sources' => $this->sources,
+                        ]);
+                    }
+                } finally {
+                    $stopwatchPeriod->stop();
+                }
+            }
+
+            flock($fh, LOCK_UN);
+        }
+
+        fclose($fh);
+
+        return $result;
+    }
+
+    public function addSource(Resource $resource): void
+    {
+        if (!self::resourcePublishable($resource)) {
+            throw new InvalidArgumentException('Cannot use Resource `' . $resource->getLocator()->getString() . '` as a source for Asset');
+        }
+
+        $this->sources[] = self::getSourceSignature($resource);
+    }
+
+    private function getContent(): string
+    {
+        $resource = $this->asset->getResource();
+
+        $this->addSource($resource);
+
+        return $resource->getContent();
+    }
+
+    private function getProcessedContent(string $content): string
+    {
+        foreach ($this->processors as $processor) {
+            $processor = new $processor($this, $this->asset);
+
+            $processor->setInputContent($content);
+
+            $content = $processor->getOutputContent();
+        }
+
+        return $content;
+    }
+}

--- a/inc/src/View/Asset/StaticAsset.php
+++ b/inc/src/View/Asset/StaticAsset.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Asset;
+
+use LogicException;
+use MyBB\View\Locator\StaticLocator;
+use MyBB\View\Themelet\ThemeletInterface;
+
+/**
+ * An Asset not published from Themelet sources.
+ */
+class StaticAsset extends Asset
+{
+    public function __construct(
+        readonly protected StaticLocator $locator,
+        readonly protected ?ThemeletInterface $themelet = null,
+        readonly protected ?string $declarationNamespace = null,
+    ) {}
+
+    public function getAbsolutePath(): string
+    {
+        if (!$this->isInApplicationDirectory()) {
+            throw new LogicException('Cannot call `' . __METHOD__ . '` on Assets outside of the application directory');
+        }
+
+        return MYBB_ROOT . str_replace('./', '', $this->getPublicPath());
+    }
+
+    /**
+     * Return an HTTP-accessible path to the file.
+     */
+    public function getPublicPath(): string
+    {
+        return $this->locator->getPath();
+    }
+
+    public function getUrl(bool $useCdn = true): string
+    {
+        $url = parent::getUrl();
+
+        if (
+            $this->isInApplicationDirectory() &&
+            $time = filemtime($this->getAbsolutePath())
+        ) {
+            $url .= '?t=' . $time;
+        }
+
+        return $url;
+    }
+
+    public function isInApplicationDirectory(): bool
+    {
+        return $this->locator->isCurrentDirectoryRelative();
+    }
+
+    protected function getEntityNamespace(): string
+    {
+        return $this->declarationNamespace;
+    }
+}

--- a/inc/src/View/Asset/ThemeletAsset.php
+++ b/inc/src/View/Asset/ThemeletAsset.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Asset;
+
+use InvalidArgumentException;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Resource;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\Decorator\PublishableThemelet;
+use MyBB\View\Themelet\ThemeletInterface;
+
+/**
+ * An Asset created from a Themelet Resource.
+ *
+ * @property ThemeletLocator $locator
+ */
+class ThemeletAsset extends Asset
+{
+    public const WEB_ROOT_RELATIVE_BASE_PATH = 'cache/themelets/';
+    public const ABSOLUTE_BASE_PATH = MYBB_ROOT . self::WEB_ROOT_RELATIVE_BASE_PATH;
+
+    private Resource $resource;
+
+    public function __construct(
+        readonly protected ThemeletLocator $locator,
+        readonly protected ThemeletInterface $themelet,
+    )
+    {
+        if (!PublishableThemelet::decorates($themelet)) {
+            throw new InvalidArgumentException('PublishableThemelet required for `' . static::class . '`');
+        }
+    }
+
+    /**
+     * Return a server path to the generated static file.
+     */
+    public function getAbsolutePath(): string
+    {
+        return MYBB_ROOT . $this->getPublicPath();
+    }
+
+    /**
+     * Return an HTTP-accessible path to the file.
+     */
+    public function getPublicPath(): string
+    {
+        return $this->themelet->getPublishingPath() . '/' . $this->locator->getNamespace() . '/' . $this->locator->getSubPath();
+    }
+
+    public function getUrl(bool $useCdn = true): string
+    {
+        $url = parent::getUrl();
+
+        if ($time = filemtime($this->getAbsolutePath())) {
+            $url .= '?t=' . $time;
+        }
+
+        return $url;
+    }
+
+    public function getType(): ResourceType
+    {
+        return $this->locator->type;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->locator->namespace;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->locator->group;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->locator->filename;
+    }
+
+    public function getSubPath(): string
+    {
+        return $this->locator->getSubPath();
+    }
+
+    public function getResource(): Resource
+    {
+        if (!isset($this->resource)) {
+            $sourceLocatorString = $this->getProperties()['source'] ?? null;
+
+            if ($sourceLocatorString !== null) {
+                $resourceLocator = $this->locator->getSibling($sourceLocatorString);
+            } else {
+                $resourceLocator = $this->locator;
+            }
+
+            $this->resource = $this->getThemelet()->getResource($resourceLocator);
+        }
+
+        return $this->resource;
+    }
+
+    public function exists(): bool
+    {
+        return file_exists(
+            $this->getAbsolutePath()
+        );
+    }
+
+    public function write(string $content, bool $lock = true): bool
+    {
+        $path = $this->getAbsolutePath();
+
+        if (
+            !str_starts_with($path, realpath(self::ABSOLUTE_BASE_PATH) . '/') ||
+            str_ends_with($path, '.php')
+        ) {
+            throw new \Exception('Illegal write path `' . $path . '`');
+        }
+
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), recursive: true);
+        }
+
+        $result = file_put_contents($path, $content, $lock ? LOCK_EX : 0) !== false;
+
+        return $result;
+    }
+
+    public function delete(): bool
+    {
+        $path = $this->getAbsolutePath();
+
+        if (
+            !str_starts_with($path, realpath(self::ABSOLUTE_BASE_PATH) . '/') ||
+            str_ends_with($path, '.php')
+        ) {
+            throw new \Exception('Illegal write path `' . $path . '`');
+        }
+
+        return unlink($path);
+    }
+
+    protected function getEntityNamespace(): string
+    {
+        return $this->getNamespace();
+    }
+}

--- a/inc/src/View/HierarchicalResource.php
+++ b/inc/src/View/HierarchicalResource.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View;
+
+use LogicException;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Themelet\Decorator\Hierarchy\HierarchicalThemelet;
+use MyBB\View\Themelet\NamespaceCargo\Repository;
+use MyBB\View\Themelet\ThemeletInterface;
+
+/**
+ * Inheritance-aware Resource.
+ *
+ * Reads from resolved Themelets; writes to own Themelet. Properties not inherited.
+ */
+readonly class HierarchicalResource extends Resource
+{
+    public function __construct(ThemeletInterface $themelet, ThemeletLocator $locator)
+    {
+        parent::__construct($themelet, $locator);
+
+        if (!HierarchicalThemelet::decorates($themelet)) {
+            throw new \Exception('`' . __CLASS__ . '` must be associated with a Hierarchical Themelet');
+        }
+    }
+
+    public function exists(): bool
+    {
+        return $this->getResolved()?->exists() === true;
+    }
+
+    public function setContent(string $content, bool $lock = true, bool $normalize = false): bool
+    {
+        $ownRepository = $this->getRepository()->getOwnRepository();
+
+        if ($ownRepository->has($this->getLocator())) {
+            $ownResource = $ownRepository->getExisting($this->getLocator());
+        } else {
+            $ownResource = $ownRepository->create($this->getLocator());
+        }
+
+        $result = $ownResource->write($content, $lock);
+
+        if ($normalize && $this->contentMatchesInherited()) {
+            $ownResource->delete();
+        }
+
+        $this->resolve();
+
+        return $result;
+    }
+
+    public function delete(): void
+    {
+        $ownRepository = $this->getRepository()->getOwnRepository();
+
+        $resource = $ownRepository->getExisting($this->getLocator());
+
+        $resource->delete();
+
+        if ($this->getInherited()) {
+            $resource->setProperties([
+                Repository::ANCESTOR_DECLARATIONS_KEY => false,
+            ]);
+        }
+
+        $this->resolve();
+    }
+
+    /**
+     * Makes a Themelet's Resource inherit its content.
+     */
+    public function revert(): void
+    {
+        $ownRepository = $this->getRepository()->getOwnRepository();
+
+        $resource = $ownRepository->get($this->getLocator());
+
+        if (!$resource->declaredInherited()) {
+            $resource->setProperties([
+                Repository::ANCESTOR_DECLARATIONS_KEY => true,
+            ]);
+        }
+
+        if ($this->getInherited()) {
+            $resource->delete();
+        }
+
+        $this->resolve();
+    }
+
+    public function getAbsolutePath(): string
+    {
+        return $this->getResolved()->getAbsolutePath();
+    }
+
+    public function getResolved(): ?Resource
+    {
+        return $this->getRepository()->getResolved($this->getLocator());
+    }
+
+    public function declaredInherited(): bool
+    {
+        throw new LogicException('`' . __FUNCTION__ . '()` cannot be called on `' . __CLASS__ . '`');
+    }
+
+    public function deleteFirstPartyProperties(): void
+    {
+        throw new LogicException('`' . __FUNCTION__ . '()` cannot be called on `' . __CLASS__ . '`');
+    }
+
+    public function getProperties(): array
+    {
+        throw new LogicException('`' . __FUNCTION__ . '()` cannot be called on `' . __CLASS__ . '`');
+    }
+
+    public function setProperties(array $properties): void
+    {
+        throw new LogicException('`' . __FUNCTION__ . '()` cannot be called on `' . __CLASS__ . '`');
+    }
+
+    public function contentMatchesInherited(): bool
+    {
+        $closestInheritedResource = $this->getInherited();
+
+        if (!$closestInheritedResource) {
+            return false;
+        }
+
+        return $this->getContent() === $closestInheritedResource->getContent();
+    }
+
+    /**
+     * Returns the closest ancestor from which the Resource may be inherited.
+     */
+    public function getInherited(): ?Resource
+    {
+        $repository = $this->getRepository()->getClosestEntityAncestorRepository($this->locator);
+
+        return $repository?->get($this->locator);
+    }
+
+    public function resolve(): void
+    {
+        $this->getRepository()->resolveRepository(
+            $this->getLocator()
+        );
+    }
+}

--- a/inc/src/View/Locator/Locator.php
+++ b/inc/src/View/Locator/Locator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Locator;
+
+use MyBB\View\ResourceType;
+
+/**
+ * A reference to an Asset or Resource.
+ */
+abstract class Locator
+{
+    /**
+     * @param array{
+     *   type?: ThemeletLocator::COMPONENT_*,
+     *   namespace?: ThemeletLocator::COMPONENT_*,
+     * } $directives
+     * @param array{
+     *   type?: ResourceType,
+     *   namespace?: string,
+     * } $context
+     */
+    public static function fromString(string $string, array $directives = [], array $context = []): static
+    {
+        $class = StaticLocator::isStaticLocator($string) ? StaticLocator::class : ThemeletLocator::class;
+
+        return $class::fromString($string, $directives, $context);
+    }
+
+    abstract public static function composeString(array $components): string;
+
+    abstract public static function decomposeString(string $string): array;
+
+    public static function fromNamespaceRelativeIdentifier(string $namespace, string $identifier): static
+    {
+        return self::fromString(
+            $identifier,
+            [
+                'type' => ThemeletLocator::COMPONENT_SET,
+                'namespace' => ThemeletLocator::COMPONENT_UNSET,
+            ],
+            [
+                'namespace' => $namespace,
+            ],
+        );
+    }
+
+    public static function fromDependencyIdentifier(string $identifier, self $locator): static
+    {
+        if (StaticLocator::isStaticLocator($identifier)) {
+            return StaticLocator::fromString($identifier);
+        } else {
+            return ThemeletLocator::fromString(
+                $identifier,
+                [
+                    'type' => ThemeletLocator::COMPONENT_CONTEXT,
+                    'namespace' => ThemeletLocator::COMPONENT_CONTEXT,
+                ],
+                [
+                    'type' => ResourceType::fromFilename($identifier),
+                    'namespace' => $locator->getNamespace(),
+                ],
+            );
+        }
+    }
+
+    abstract public function getString(array $directives = [], array $context = []): string;
+
+    abstract public function getNamespaceRelativeIdentifier(): string;
+}

--- a/inc/src/View/Locator/StaticLocator.php
+++ b/inc/src/View/Locator/StaticLocator.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Locator;
+
+/**
+ * A reference to an Asset with a static path (outside any Themelet structure).
+ */
+class StaticLocator extends Locator
+{
+    private const URI_SCHEME_SUFFIX = ':';
+    private const URI_AUTHORITY_PREFIX = '//';
+
+    private const PATH_ABSOLUTE_PREFIX = '/';
+    private const PATH_RELATIVE_CURRENT_DIRECTORY_PREFIX = './';
+    private const PATH_RELATIVE_PARENT_DIRECTORY_PREFIX = '../';
+
+    public readonly ?string $path;
+
+    public function __construct(array $components = [])
+    {
+        foreach ($components as $component => $value) {
+            $this->$component = $value;
+        }
+    }
+
+    public static function fromString(string $string, array $directives = [], array $context = []): static
+    {
+        $components = static::decomposeString($string);
+
+        $locator = new static();
+
+        foreach ($components as $component => $value) {
+            $locator->$component = $value;
+        }
+
+        return $locator;
+    }
+
+    /**
+     * @param array{
+     *   path?: ?string,
+     * } $components
+     */
+    public static function composeString(array $components): string
+    {
+        if ($components['path'] !== null) {
+            $string = '';
+
+            if (self::isImplicitCurrentDirectoryRelativePath($components['path'])) {
+                $string .= self::PATH_RELATIVE_CURRENT_DIRECTORY_PREFIX;
+            }
+
+            $string .= $components['path'];
+
+            return $string;
+        } else {
+            throw new \Exception('Missing path for Locator');
+        }
+    }
+
+    /**
+     * @return array{
+     *   path: ?string,
+     * }
+     */
+    public static function decomposeString(string $string): array
+    {
+        return [
+            'path' => $string,
+        ];
+    }
+
+    public static function isStaticLocator(string $locator): bool
+    {
+        return self::isExplicitDirectoryPath($locator) || self::isRemoteLocator($locator);
+    }
+
+    private static function isRemoteLocator(string $locator): bool
+    {
+        return (
+            str_starts_with($locator, self::URI_AUTHORITY_PREFIX) || // network-path / scheme-relative URI
+            str_contains($locator, self::URI_SCHEME_SUFFIX . self::URI_AUTHORITY_PREFIX) // absolute URI
+        );
+    }
+
+    private static function isExplicitDirectoryPath(string $locator): bool
+    {
+        return (
+            str_starts_with($locator, self::PATH_ABSOLUTE_PREFIX) ||
+            str_starts_with($locator, self::PATH_RELATIVE_CURRENT_DIRECTORY_PREFIX) ||
+            str_starts_with($locator, self::PATH_RELATIVE_PARENT_DIRECTORY_PREFIX)
+        );
+    }
+
+    private static function isCurrentDirectoryRelativePath(string $locator): bool
+    {
+        return (
+            str_starts_with($locator, self::PATH_RELATIVE_CURRENT_DIRECTORY_PREFIX) ||
+            self::isImplicitCurrentDirectoryRelativePath($locator)
+        );
+    }
+
+    private static function isImplicitCurrentDirectoryRelativePath(string $locator): bool
+    {
+        return (
+            !self::isRemoteLocator($locator) &&
+            !self::isExplicitDirectoryPath($locator)
+        );
+    }
+
+    public function getString(array $directives = [], array $context = []): string
+    {
+        $information = [];
+
+        if ($this->path !== null) {
+            $information['path'] = $this->path;
+        } else {
+            throw new \Exception('Missing path for Locator');
+        }
+
+        return self::composeString($information);
+    }
+
+    public function getNamespaceRelativeIdentifier(): string
+    {
+        // no transformations needed for Static Locators
+        return $this->getPath();
+    }
+
+    public function isCurrentDirectoryRelative(): bool
+    {
+        return self::isCurrentDirectoryRelativePath(
+            $this->getPath()
+        );
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
+    }
+
+    public function isRemote(): bool
+    {
+        return self::isRemoteLocator(
+            $this->getPath()
+        );
+    }
+}

--- a/inc/src/View/Locator/ThemeletLocator.php
+++ b/inc/src/View/Locator/ThemeletLocator.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Locator;
+
+use MyBB\View\ResourceType;
+
+/**
+ * A reference to a file in a Themelet structure.
+ */
+class ThemeletLocator extends Locator
+{
+    final public const COMPONENT_SET = 2;
+    final public const COMPONENT_OPTIONAL = 4;
+    final public const COMPONENT_CONTEXT = 8;
+    final public const COMPONENT_UNSET = 16;
+
+    private const NAMESPACE_PREFIX = '@';
+    private const DIRECTORY_SEPARATOR = '/';
+
+    public readonly ?ResourceType $type;
+    public readonly ?string $namespace;
+    public readonly ?string $group;
+    public readonly ?string $filename;
+
+    public function __construct(array $components = [])
+    {
+        foreach ($components as $component => $value) {
+            $this->$component = $value;
+        }
+    }
+
+    /**
+     * @param array{
+     *   type?: self::COMPONENT_*,
+     *   namespace?: self::COMPONENT_*,
+     * } $directives
+     * @param array{
+     *   type?: ResourceType,
+     *   namespace?: string,
+     * } $context
+     */
+    public static function fromString(string $string, array $directives = [], array $context = []): static
+    {
+        $components = static::decomposeString($string);
+
+        static::validate($components, $context, $directives);
+
+        $locator = new static();
+
+        foreach ($components as $component => $value) {
+            if ($value === null && isset($context[$component])) {
+                $value = $context[$component];
+            }
+
+            $locator->$component = $value;
+        }
+
+        return $locator;
+    }
+
+    public static function fromResourceContextString(string $string, ResourceType $type, ?string $contextNamespace): static
+    {
+        return static::fromString(
+            $string,
+            [
+                'type' => ThemeletLocator::COMPONENT_UNSET,
+                'namespace' => $contextNamespace === null
+                    ? ThemeletLocator::COMPONENT_SET
+                    : ThemeletLocator::COMPONENT_CONTEXT
+                ,
+            ],
+            [
+                'type' => $type,
+                'namespace' => $contextNamespace,
+            ],
+        );
+    }
+
+    /**
+     * @param array{
+     *   type?: ?ResourceType,
+     *   namespace?: ?string,
+     *   group?: ?string,
+     *   filename?: ?string,
+     * } $components
+     */
+    public static function composeString(array $components): string
+    {
+        $string = '';
+
+        if (isset($components['namespace'])) {
+            $string .= self::NAMESPACE_PREFIX . $components['namespace'] . self::DIRECTORY_SEPARATOR;
+        }
+
+        if (isset($components['type'])) {
+            $string .= $components['type']->getPlural() . self::DIRECTORY_SEPARATOR;
+        }
+
+        if (isset($components['group'])) {
+            $string .= $components['group'] . self::DIRECTORY_SEPARATOR;
+        }
+
+        if (isset($components['filename'])) {
+            $string .= $components['filename'];
+        }
+
+        return $string;
+    }
+
+    /**
+     * @return array{
+     *   type: ?ResourceType,
+     *   namespace: ?string,
+     *   group: ?string,
+     *   filename: ?string,
+     * }
+     */
+    public static function decomposeString(string $string): array
+    {
+        $components = [
+            'type' => null,
+            'namespace' => null,
+            'group' => null,
+            'filename' => null,
+        ];
+
+        $offset = 0;
+
+        // namespace
+        $firstNamespacePrefixPosition = strpos($string, self::NAMESPACE_PREFIX, $offset);
+        $firstDirectorySeparatorPosition = strpos($string, self::DIRECTORY_SEPARATOR, $offset);
+
+        if (
+            $firstNamespacePrefixPosition !== false &&
+            $firstDirectorySeparatorPosition !== false &&
+
+            $firstNamespacePrefixPosition < $firstDirectorySeparatorPosition
+        ) {
+            $offset += strlen(self::NAMESPACE_PREFIX);
+
+            $components['namespace'] = substr($string, $offset, $firstDirectorySeparatorPosition - $offset);
+
+            $offset = $firstDirectorySeparatorPosition + 1;
+        }
+
+        // type
+        $typeSeparatorPosition = strpos($string, self::DIRECTORY_SEPARATOR, $offset);
+
+        if ($typeSeparatorPosition !== false) {
+            $type = ResourceType::tryFromPlural(
+                substr($string, $offset, $typeSeparatorPosition - $offset)
+            );
+
+            if ($type !== null) {
+                $components['type'] = $type;
+
+                $offset = $typeSeparatorPosition + 1;
+            }
+        }
+
+        // subPath
+        $subPath  = substr($string, $offset);
+
+        $lastDirectorySeparatorPosition = strrpos($subPath, self::DIRECTORY_SEPARATOR);
+
+        if ($lastDirectorySeparatorPosition !== false) {
+            $components['group'] = substr($subPath, 0, $lastDirectorySeparatorPosition);
+            $components['filename'] = substr($subPath, $lastDirectorySeparatorPosition + 1);
+        } else {
+            $components['group'] = null;
+            $components['filename'] = $subPath;
+        }
+
+        return $components;
+    }
+
+    /**
+     * @param array{
+     *   type: ?ResourceType,
+     *   namespace: ?string,
+     *   group: ?string,
+     *   filename: ?string,
+     * } $components
+     * @param array{
+     *   namespace: ?string,
+     *   type: ?ResourceType,
+     * } $context
+     * @param array{
+     *   type?: self::COMPONENT_*,
+     *   namespace?: self::COMPONENT_*,
+     * } $directives
+     */
+    private static function validate(array $components, array $context, array $directives): void
+    {
+        $directives['type'] ??= self::COMPONENT_SET;
+        $directives['namespace'] ??= self::COMPONENT_SET;
+
+        foreach (['type', 'namespace'] as $component) {
+            if ($components[$component] === null) {
+                if (
+                    $directives[$component] === self::COMPONENT_SET ||
+                    ($directives[$component] === self::COMPONENT_CONTEXT && !isset($context[$component]))
+                ) {
+                    throw new \Exception('Missing ' . $component . ' in Locator');
+                }
+            } elseif ($directives[$component] === self::COMPONENT_UNSET) {
+                throw new \Exception($component . ' not allowed in Locator');
+            }
+        }
+    }
+
+    /**
+     * @param array{
+     *   type?: self::COMPONENT_SET | self::COMPONENT_CONTEXT | self::COMPONENT_UNSET,
+     *   namespace?: self::COMPONENT_SET | self::COMPONENT_CONTEXT | self::COMPONENT_UNSET,
+     * } $directives
+     * @param array{
+     *   namespace: ?string,
+     *   type: ?ResourceType,
+     * } $context
+     */
+    public function getString(array $directives = [], array $context = []): string
+    {
+        $directives['type'] ??= self::COMPONENT_SET;
+        $directives['namespace'] ??= self::COMPONENT_SET;
+
+        $context['namespace'] ??= null;
+        $context['type'] ??= null;
+
+        $components = [];
+
+        foreach (['type', 'namespace'] as $component) {
+            if ($directives[$component] !== self::COMPONENT_UNSET) {
+                if ($directives[$component] === self::COMPONENT_CONTEXT && $context[$component] !== null) {
+                    if ($this->$component !== null && $this->$component !== $context[$component]) {
+                        $components[$component] = $this->$component;
+                    }
+                } elseif ($this->$component !== null) {
+                    $components[$component] = $this->$component;
+                } elseif ($context[$component] !== null) {
+                    $components[$component] = $context[$component];
+                } else {
+                    throw new \Exception('Missing ' . $component . ' for Locator');
+                }
+            }
+        }
+
+        $components['group'] = $this->group;
+
+        if ($this->filename !== null) {
+            $components['filename'] = $this->filename;
+        } else {
+            throw new \Exception('Missing filename for Locator');
+        }
+
+        return self::composeString($components);
+    }
+
+    public function getNamespaceRelativeIdentifier(): string
+    {
+        return $this->getString([
+            'namespace' => self::COMPONENT_UNSET,
+        ]);
+    }
+
+    public function getType(): ?ResourceType
+    {
+        return $this->type;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function getSubPath(): string
+    {
+        $subPath = '';
+
+        if ($this->group !== null) {
+            $subPath .= $this->group . '/';
+        }
+
+        $subPath .= $this->filename;
+
+        return $subPath;
+    }
+
+    /**
+     * Returns a Locator used for Resources and Assets with shared context.
+     */
+    public function getSibling(string $subPath): static
+    {
+        return static::fromString(
+            $subPath,
+            [
+                'type' => ThemeletLocator::COMPONENT_UNSET,
+                'namespace' => ThemeletLocator::COMPONENT_UNSET,
+            ],
+            [
+                'type' => $this->getType(),
+                'namespace' => $this->getNamespace(),
+            ],
+        );
+    }
+}

--- a/inc/src/View/NamespaceType.php
+++ b/inc/src/View/NamespaceType.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View;
+
+use InvalidArgumentException;
+use MyBB\Extensions\Extension;
+use MyBB\Extensions\ViewExtensionInterface;
+
+enum NamespaceType
+{
+    case GENERIC;
+    case EXTENSION;
+    case EXTENSION_OWN;
+
+    /**
+     * @return null | ($contextExtension is null ? (self::GENERIC | self::EXTENSION) : self)
+     */
+    public static function tryFromNamespace(string $namespace, ?ViewExtensionInterface $contextExtension = null): ?self
+    {
+        // try self::EXTENSION_OWN before self::EXTENSION
+        foreach ([self::GENERIC, self::EXTENSION_OWN, self::EXTENSION] as $type) {
+            if ($type->namespaceValid($namespace, $contextExtension)) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+
+    public function namespaceValid(string $namespace, ?ViewExtensionInterface $contextExtension = null): bool
+    {
+        return (
+            str_starts_with($namespace, $this->getPrefix()) &&
+            $this->namespaceIdentifierValid(
+                $this->getNamespaceIdentifier($namespace),
+                $contextExtension,
+            )
+        );
+    }
+
+    public function getNamespaceIdentifier(string $namespace): string
+    {
+        $prefix = $this->getPrefix();
+
+        if (!str_starts_with($namespace, $prefix)) {
+            throw new InvalidArgumentException();
+        }
+
+        return substr($namespace, strlen($prefix));
+    }
+
+    public function getPrefix(): string
+    {
+        return match ($this) {
+            self::GENERIC => '',
+            self::EXTENSION, self::EXTENSION_OWN => 'ext.',
+        };
+    }
+
+    public function getNamespaceFromIdentifier(string $identifier): string
+    {
+        return $this->getPrefix() . $identifier;
+    }
+
+    private function namespaceIdentifierValid(string $identifier, ?ViewExtensionInterface $contextExtension): bool
+    {
+        return match ($this) {
+            self::GENERIC =>
+                ctype_alpha(str_replace('_', '', $identifier)),
+            self::EXTENSION =>
+                Extension::codenameValid($identifier),
+            self::EXTENSION_OWN =>
+                Extension::codenameValid($identifier) &&
+                (
+                    $contextExtension === null ||
+                    $contextExtension->getPackageName() === $identifier
+                )
+            ,
+        };
+    }
+}

--- a/inc/src/View/Optimization.php
+++ b/inc/src/View/Optimization.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View;
+
+use MyBB\Utilities\FileStamp;
+use MyBB\View\Themelet\Decorator\PublishableThemelet;
+
+enum Optimization: int
+{
+    /**
+     * No custom cache is used.
+     */
+    case NONE = 1;
+
+    /**
+     * Cache is verified to account for changes during Extension development.
+     */
+    case WATCH = 2;
+
+    /**
+     * Lightweight cache validation to respond to high-level changes.
+     */
+    case BALANCED = 3;
+
+    /**
+     * Cache is not verified to maximize optimization.
+     */
+    case PERFORMANCE = 4;
+
+    /**
+     * Returns configuration values according to chosen mode.
+     */
+    public function getDirective(string $name): mixed
+    {
+        $level = $this->value;
+
+        return match ($name) {
+            'twig.autoReload' => $level <= self::WATCH->value,
+            'hierarchy.cache' => $level > self::NONE->value,
+            'hierarchy.cacheValidation' => $level < self::PERFORMANCE->value,
+            'hierarchy.cacheValidationType' => FileStamp::TYPE_MODIFICATION_TIME,
+            'publication.publishMode' => match (true) {
+                $level <= self::NONE->value => PublishableThemelet::PUBLISH_ALWAYS,
+                $level >= self::PERFORMANCE->value => PublishableThemelet::PUBLISH_NEVER,
+                default => PublishableThemelet::PUBLISH_AUTO,
+            },
+        };
+    }
+}

--- a/inc/src/View/Resource.php
+++ b/inc/src/View/Resource.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View;
+
+use Exception;
+use MyBB\Cargo\EntityInterface as CargoEntityInterface;
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\View\Themelet\NamespaceCargo\EntityTrait;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Themelet\ThemeletInterface;
+
+readonly class Resource implements CargoEntityInterface
+{
+    use EntityTrait;
+
+    protected ThemeletInterface $themelet;
+
+    protected ThemeletLocator $locator;
+
+    public function __construct(ThemeletInterface $themelet, ThemeletLocator $locator)
+    {
+        $this->themelet = $themelet;
+        $this->locator = $locator;
+    }
+
+    public function exists(): bool
+    {
+        return file_exists(
+            $this->getAbsolutePath()
+        );
+    }
+
+    public function getModificationTime(): ?int
+    {
+        return filemtime(
+            $this->getAbsolutePath()
+        );
+    }
+
+    public function getContent(): string
+    {
+        $path = $this->getAbsolutePath();
+
+        return file_get_contents($path);
+    }
+
+    public function setContent(string $content, bool $lock = true): bool
+    {
+        $path = realpath($this->getAbsolutePath());
+
+        if (
+            !str_starts_with(
+                $path,
+                realpath($this->getThemelet()->getExtension()::EXTENSION_TYPE_ABSOLUTE_BASE_PATH) . '/'
+            ) ||
+            str_ends_with($path, '.php')
+        ) {
+            throw new Exception('Illegal write path `' . $path . '`');
+        }
+
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), recursive: true);
+        }
+
+        return file_put_contents($path, $content, $lock ? LOCK_EX : 0) !== false;
+    }
+
+    public function delete(): void
+    {
+        $path = realpath($this->getAbsolutePath());
+
+        if (
+            !str_starts_with(
+                $path,
+                realpath($this->getThemelet()->getExtension()::EXTENSION_TYPE_ABSOLUTE_BASE_PATH) . '/'
+            ) ||
+            str_ends_with($path, '.php')
+        ) {
+            throw new Exception('Illegal write path `' . $path . '`');
+        }
+
+        if (!unlink($path)) {
+            throw new Exception('Could not delete file `' . $path . '`');
+        }
+
+        $this->deleteFirstPartyProperties();
+    }
+
+    public function getAbsolutePath(): string
+    {
+        return
+            $this->getThemelet()->getResourceTypeAbsolutePath($this->getNamespace(), $this->getType()) .
+            '/' .
+            $this->getSubPath()
+        ;
+    }
+
+    public function getIdentifierPath(): string
+    {
+        return
+            $this->getNamespace() .
+            '/' .
+            $this->getType()->getDirectoryName() .
+            '/' .
+            $this->getSubPath()
+        ;
+    }
+
+    public function getThemelet(): ThemeletInterface
+    {
+        return $this->themelet;
+    }
+
+    public function getLocator(): ThemeletLocator
+    {
+        return $this->locator;
+    }
+
+    public function getType(): ResourceType
+    {
+        return $this->locator->type;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->locator->namespace;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->locator->group;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->locator->filename;
+    }
+
+    public function getSubPath(): string
+    {
+        return $this->locator->getSubPath();
+    }
+
+    public function getRepository(): RepositoryInterface
+    {
+        return $this->getThemelet()->getResourceRepository(
+            $this->getNamespace()
+        );
+    }
+}

--- a/inc/src/View/ResourceType.php
+++ b/inc/src/View/ResourceType.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View;
+
+enum ResourceType: string
+{
+    case IMAGE = 'image';
+    case SCRIPT = 'script';
+    case STYLE = 'style';
+    case TEMPLATE = 'template';
+
+    public static function fromFilename(string $filename): ?self
+    {
+        $extension = pathinfo($filename, PATHINFO_EXTENSION);
+
+        return self::tryFromFilenameExtension($extension);
+    }
+
+    public static function tryFromFilenameExtension(string $extension): ?self
+    {
+        return match ($extension) {
+            'js' => self::SCRIPT,
+            'css', 'scss' => self::STYLE,
+            'twig' => self::TEMPLATE,
+            default => null,
+        };
+    }
+
+    public static function tryFromPlural(string $value): ?self
+    {
+        return self::tryFrom(
+            rtrim($value, 's')
+        );
+    }
+
+    public function getPlural(): string
+    {
+        return $this->value . 's';
+    }
+
+    public function getDirectoryName(): string
+    {
+        return $this->getPlural();
+    }
+}

--- a/inc/src/View/Runtime/AssetManagementTrait.php
+++ b/inc/src/View/Runtime/AssetManagementTrait.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Runtime;
+
+use MyBB\View\Asset\Asset;
+use MyBB\View\Locator\StaticLocator;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\ResourceType;
+
+trait AssetManagementTrait
+{
+    /**
+     * @var ResourceType[]
+     */
+    public const ATTACHABLE_TYPES = [
+        ResourceType::STYLE,
+        ResourceType::SCRIPT,
+    ];
+
+    /**
+     * @var array{
+     *   script: string,
+     *   action: string,
+     * }
+     */
+    private array $context;
+
+    /**
+     * Assets by type and Locator string.
+     *
+     * @var array<value-of<ResourceType>, array<string, Asset>
+     */
+    private array $attachedAssets;
+
+    /**
+     * @param array{
+     *   script: string,
+     *   actions?: string[],
+     * } $conditions
+     * @param array{
+     *   script: string,
+     *   action: string,
+     * } $context
+     * @return bool
+     */
+    public static function attachConditionsSatisfied(array $conditions, array $context): bool
+    {
+        foreach ($conditions as $condition) {
+            if (
+                isset($condition['script']) &&
+                (
+                    $condition['script'] === 'global' ||
+                    $condition['script'] === $context['script']
+                ) &&
+                (
+                    !isset($condition['actions']) ||
+                    in_array('global', $condition['actions']) ||
+                    in_array($context['action'], $condition['actions'])
+                )
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function setContext(array $context): void
+    {
+        $this->context = $context;
+    }
+
+    public function getAttachedAssets(ResourceType $type): array
+    {
+        if (!isset($this->attachedAssets)) {
+            $this->populateAttachedAssetsFromThemelet();
+        }
+
+        return $this->attachedAssets[$type->value] ?? [];
+    }
+
+    public function populateAttachedAssetsFromThemelet(): void
+    {
+        foreach ($this->themelet->getCompositeAssetProperties() as $locatorString => $properties) {
+            if ($this->assetApplicableThroughProperties($properties)) {
+                $this->attachAsset(Locator::fromString($locatorString));
+            }
+        }
+    }
+
+    /**
+     * @param string[] $dependentAncestors
+     */
+    public function attachAsset(Locator $locator, array $properties = [], array $dependentAncestors = []): void
+    {
+        $locatorString = $locator->getString([
+            'type' => ThemeletLocator::COMPONENT_SET,
+            'namespace' => ThemeletLocator::COMPONENT_SET,
+        ]);
+
+        $type = match (get_class($locator)) {
+            StaticLocator::class => ResourceType::fromFilename($locator->getPath()),
+            ThemeletLocator::class => $locator->getType(),
+        };
+
+
+        if ($type === null) {
+            throw new \Exception('Unknown Asset type (`' . $locatorString . '`)');
+        }
+
+        if (!in_array($type, static::ATTACHABLE_TYPES)) {
+            throw new \Exception('Cannot attach Asset of type `' . $type->value . '` (`' . $locatorString . '`)');
+        }
+
+        if (in_array($locatorString, $dependentAncestors)) {
+            throw new \Exception('Circular dependency declared for Asset `' . $locatorString . '`');
+        }
+
+
+        if (isset($this->attachedAssets[$type->value][$locatorString])) {
+            $asset = $this->attachedAssets[$type->value][$locatorString];
+        } else {
+            $dependentAncestors[] = $locatorString;
+
+            $dependencies = $this->getAssetImmediateDependencies($locator);
+
+            foreach ($dependencies as $dependency) {
+                $this->attachAsset($dependency, dependentAncestors: $dependentAncestors);
+            }
+
+
+            $asset = $this->themelet->getPublishedAsset($locator);
+
+            $asset->setCompositeProperties(
+                $this->themelet->getCompositeAssetProperties($locator)['attributes'] ?? [],
+            );
+
+            $this->attachedAssets[$type->value][$locatorString] = $asset;
+        }
+
+        $asset->setCompositeProperties($properties);
+    }
+
+    public function assetApplicableThroughProperties(array $properties = null): bool
+    {
+        return (
+            isset($properties['attached_to']) &&
+            static::attachConditionsSatisfied($properties['attached_to'], $this->context)
+        );
+    }
+
+    /**
+     * Returns an Asset's dependencies that should be attached before it.
+     *
+     * @return Locator[]
+     */
+    private function getAssetImmediateDependencies(Locator $locator): array
+    {
+        return array_map(
+            fn (string $identifier) =>
+                Locator::fromDependencyIdentifier($identifier, $locator),
+            $this->themelet->getCompositeAssetProperties($locator)['depends_on'] ?? [],
+        );
+    }
+}

--- a/inc/src/View/Runtime/DataSharingTrait.php
+++ b/inc/src/View/Runtime/DataSharingTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Runtime;
+
+use Twig\Environment;
+
+trait DataSharingTrait
+{
+    /**
+     * @var array<string, scalar>
+     */
+    private array $sharedData = [];
+
+    private Environment $twig;
+
+    /**
+     * @param array<string, scalar> $data
+     */
+    public function setSharedData(array $data): void
+    {
+        foreach ($data as $key => $value) {
+            $this->sharedData[$key] = $value;
+
+            $this->twig->addGlobal($key, $value);
+        }
+    }
+
+    public function getSharedData(string $key): null|int|float|string|bool
+    {
+        return $this->sharedData[$key] ?? null;
+    }
+
+    public function setTwig(Environment $twig): void
+    {
+        $this->twig = $twig;
+    }
+}

--- a/inc/src/View/Runtime/NamespacesTrait.php
+++ b/inc/src/View/Runtime/NamespacesTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Runtime;
+
+/**
+ * Provides Asset data merged from selected namespaces.
+ */
+trait NamespacesTrait
+{
+    private ?string $mainNamespace = null;
+
+    public function setMainNamespace(string $name): void
+    {
+        $this->mainNamespace = $name;
+
+        $this->themelet->applyNamespace($name);
+    }
+
+    public function getMainNamespace(): ?string
+    {
+        return $this->mainNamespace;
+    }
+
+    public function applyNamespace(string $name): void
+    {
+        $this->themelet->applyNamespace($name);
+    }
+}

--- a/inc/src/View/Runtime/Runtime.php
+++ b/inc/src/View/Runtime/Runtime.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Runtime;
+
+use MyBB;
+use MyBB\Extensions\Plugin;
+use MyBB\Extensions\Theme;
+use MyBB\View\Themelet\Decorator\CompositeThemelet;
+use MyBB\View\Themelet\Decorator\Hierarchy\HierarchicalThemelet;
+use MyBB\View\Themelet\Decorator\PublishableThemelet;
+use MyBB\View\Themelet\Decorator\ThemeletDecorator;
+use MyBB\View\Themelet\ThemeletInterface;
+
+/**
+ * Environment information and operations related to interface handling.
+ */
+class Runtime
+{
+    use AssetManagementTrait;
+    use DataSharingTrait;
+    use NamespacesTrait;
+
+    public Theme $theme;
+
+    public ThemeletInterface $themelet;
+
+    public function __construct(MyBB $mybb, Theme $theme)
+    {
+        $this->theme = $theme;
+
+        $this->themelet = ThemeletDecorator::decorate(
+            $this->theme->getThemelet(),
+            [
+                HierarchicalThemelet::class,
+                PublishableThemelet::class,
+                CompositeThemelet::class,
+            ],
+        );
+
+        $this->themelet->setBaseThemelets(
+            $this->getPluginThemelets($mybb)
+        );
+    }
+
+    /**
+     * @return ThemeletInterface[]
+     */
+    private function getPluginThemelets(MyBB $mybb): array
+    {
+        return array_map(
+            fn (string $codename) => Plugin::get($codename)->getThemelet(),
+            $mybb->cache->read('plugins')['active'] ?? [],
+        );
+    }
+}

--- a/inc/src/View/ServiceProvider.php
+++ b/inc/src/View/ServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View;
+
+use Illuminate\Contracts\Support\DeferrableProvider;
+use MyBB\Extensions\Theme;
+use MyBB\View\Runtime\Runtime;
+
+class ServiceProvider extends \Illuminate\Support\ServiceProvider implements DeferrableProvider
+{
+    public function register()
+    {
+        $this->app->singleton(Theme::class, function () {
+            return Theme::get(DEFAULT_THEME_PACKAGE);
+        });
+
+        $this->app->singleton(Runtime::class);
+
+        $this->app->instance(Optimization::class, Optimization::WATCH);
+
+        $this->app->afterResolving(
+            'twig',
+            fn ($twig) => $this->app->get(Runtime::class)->setTwig($twig),
+        );
+    }
+
+    public function provides()
+    {
+        return [
+            Optimization::class,
+            Runtime::class,
+            Theme::class,
+        ];
+    }
+}

--- a/inc/src/View/Themelet/AssetsTrait.php
+++ b/inc/src/View/Themelet/AssetsTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet;
+
+use MyBB\View\Asset\Asset;
+use MyBB\View\Locator\Locator;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\NamespaceCargo\Asset\Repository as AssetRepository;
+use MyBB\View\Themelet\NamespaceCargo\Repository as NamespaceCargoRepository;
+
+trait AssetsTrait
+{
+    /**
+     * Asset Repositories by namespace.
+     *
+     * @var array<string, NamespaceCargoRepository>
+     */
+    private array $assetRepositories = [];
+
+    public function getAssetRepository(string $namespace): NamespaceCargoRepository
+    {
+        return $this->assetRepositories[$namespace] ??=
+            new AssetRepository($this, $namespace);
+    }
+
+    public function getAsset(Locator $locator, ?string $declarationNamespace = null): Asset
+    {
+        return Asset::fromLocator($locator, $this, $declarationNamespace);
+    }
+
+    public function getAssetPropertiesOfType(string $namespace, ResourceType $type): array
+    {
+        return array_filter(
+            $this->getAssetProperties($namespace),
+            fn ($identifier) => ResourceType::fromFilename($identifier) === $type,
+            ARRAY_FILTER_USE_KEY,
+        );
+    }
+
+    public function getAssetProperties(string $namespace): array
+    {
+        $repository = $this->getAssetRepository($namespace);
+
+        return $repository->getEntityProperties();
+    }
+}

--- a/inc/src/View/Themelet/Decorator/CompositeThemelet.php
+++ b/inc/src/View/Themelet/Decorator/CompositeThemelet.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\Decorator;
+
+use MyBB\View\Asset\Asset;
+use MyBB\View\Locator\StaticLocator;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\ThemeletLocator;
+
+/**
+ * Merges common data from active namespaces.
+ */
+class CompositeThemelet extends ThemeletDecorator
+{
+    /**
+     * Namespaces from which Resources are used.
+     *
+     * @var string[]
+     */
+    private array $appliedNamespaces = [];
+
+    /**
+     * Properties indexed by locator string.
+     *
+     * @var ?array<string, array>
+     */
+    private ?array $combinedAssetProperties;
+
+    public function applyNamespace(string $name): void
+    {
+        if (!in_array($name, $this->appliedNamespaces)) {
+            $this->appliedNamespaces[$name] = $name;
+
+            $this->combinedAssetProperties = null; // rebuild needed
+        }
+    }
+
+    public function getAppliedNamespaces(): array
+    {
+        return $this->appliedNamespaces;
+    }
+
+    /**
+     * Returns Asset properties defined in all applied namespaces.
+     */
+    public function getCompositeAssetProperties(Locator $selector = null): array
+    {
+        if ($selector === null) {
+            if (!isset($this->combinedAssetProperties)) {
+                $this->populateAssetProperties();
+            }
+
+            return $this->combinedAssetProperties;
+        } else {
+            if (!isset($this->combinedAssetProperties[$selector->getString()])) {
+                $this->populateAssetProperties($selector);
+            }
+
+            return $this->combinedAssetProperties[$selector->getString()];
+        }
+    }
+
+    private function populateAssetProperties(?Locator $locator = null): void
+    {
+        $sets = [];
+
+        if ($locator === null) {
+            foreach ($this->getAppliedNamespaces() as $namespace) {
+                foreach ($this->getAssetProperties($namespace) as $identifier => $properties) {
+                    $locator = Locator::fromNamespaceRelativeIdentifier($namespace, $identifier);
+
+                    $sets[$locator->getString()][] = $properties;
+                }
+            }
+
+            $this->combinedAssetProperties = array_map(
+                Asset::getMergedProperties(...),
+                $sets,
+            );
+        } else {
+            foreach ($this->getAssetSourceNamespaces($locator) as $namespace) {
+                $asset = $this->getAsset($locator, declarationNamespace: $namespace);
+
+                $sets[] = $asset->getProperties();
+            }
+
+            $this->combinedAssetProperties[$locator->getString()] = Asset::getMergedProperties($sets);
+        }
+    }
+
+    /**
+     * Returns namespaces from which an Asset's properties may be retrieved.
+     */
+    private function getAssetSourceNamespaces(Locator $locator): array
+    {
+        return match (get_class($locator)) {
+            StaticLocator::class => $this->getAppliedNamespaces(),
+            ThemeletLocator::class => [$locator->getNamespace()],
+        };
+    }
+}

--- a/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalAssetsTrait.php
+++ b/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalAssetsTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\Decorator\Hierarchy;
+
+use MyBB\Cargo\Decorator\RepositoryDecorator;
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\View\Themelet\AssetsTrait;
+use MyBB\View\Themelet\NamespaceCargo\Asset\Repository as AssetRepository;
+use MyBB\View\Themelet\NamespaceCargo\HierarchicalRepository;
+use MyBB\View\Themelet\NamespaceCargo\Repository as NamespaceCargoRepository;
+
+trait HierarchicalAssetsTrait
+{
+    use AssetsTrait; // override scope for remaining methods
+
+    /**
+     * Asset Repositories by namespace.
+     *
+     * @var array<string, NamespaceCargoRepository>
+     */
+    private array $assetRepositories = [];
+
+    public function getAssetRepository(string $namespace): RepositoryInterface
+    {
+        return $this->assetRepositories[$namespace] ??=
+            RepositoryDecorator::decorate(
+                new AssetRepository($this, $namespace),
+                [
+                    HierarchicalRepository::class,
+                ],
+            )
+        ;
+    }
+
+    private function buildAssetProperties(): void
+    {
+        $this->getHydrableRepository()->delete('hierarchy.assets');
+
+        foreach ($this->getNamespaces() as $namespace) {
+            $repository = $this->getAssetRepository($namespace);
+
+            $repository->buildCache();
+        }
+    }
+}

--- a/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalNamespacesTrait.php
+++ b/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalNamespacesTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\Decorator\Hierarchy;
+
+use MyBB\View\NamespaceType;
+
+trait HierarchicalNamespacesTrait
+{
+    /**
+     * @override
+     */
+    public function hasNamespaceTypeAccess(NamespaceType $type): bool
+    {
+        throw self::decoratedCallException();
+    }
+
+    /**
+     * @return string[]
+     * @override
+     */
+    public function getNamespaces(): array
+    {
+       return array_keys(
+           $this->getThemeletsByNamespace()
+       );
+    }
+
+    /**
+     * Returns absolute paths at which Resource namespaces may be found, in ascending priority.
+     *
+     * @return array<string, string[]>
+     * @override
+     */
+    public function getNamespaceAbsolutePaths(): array
+    {
+        $pathsByNamespace = [];
+
+        foreach ($this->getThemeletsByNamespace() as $namespace => $themelets) {
+            foreach ($themelets as $themelet) {
+                $pathsByNamespace[$namespace][] = $themelet->getNamespaceAbsolutePath($namespace);
+            }
+        }
+
+        return $pathsByNamespace;
+    }
+
+    /**
+     * @override
+     */
+    public function getNamespaceAbsolutePath(string $namespace): string
+    {
+        throw self::decoratedCallException();
+    }
+
+    /**
+     * @override
+     */
+    public function getNamespaceDirectoryPath(string $namespace): string
+    {
+        throw self::decoratedCallException();
+    }
+
+    /**
+     * @override
+     */
+    public function getNamespaceFromDirectoryName(string $name): string
+    {
+        throw self::decoratedCallException();
+    }
+}

--- a/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalResourcesTrait.php
+++ b/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalResourcesTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\Decorator\Hierarchy;
+
+use MyBB\Cargo\Decorator\RepositoryDecorator;
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\NamespaceCargo\Repository as NamespaceCargoRepository;
+use MyBB\View\Themelet\NamespaceCargo\Resource\Repository as ResourceRepository;
+use MyBB\View\Themelet\NamespaceCargo\Resource\Decorator\HierarchicalRepository as HierarchicalResourceRepository;
+use MyBB\View\Themelet\ResourcesTrait;
+
+trait HierarchicalResourcesTrait
+{
+    use ResourcesTrait; // override scope for remaining methods
+
+    /**
+     * Resource Repositories by namespace.
+     *
+     * @var array<string, NamespaceCargoRepository>
+     */
+    private array $resourceRepositories = [];
+
+    public function getResourceRepository(string $namespace): RepositoryInterface
+    {
+        return $this->resourceRepositories[$namespace] ??=
+            RepositoryDecorator::decorate(
+                new ResourceRepository($this, $namespace),
+                [
+                    HierarchicalResourceRepository::class,
+                ],
+            )
+        ;
+    }
+
+    /**
+     * @override
+     */
+    public function getResourceTypeAbsolutePath(string $namespace, ResourceType $type): string
+    {
+        throw self::decoratedCallException();
+    }
+}

--- a/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalThemelet.php
+++ b/inc/src/View/Themelet/Decorator/Hierarchy/HierarchicalThemelet.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\Decorator\Hierarchy;
+
+use MyBB\Utilities\FileStamp;
+use MyBB\Utilities\Hydrable\Hydrable;
+use MyBB\View\Themelet\Decorator\ThemeletDecorator;
+use MyBB\View\Themelet\Themelet;
+use MyBB\View\Themelet\ThemeletInterface;
+
+use function MyBB\View\directive;
+
+/**
+ * Adds awareness of parent and base extensions to a Themelet.
+ */
+class HierarchicalThemelet extends ThemeletDecorator
+{
+    use HierarchicalAssetsTrait;
+    use HierarchicalNamespacesTrait;
+    use HierarchicalResourcesTrait;
+
+    public string $inheritanceHydrableValidationType = FileStamp::TYPE_MODIFICATION_TIME;
+
+    private Hydrable $ancestorsHydrable;
+
+    /**
+     * @var ThemeletInterface[]
+     */
+    private array $baseThemelets = [];
+
+    /**
+     * @var array<string, ThemeletInterface>
+     */
+    private array $themelets;
+
+    /**
+     * @var array<string, ThemeletInterface[]>
+     */
+    private array $themeletsByNamespace;
+
+    public function __construct()
+    {
+        $hydrables = $this->getHydrableRepository();
+
+        $storeMode = directive('hierarchy.cache')
+            ? Hydrable::MODE_DEFERRED
+            : Hydrable::MODE_PASSIVE
+        ;
+
+        $this->ancestorsHydrable = $hydrables->add(
+            new Hydrable(
+                /**
+                 * @type array<string, ThemeletInterface>
+                 */
+                [],
+                key: 'hierarchy.ancestors',
+                build: $this->buildAncestors(...),
+                validateStamp: $this->ancestorsStampValid(...),
+                write: array_keys(...),
+                read: fn (array $value) => array_map(
+                    $this->getThemelet(...),
+                    $value,
+                ),
+                writeMode: $storeMode,
+                readMode: $storeMode,
+                validateStampMode: directive('hierarchy.cacheValidation')
+                    ? Hydrable::MODE_IMMEDIATE
+                    : Hydrable::MODE_PASSIVE
+            ),
+        );
+    }
+
+    /**
+     * @param ThemeletInterface[] $themelets
+     */
+    public function setBaseThemelets(array $themelets): void
+    {
+        $this->baseThemelets = $themelets;
+    }
+
+    public function getOwnThemelet(): Themelet
+    {
+        /** @var Themelet */
+        return $this->getDecorated();
+    }
+
+    /**
+     * Returns Themelets by target namespace in ascending priority.
+     *
+     * @return array<string, ThemeletInterface>
+     */
+    public function getThemeletsByNamespace(?string $namespace = null): array
+    {
+        if (!isset($this->themeletsByNamespace)) {
+            $this->themeletsByNamespace = [];
+
+            foreach ($this->getThemelets() as $themelet) {
+                $names = $themelet->getNamespaces();
+
+                foreach ($names as $name) {
+                    $this->themeletsByNamespace[$name][] = $themelet;
+                }
+            }
+        }
+
+        if ($namespace === null) {
+            return $this->themeletsByNamespace;
+        } else {
+            return $this->themeletsByNamespace[$namespace] ?? [];
+        }
+    }
+
+    public function getThemelet(string $identifier): ?ThemeletInterface
+    {
+        return $this->getThemelets()[$identifier]
+            ?? (new ($this->getExtension()::class)($identifier))
+            ?? null;
+    }
+
+    /**
+     * Returns source Themelets in ascending priority.
+     *
+     * @return array<string, ThemeletInterface>
+     */
+    private function getThemelets(): array
+    {
+        if (!isset($this->themelets)) {
+            $themelets = [
+                // the common inheritance base
+                ...$this->baseThemelets,
+
+                // the Themelet's ancestors
+                ...$this->getAncestors(),
+
+                // the Themelet itself
+                $this->getOwnThemelet(),
+            ];
+
+            $this->themelets = [];
+
+            foreach ($themelets as $themelet) {
+                $this->themelets[$themelet->getIdentifier()] = $themelet;
+            }
+        }
+
+        return $this->themelets;
+    }
+
+    /**
+     * @return array<string, ThemeletInterface>
+     */
+    private function getAncestors(): array
+    {
+        return $this->ancestorsHydrable->get();
+    }
+
+    /**
+     * @return array<string, ThemeletInterface>
+     */
+    private function buildAncestors(&$stamp = []): array
+    {
+        $results = [];
+        $stamp = [];
+
+        $extensions = [
+            $this->getExtension(),
+            ...$this->getExtension()->getAncestors(),
+        ];
+
+        foreach ($extensions as $extension) {
+            if ($extension !== $this->getExtension()) {
+                $results = $extension->getThemelet();
+            }
+
+            $stamp[$extension->getPackageName()] = $extension->getManifestStamp();
+        }
+
+        return $results;
+    }
+
+    private function ancestorsStampValid(array $stamp): bool
+    {
+        $extensions = $this->getExtension()->getInheritanceChain();
+
+        if (count($stamp) !== count($extensions)) {
+            return false;
+        }
+
+        if (array_keys($extensions) !== array_keys($stamp)) {
+            return false;
+        }
+
+        foreach ($extensions as $packageName => $extension) {
+            if (!$extension->manifestStampValid(
+                $stamp[$packageName],
+                $this->inheritanceHydrableValidationType,
+            )) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/inc/src/View/Themelet/Decorator/PublishableThemelet.php
+++ b/inc/src/View/Themelet/Decorator/PublishableThemelet.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\Decorator;
+
+use Exception;
+use MyBB\Utilities\Hydrable\Hydrable;
+use MyBB\View\Asset\Asset;
+use MyBB\View\Asset\Publication;
+use MyBB\View\Asset\ThemeletAsset;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Resource;
+use function MyBB\View\directive;
+
+/**
+ * Adds asset generation features to a Themelet.
+ */
+class PublishableThemelet extends ThemeletDecorator
+{
+    /**
+     * Rely on generated Asset files without validation.
+     */
+    final public const PUBLISH_NEVER = 2;
+
+    /**
+     * Generate Asset files if existing ones are stale.
+     */
+    final public const PUBLISH_AUTO = 4;
+
+    /**
+     * Generate Asset files each time.
+     */
+    final public const PUBLISH_ALWAYS = 8;
+
+    /**
+     * @var self::PUBLISH_*
+     */
+    public int $publishMode;
+
+    private Hydrable $publicationHydrable;
+
+    public function __construct()
+    {
+        $hydrables = $this->getHydrableRepository();
+
+        $this->publicationHydrable = $hydrables->add(
+            new Hydrable(
+                [],
+                'publication',
+            ),
+        );
+
+        $this->publishMode = directive('publication.publishMode');
+    }
+
+    /**
+     * @override scope
+     */
+    public function getAsset(Locator $locator, ?string $declarationNamespace = null): Asset
+    {
+        return Asset::fromLocator($locator, $this, $declarationNamespace);
+    }
+
+    public function getPublishedAsset(Locator $locator): Asset
+    {
+        $asset = $this->getAsset($locator);
+
+        if ($asset instanceof ThemeletAsset) {
+            $this->publishThemeletAsset($asset);
+        }
+
+        return $asset;
+    }
+
+    public function publishAssets(bool $force = false): void
+    {
+        foreach ($this->getPublishableThemeletAssets() as $asset) {
+            $this->publishThemeletAsset($asset, $force);
+        }
+    }
+
+    public function publishAssetsFromResource(Resource $resource, bool $force = false): void
+    {
+        foreach ($this->getAssetsFromResource($resource) as $asset) {
+            $this->publishThemeletAsset($asset, $force);
+        }
+    }
+
+    public function publishThemeletAsset(ThemeletAsset $asset, bool $force = false): void
+    {
+        if ($force || $this->publishMode !== self::PUBLISH_NEVER) {
+            $publication = new Publication($asset);
+
+            $publication->publish($force || $this->publishMode === self::PUBLISH_ALWAYS);
+
+            copy_file_to_cdn($asset->getAbsolutePath());
+        }
+    }
+
+    /**
+     * Return Assets publishable from, or published using, the provided Resource.
+     *
+     * @return ThemeletAsset[]
+     */
+    public function getAssetsFromResource(Resource $resource): array
+    {
+        return array_merge(
+            $this->getPublishableThemeletAssets([$resource]),
+            Publication::getAssetsPublishedUsingResource($resource, $this),
+        );
+    }
+
+    /**
+     * @param ?Resource[] $sourceResources
+     * @return ThemeletAsset[]
+     */
+    public function getPublishableThemeletAssets(?array $sourceResources = null): array
+    {
+        $explicitlyPublishableAssets = $this->getExplicitlyPublishableAssets($sourceResources);
+
+        $claimedResources = array_map(
+            fn (ThemeletAsset $asset) => $asset->getResource(),
+            $explicitlyPublishableAssets,
+        );
+
+        return array_merge(
+            $explicitlyPublishableAssets,
+            $this->getImplicitlyPublishableAssets(
+                array_diff_key($sourceResources, $claimedResources)
+            ),
+        );
+    }
+
+    /**
+     * Returns Assets referenced in the properties file.
+     *
+     * @param ?Resource[] $sourceResources
+     * @return ThemeletAsset[]
+     */
+    public function getExplicitlyPublishableAssets(?array $sourceResources = null): array
+    {
+        $assets = [];
+
+        if ($sourceResources === null) {
+            $sourceResources = $this->getPublishableResources();
+            $namespaces = $this->getNamespaces();
+        } else {
+            $namespaces = array_map(
+                fn (Resource $resource) => $resource->getNamespace(),
+                $sourceResources,
+            );
+        }
+
+        foreach ($namespaces as $namespace) {
+            foreach ($this->getAssetProperties($namespace) as $identifier => $asset) {
+                $locator = Locator::fromNamespaceRelativeIdentifier($namespace, $identifier);
+
+                if ($locator instanceof ThemeletLocator) {
+                    $asset = $this->getAsset($locator);
+
+                    if (in_array($asset->getResource(), $sourceResources)) {
+                        $assets[$locator->getString()] = $asset;
+                    }
+                }
+            }
+        }
+
+        return $assets;
+    }
+
+    /**
+     * Returns Assets that can be published without being referenced in the properties file.
+     *
+     * @param ?Resource[] $sourceResources
+     * @return ThemeletAsset[]
+     */
+    public function getImplicitlyPublishableAssets(?array $sourceResources = null): array
+    {
+        $assets = [];
+
+        foreach ($sourceResources ?? $this->getPublishableResources() as $resource) {
+            $resourceLocator = $resource->getLocator();
+
+            $asset = new ThemeletAsset($resourceLocator, $this);
+
+            if (Publication::isPlain($asset)) {
+                $assets[$resourceLocator->getString()] = $asset;
+            }
+        }
+
+        return $assets;
+    }
+
+    /**
+     * Returns Resources generally usable for publishing.
+     *
+     * @return array<string, Resource>
+     */
+    public function getPublishableResources(): array
+    {
+        return $this->getResources(resourceTypes: Publication::PUBLISHABLE_RESOURCE_TYPES);
+    }
+
+    public function getPublishingPath(): string
+    {
+        $extension = $this->getExtension();
+
+        if ($extension === null) {
+            throw new Exception('Cannot use publishing path for non-Extension Themelet');
+        }
+
+        return ThemeletAsset::WEB_ROOT_RELATIVE_BASE_PATH . $extension->getPackageName();
+    }
+
+    public function getAssetPublicationData(?ThemeletAsset $asset = null): ?array
+    {
+        $items = $this->publicationHydrable->get();
+
+        return $asset
+            ? $items[$asset->getLocator()->getString()] ?? null
+            : $items
+        ;
+    }
+
+    public function setAssetPublicationData(ThemeletAsset $asset, array $data): void
+    {
+        $this->publicationHydrable->setNested([$asset->getLocator()->getString()], $data);
+    }
+}

--- a/inc/src/View/Themelet/Decorator/ThemeletDecorator.php
+++ b/inc/src/View/Themelet/Decorator/ThemeletDecorator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\Decorator;
+
+use MyBB\Utilities\Decorator;
+use MyBB\View\Themelet\ThemeletInterface;
+
+class ThemeletDecorator extends Decorator implements ThemeletInterface {}

--- a/inc/src/View/Themelet/NamespaceCargo/Asset/Repository.php
+++ b/inc/src/View/Themelet/NamespaceCargo/Asset/Repository.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\NamespaceCargo\Asset;
+
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\View\Themelet\ThemeletInterface;
+
+/**
+ * Metadata of items in a Themelet's namespace.
+ */
+class Repository extends \MyBB\View\Themelet\NamespaceCargo\Repository
+{
+    public const NAME = 'assets';
+
+    public function getRepository(ThemeletInterface $themelet): RepositoryInterface
+    {
+        return $themelet->getAssetRepository($this->namespace);
+    }
+}

--- a/inc/src/View/Themelet/NamespaceCargo/EntityTrait.php
+++ b/inc/src/View/Themelet/NamespaceCargo/EntityTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\NamespaceCargo;
+
+trait EntityTrait
+{
+    use \MyBB\Cargo\EntityTrait;
+
+    public function getRepositoryEntityKey(): string
+    {
+        return $this->getLocator()->getNamespaceRelativeIdentifier();
+    }
+}

--- a/inc/src/View/Themelet/NamespaceCargo/HierarchicalRepository.php
+++ b/inc/src/View/Themelet/NamespaceCargo/HierarchicalRepository.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\NamespaceCargo;
+
+use MyBB\Cargo\Repository;
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\Stopwatch\Stopwatch;
+use MyBB\Utilities\FileStamp;
+use MyBB\Utilities\Hydrable\Hydrable;
+use MyBB\View\Locator\ThemeletLocator;
+
+use function MyBB\app;
+use function MyBB\View\directive;
+
+class HierarchicalRepository extends \MyBB\Cargo\Decorator\HierarchicalRepository
+{
+    public function __construct()
+    {
+        $cacheMode = directive('hierarchy.cache')
+            ? Hydrable::MODE_DEFERRED
+            : Hydrable::MODE_PASSIVE
+        ;
+        $validateMode = directive('hierarchy.cacheValidation')
+            ? Hydrable::MODE_IMMEDIATE
+            : Hydrable::MODE_PASSIVE
+        ;
+
+        $hydrables = $this->themelet->getHydrableRepository();
+
+        $this->resolvedProperties = $hydrables->add(
+            new Hydrable(
+                [
+                    Repository::SCOPE_SHARED => [],
+                    Repository::SCOPE_ENTITY => [],
+                ],
+                key: 'hierarchy.properties.' . $this->getDecorated()::NAME,
+                path: [$this->namespace],
+                build: $this->buildResolvedProperties(...),
+                validateStamp: $this->stampValid(...),
+                writeMode: $cacheMode,
+                readMode: $cacheMode,
+                validateStampMode: $validateMode,
+            ),
+        );
+        $this->resolvedRepositories = $hydrables->add(
+            new Hydrable(
+                [],
+                key: 'hierarchy.resolution.' . $this->getDecorated()::NAME,
+                path: [$this->namespace],
+                build: $this->buildResolvedRepositories(...),
+                validateStamp: $this->stampValid(...),
+                write: fn (array $data) => array_map(
+                    fn (Repository $repository) => $repository->getHierarchicalIdentifier(),
+                    $data,
+                ),
+                read: fn (array $data) => array_map(
+                    fn (string $identifier) => $this->getRepository(
+                        $this->themelet->getThemelet($identifier)
+                    ),
+                    $data,
+                ),
+                buildMode: $cacheMode,
+                writeMode: $cacheMode,
+                readMode: $cacheMode,
+                validateStampMode: $validateMode,
+            ),
+        );
+    }
+
+    public function getResolvedRepository(string|ThemeletLocator $key): ?RepositoryInterface
+    {
+        if ($key instanceof ThemeletLocator) {
+            $key = $key->getNamespaceRelativeIdentifier();
+        }
+
+        return parent::getResolvedRepository($key);
+    }
+
+    public function resolveRepository(string|ThemeletLocator $key): ?RepositoryInterface
+    {
+        if ($key instanceof ThemeletLocator) {
+            $key = $key->getNamespaceRelativeIdentifier();
+        }
+
+        $repository = $this->queryRepository($key);
+
+        if ($repository !== null) {
+            $this->resolvedRepositories->setNested([
+                $key,
+            ], $repository);
+        }
+
+        return $repository;
+    }
+
+    public function queryRepository(string|ThemeletLocator $key): ?RepositoryInterface
+    {
+        if ($key instanceof ThemeletLocator) {
+            $key = $key->getNamespaceRelativeIdentifier();
+            $locator = $key;
+        } else {
+            $locator = ThemeletLocator::fromNamespaceRelativeIdentifier(
+                $this->namespace,
+                $key,
+            );
+        }
+
+        $stopwatchPeriod = app(Stopwatch::class)->start(
+            $locator->getString(),
+            'core.view.hierarchy.resolution',
+        );
+
+        $repository = $this->getOwnRepository()->has($key)
+            ? $this->getOwnRepository()
+            : $this->getClosestEntityAncestorRepository($key)
+        ;
+
+        $stopwatchPeriod->stop();
+
+        return $repository;
+    }
+
+    public function getClosestEntityAncestorRepository(string|ThemeletLocator $key): ?RepositoryInterface
+    {
+        if ($key instanceof ThemeletLocator) {
+            $key = $key->getNamespaceRelativeIdentifier();
+        }
+
+        return $this->getEntityAncestorRepositories($key)?->current();
+    }
+
+    /**
+     * @return iterable<RepositoryInterface>
+     */
+    public function getEntityAncestorRepositories(string|ThemeletLocator $key): iterable
+    {
+        if ($key instanceof ThemeletLocator) {
+            $key = $key->getNamespaceRelativeIdentifier();
+        }
+
+        foreach ($this->getAncestors() as $repository) {
+            if (
+                $repository !== $this->getOwnRepository() &&
+                $repository->has($key)
+            ) {
+                yield $repository;
+            } elseif (!$repository->entityDeclaredInherited($key)) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * @param FileStamp::TYPE_* $type
+     */
+    public function stampValid(array $stamp, string $type = FileStamp::TYPE_MODIFICATION_TIME): bool
+    {
+        $ancestors = $this->getAncestors();
+
+        if (array_keys($ancestors) !== array_keys($stamp)) {
+            return false;
+        }
+
+        foreach ($ancestors as $identifier => $repository) {
+            $stamp = new FileStamp($stamp[$identifier]);
+
+            if (!$repository->stampValid($stamp)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function getStamp(): array
+    {
+        $stamps = [];
+
+        foreach ($this->getAncestors() as $name => $repository) {
+            $stamps[$name] = $repository->getStamp();
+        }
+
+        return $stamps;
+    }
+
+    public function buildCache(): void
+    {
+        $this->resolvedProperties->build();
+        $this->resolvedRepositories->build();
+    }
+
+    protected function buildResolvedProperties(&$stamp = []): array
+    {
+        $stopwatchPeriod = app(Stopwatch::class)->start(
+            '@' . $this->namespace . ' (' . $this->getDecorated()::NAME . ')',
+            'core.view.hierarchy.properties',
+        );
+
+        $results = parent::buildResolvedProperties($stamp);
+
+        $stopwatchPeriod->stop();
+
+        return $results;
+    }
+
+    protected function buildResolvedRepositories(&$stamp = []): array
+    {
+        $stopwatchPeriod = app(Stopwatch::class)->start(
+            '@' . $this->namespace . ' (' . $this->getDecorated()::NAME . ')',
+            'core.view.hierarchy.repositories',
+        );
+
+        $results = parent::buildResolvedRepositories($stamp);
+
+        $stopwatchPeriod->stop();
+
+        return $results;
+    }
+
+    protected function getOwnRepository(): RepositoryInterface
+    {
+        return $this->getRepository(
+            $this->themelet->getOwnThemelet()
+        );
+    }
+
+    /**
+     * @return RepositoryInterface[]
+     */
+    protected function getAncestors(): array
+    {
+        $results = [];
+
+        $themeletsByPriority = array_reverse(
+            $this->themelet->getThemeletsByNamespace($this->namespace)
+        );
+
+        foreach ($themeletsByPriority as $themelet) {
+            $results[$themelet->getIdentifier()] = $this->getRepository($themelet);
+        }
+
+        return $results;
+    }
+}

--- a/inc/src/View/Themelet/NamespaceCargo/Repository.php
+++ b/inc/src/View/Themelet/NamespaceCargo/Repository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\NamespaceCargo;
+
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\View\Themelet\ThemeletInterface;
+
+/**
+ * Metadata of items in a Themelet's namespace.
+ */
+abstract class Repository extends \MyBB\Cargo\Repository
+{
+    public function __construct(
+        public readonly ?ThemeletInterface $themelet,
+        public readonly ?string $namespace,
+    ) {}
+
+    public function getHierarchicalIdentifier(): string
+    {
+        return $this->themelet->getIdentifier();
+    }
+
+    /**
+     * Returns a Repository with the same type and namespace
+     * from the provided Themelet.
+     */
+    abstract public function getRepository(ThemeletInterface $themelet): RepositoryInterface;
+
+    protected function getPropertiesFilePath(): string
+    {
+        return
+            $this->themelet->getNamespaceAbsolutePath($this->namespace) .
+            '/' .
+            static::NAME .
+            '.json'
+        ;
+    }
+}

--- a/inc/src/View/Themelet/NamespaceCargo/Resource/Decorator/HierarchicalRepository.php
+++ b/inc/src/View/Themelet/NamespaceCargo/Resource/Decorator/HierarchicalRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\NamespaceCargo\Resource\Decorator;
+
+use LogicException;
+use MyBB\Cargo\EntityInterface as CargoEntityInterface;
+use MyBB\Cargo\FileRepositoryInterface;
+use MyBB\View\HierarchicalResource;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Resource;
+
+/**
+ * Metadata of items in a Themelet's namespace.
+ */
+class HierarchicalRepository extends \MyBB\View\Themelet\NamespaceCargo\HierarchicalRepository implements FileRepositoryInterface
+{
+    /**
+     * @override scope
+     */
+    public function has(string|ThemeletLocator $key): bool
+    {
+        return $this->get($key)->exists();
+    }
+
+    /**
+     * @override scope
+     */
+    public function getExisting(string|ThemeletLocator $key): ?Resource
+    {
+        $resource = $this->get($key);
+
+        if ($resource->exists()) {
+            return $resource;
+        } else {
+            return null;
+        }
+    }
+
+     /**
+     * @override scope
+     */
+    public function get(string|ThemeletLocator $key): Resource
+    {
+        if (!($key instanceof ThemeletLocator)) {
+            $key = ThemeletLocator::fromNamespaceRelativeIdentifier($this->namespace, $key);
+        }
+
+        return new HierarchicalResource($this->themelet, $key);
+    }
+
+    /**
+     * @override
+     */
+    public function create(string|ThemeletLocator $key): Resource
+    {
+        $resource = $this->getOwnRepository()->get($key);
+
+        if ($resource->exists()) {
+            throw new LogicException('Resource `' . $key->getString() . '` already exists');
+        } else {
+            return $resource;
+        }
+    }
+
+    public function getResolved(string|ThemeletLocator $key): ?CargoEntityInterface
+    {
+        if ($key instanceof ThemeletLocator) {
+            $key = $key->getNamespaceRelativeIdentifier();
+        }
+
+        return parent::getResolved($key);
+    }
+}

--- a/inc/src/View/Themelet/NamespaceCargo/Resource/Repository.php
+++ b/inc/src/View/Themelet/NamespaceCargo/Resource/Repository.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet\NamespaceCargo\Resource;
+
+use FilesystemIterator;
+use LogicException;
+use MyBB\Cargo\FileRepositoryInterface;
+use MyBB\Cargo\RepositoryInterface;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Resource;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\ThemeletInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Metadata of items in a Themelet's namespace.
+ */
+class Repository extends \MyBB\View\Themelet\NamespaceCargo\Repository implements FileRepositoryInterface
+{
+    public const NAME = 'resources';
+
+    public function getRepository(ThemeletInterface $themelet): RepositoryInterface
+    {
+        return $themelet->getResourceRepository($this->namespace);
+    }
+
+    /**
+     * @param ?ResourceType[] $resourceTypes
+     * @return array<string, Resource>
+     */
+    public function getAll(?array $resourceTypes = null): array
+    {
+        $results = [];
+
+        foreach ($resourceTypes ?? ResourceType::cases() as $resourceType) {
+            $resourceTypeAbsolutePath = $this->themelet->getResourceTypeAbsolutePath(
+                $this->namespace,
+                $resourceType,
+            );
+
+            if (is_dir($resourceTypeAbsolutePath)) {
+                $files = new RecursiveIteratorIterator(
+                    new RecursiveDirectoryIterator(
+                        $resourceTypeAbsolutePath,
+                        FilesystemIterator::SKIP_DOTS,
+                    )
+                );
+
+                foreach ($files as $file) {
+                    $path = $file->getRealpath();
+
+                    if (str_starts_with($path, $resourceTypeAbsolutePath . '/')) {
+                        $path = substr($path, strlen($resourceTypeAbsolutePath . '/'));
+                    }
+
+                    $locator = ThemeletLocator::fromString(
+                        $path,
+                        [
+                            'namespace' => ThemeletLocator::COMPONENT_UNSET,
+                            'type' => ThemeletLocator::COMPONENT_UNSET,
+                        ],
+                        [
+                            'namespace' => $this->namespace,
+                            'type' => $resourceType,
+                        ],
+                    );
+
+                    $key = $locator->getNamespaceRelativeIdentifier();
+
+                    $results[$key] = $this->getExisting($locator);
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    public function has(string|ThemeletLocator $key): bool
+    {
+        return $this->get($key)->exists();
+    }
+
+    public function getExisting(string|ThemeletLocator $key): ?Resource
+    {
+        $resource = $this->get($key);
+
+        if ($resource->exists()) {
+            return $resource;
+        } else {
+            return null;
+        }
+    }
+
+    public function get(string|ThemeletLocator $key): Resource
+    {
+        if (!($key instanceof ThemeletLocator)) {
+            $key = ThemeletLocator::fromNamespaceRelativeIdentifier($this->namespace, $key);
+        }
+
+        return new Resource($this->themelet, $key);
+    }
+
+    public function create(string|ThemeletLocator $key): Resource
+    {
+        $resource = $this->get($key);
+
+        if ($resource->exists()) {
+            throw new LogicException('Resource `' . $key->getString() . '` already exists');
+        } else {
+            return $resource;
+        }
+    }
+}

--- a/inc/src/View/Themelet/NamespacesTrait.php
+++ b/inc/src/View/Themelet/NamespacesTrait.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet;
+
+use FilesystemIterator;
+use InvalidArgumentException;
+use MyBB\View\NamespaceType;
+use SplFileInfo;
+
+trait NamespacesTrait
+{
+    /**
+     * @var NamespaceType[]
+     */
+    private array $namespaceTypeAccess = [];
+
+    /**
+     * An implied and only namespace for Resources,
+     * located directly in the Themelet directory.
+     */
+    private ?string $directNamespace = null;
+
+    public function hasNamespaceTypeAccess(NamespaceType $type): bool
+    {
+        return in_array($type, $this->namespaceTypeAccess);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNamespaces(): array
+    {
+        if ($this->directNamespace) {
+            return [
+                $this->directNamespace,
+            ];
+        } else {
+            $directoryNames = array_keys(
+                array_filter(
+                    iterator_to_array(
+                        new FilesystemIterator(
+                            $this->getAbsolutePath(),
+                            FilesystemIterator::KEY_AS_FILENAME
+                            | FilesystemIterator::CURRENT_AS_FILEINFO
+                            | FilesystemIterator::SKIP_DOTS
+                        )
+                    ),
+                    fn(SplFileInfo $item) => $item->isDir(),
+                )
+            );
+
+            return array_map(
+                $this->getNamespaceFromDirectoryName(...),
+                $directoryNames,
+            );
+        }
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getNamespaceAbsolutePaths(): array
+    {
+        $paths = [];
+
+        foreach ($this->getNamespaces() as $namespace) {
+            $paths[$namespace][] = $this->getNamespaceAbsolutePath($namespace);
+        }
+
+        return $paths;
+    }
+
+    public function getNamespaceAbsolutePath(string $namespace): string
+    {
+        $directoryPath = $this->getNamespaceDirectoryPath($namespace);
+
+        if ($directoryPath === '.') {
+            return $this->getAbsolutePath();
+        } else {
+            return $this->getAbsolutePath() . '/' . $directoryPath;
+        }
+    }
+
+    public function getNamespaceDirectoryPath(string $namespace): string
+    {
+        $namespaceType = NamespaceType::tryFromNamespace($namespace, $this->getExtension());
+
+        if ($namespaceType === null) {
+            throw new InvalidArgumentException('Invalid namespace `' . $namespace . '`');
+        }
+
+        if ($namespace === $this->directNamespace) {
+            return '.';
+        } else {
+            return $namespace;
+        }
+    }
+
+    public function getNamespaceFromDirectoryName(string $name): string
+    {
+        if ($name === $this->directNamespace) {
+            throw new InvalidArgumentException('Resources in Extension\'s own namespace `' . $name . '` must be placed directly in the view directory');
+        }
+
+        if ($this->directNamespace && $name === '.') {
+            return $this->directNamespace;
+        }
+
+        $namespaceType = NamespaceType::tryFromNamespace($name, $this->extension);
+
+        if ($namespaceType === null) {
+            throw new InvalidArgumentException('Invalid namespace directory `' . $name . '`');
+        }
+
+        if (!$this->hasNamespaceTypeAccess($namespaceType)) {
+            throw new InvalidArgumentException('Extension `' . $this->getExtension()->getPackageName() . '` cannot populate namespace `' . $name . '`');
+        }
+
+        return $name;
+    }
+}

--- a/inc/src/View/Themelet/ResourcesTrait.php
+++ b/inc/src/View/Themelet/ResourcesTrait.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet;
+
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\Resource;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\NamespaceCargo\Repository as NamespaceCargoRepository;
+use MyBB\View\Themelet\NamespaceCargo\Resource\Repository as ResourceRepository;
+
+trait ResourcesTrait
+{
+    /**
+     * Resource Repositories by namespace.
+     *
+     * @var array<string, NamespaceCargoRepository>
+     */
+    private array $resourceRepositories = [];
+
+    public function getResourceRepository(string $namespace): NamespaceCargoRepository
+    {
+        return $this->resourceRepositories[$namespace] ??=
+            new ResourceRepository($this, $namespace);
+    }
+
+    public function getResourceTypeAbsolutePath(string $namespace, ResourceType $type): string
+    {
+        return
+            $this->getNamespaceAbsolutePath($namespace) .
+            '/' .
+            $type->getDirectoryName()
+        ;
+    }
+
+    /**
+     * Returns absolute paths at which Resources of specified type may be found, by namespace.
+     *
+     * @return array<string, string[]>
+     */
+    public function getResourceTypeAbsolutePaths(ResourceType $type): array
+    {
+        $resultPaths = [];
+
+        $namespacePaths = $this->getNamespaceAbsolutePaths();
+
+        foreach ($namespacePaths as $namespace => $paths) {
+            foreach ($paths as $path) {
+                $resultPaths[$namespace][] = $path . '/' . $type->getDirectoryName();
+            }
+        }
+
+        return $resultPaths;
+    }
+
+    /**
+     * @param ?string[] $namespaces
+     * @param ?ResourceType[] $resourceTypes
+     * @return array<string, Resource>
+     */
+    public function getResources(?array $namespaces = null, ?array $resourceTypes = null): array
+    {
+        $resources = [];
+
+        foreach ($namespaces ?? $this->getNamespaces() as $namespace) {
+            foreach ($this->getNamespaceResources($namespace, $resourceTypes) as $resource) {
+                // use Locator strings with namespaces
+                $resources[$resource->getLocator()->getString()] = $resource;
+            }
+        }
+
+        return $resources;
+    }
+
+    /**
+     * @param ?ResourceType[] $resourceTypes
+     * @return array<string, Resource>
+     */
+    public function getNamespaceResources(string $namespace, ?array $resourceTypes = null): array
+    {
+        $repository = $this->getResourceRepository($namespace);
+
+        return $repository->getAll($resourceTypes);
+    }
+
+    public function hasResource(ThemeletLocator $locator): bool
+    {
+        $repository = $this->getResourceRepository($locator->getNamespace());
+
+        return $repository->has($locator);
+    }
+
+    public function getExistingResource(ThemeletLocator $locator): ?Resource
+    {
+        $repository = $this->getResourceRepository($locator->getNamespace());
+
+        return $repository->getExisting($locator);
+    }
+
+    public function getResource(ThemeletLocator $locator): Resource
+    {
+        $repository = $this->getResourceRepository($locator->getNamespace());
+
+        return $repository->get($locator);
+    }
+
+    public function createResource(ThemeletLocator $locator): ?Resource
+    {
+        $repository = $this->getResourceRepository($locator->getNamespace());
+
+        return $repository->create($locator);
+    }
+
+    public function getResourceProperties(): array
+    {
+        $results = [];
+
+        foreach ($this->getNamespaces() as $namespace) {
+            $repository = $this->getResourceRepository($namespace);
+
+            $results = array_merge($results, $repository->getEntityProperties());
+        }
+
+        return $results;
+    }
+}

--- a/inc/src/View/Themelet/Themelet.php
+++ b/inc/src/View/Themelet/Themelet.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet;
+
+use MyBB\Extensions\ViewExtensionInterface;
+use MyBB\Utilities\Hydrable\FilesystemStore;
+use MyBB\Utilities\Hydrable\Repository;
+
+/**
+ * A UI package containing Resources and metadata.
+ */
+class Themelet implements ThemeletInterface
+{
+    use AssetsTrait;
+    use NamespacesTrait;
+    use ResourcesTrait;
+
+    public const CACHE_BASE_PATH = MYBB_ROOT . 'cache/themelets/';
+
+    private ?ViewExtensionInterface $extension = null;
+
+    private string $absolutePath;
+    private readonly Repository $hydrableRepository;
+
+    public static function fromExtension(?ViewExtensionInterface $extension = null): self
+    {
+        return new self($extension);
+    }
+
+    public function getExtension(): ?ViewExtensionInterface
+    {
+        return $this->extension;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->extension->getPackageName();
+    }
+
+    public function getAbsolutePath(): string
+    {
+        return $this->absolutePath;
+    }
+
+    public function getHydrableRepository(): Repository
+    {
+        if (!isset($this->hydrableRepository)) {
+            $store = new FilesystemStore(self::CACHE_BASE_PATH . $this->getIdentifier());
+
+            $this->hydrableRepository = new Repository($store);
+        }
+
+        return $this->hydrableRepository;
+    }
+
+    private function __construct(?ViewExtensionInterface $extension = null)
+    {
+        if ($extension !== null) {
+            $this->extension = $extension;
+
+            $this->absolutePath = $extension->getThemeletAbsolutePath();
+
+            $this->namespaceTypeAccess = $extension::NAMESPACE_TYPE_ACCESS;
+
+            if ($extension::THEMELET_DIRECT_NAMESPACE) {
+                $this->directNamespace = $extension->getThemeletDirectNamespace();
+            }
+        }
+    }
+}

--- a/inc/src/View/Themelet/ThemeletInterface.php
+++ b/inc/src/View/Themelet/ThemeletInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View\Themelet;
+
+use MyBB\Extensions\ViewExtensionInterface;
+use MyBB\Utilities\Hydrable\Repository as HydrableRepository;
+use MyBB\View\Asset\Asset;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\ThemeletLocator;
+use MyBB\View\NamespaceType;
+use MyBB\View\Resource;
+use MyBB\View\ResourceType;
+use MyBB\View\Themelet\NamespaceCargo\Repository;
+
+/**
+ * @method static self fromExtension(?ViewExtensionInterface $extension = null)
+ * @method ViewExtensionInterface|null getExtension()
+ * @method string getIdentifier()
+ * @method string getAbsolutePath()
+ * @method HydrableRepository getHydrableRepository()
+ *
+ * // AssetsTrait
+ * @method Repository getAssetRepository(string $namespace)
+ * @method Asset getAsset(Locator $locator, ?string $declarationNamespace = null)
+ * @method array getAssetPropertiesOfType(string $namespace, ResourceType $type)
+ * @method array getAssetProperties(string $namespace)
+ *
+ * // NamespacesTrait
+ * @method bool hasNamespaceTypeAccess(NamespaceType $type)
+ * @method array getNamespaces()
+ * @method array getNamespaceAbsolutePaths()
+ * @method string getNamespaceAbsolutePath(string $namespace)
+ * @method string getNamespaceDirectoryPath(string $namespace)
+ * @method string getNamespaceFromDirectoryName(string $name)
+ *
+ * // ResourcesTrait
+ * @method Repository getResourceRepository(string $namespace)
+ * @method string getResourceTypeAbsolutePath(string $namespace, ResourceType $type)
+ * @method array getResourceTypeAbsolutePaths(ResourceType $type)
+ * @method array getResources(?array $namespaces = null, ?array $resourceTypes = null)
+ * @method array getNamespaceResources(string $namespace, ?array $resourceTypes = null)
+ * @method bool hasResource(ThemeletLocator $locator)
+ * @method Resource|null getExistingResource(ThemeletLocator $locator)
+ * @method Resource|null getResource(ThemeletLocator $locator)
+ * @method Resource|null createResource(ThemeletLocator $locator)
+ * @method array getResourceProperties()
+ */
+interface ThemeletInterface {}

--- a/inc/src/View/functions.php
+++ b/inc/src/View/functions.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\View;
+
+use MyBB\View\Runtime\Runtime;
+
+use function MyBB\app;
+
+const DEFAULT_THEME_PACKAGE = 'core.default';
+
+/**
+ * Passes data to Resources.
+ *
+ * @param array<string, scalar> $data
+ */
+function set(array $data): void
+{
+    app(Runtime::class)->setSharedData($data);
+}
+
+function directive(string $name): mixed
+{
+    return app(Optimization::class)->getDirective($name);
+}

--- a/inc/themes/core.default/frontend/assets.json
+++ b/inc/themes/core.default/frontend/assets.json
@@ -1,0 +1,187 @@
+{
+	"assets": {
+		"styles/main.css": {
+			"source": "main.scss",
+			"attached_to": [
+				{
+					"script": "global"
+				}
+			]
+		},
+		"./jscripts/jquery.js": {
+			"attached_to": [
+				{
+					"script": "global"
+				}
+			]
+		},
+		"./jscripts/jquery.plugins.min.js": {
+			"attached_to": [
+				{
+					"script": "global"
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/general.js": {
+			"attached_to": [
+				{
+					"script": "global"
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js",
+				"./jscripts/jquery.plugins.min.js"
+			]
+		},
+		"./jscripts/jeditable/jeditable.min.js": {
+			"attached_to": [
+				{
+					"script": "forumdisplay.php"
+				},
+				{
+					"script": "showthread.php"
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/inline_edit.js": {
+			"attached_to": [
+				{
+					"script": "forumdisplay.php"
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/rating.js": {
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/inline_moderation.js": {
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/report.js": {
+			"attached_to": [
+				{
+					"script": "member.php",
+					"actions": [
+						"profile"
+					]
+				},
+				{
+					"script": "reputation.php"
+				},
+				{
+					"script": "showthread.php"
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/jquery.validate.min.js": {
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/regvalidator.js": {
+			"attached_to": [
+				{
+					"script": "member.php",
+					"actions": [
+						"register"
+					]
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/question.js": {
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/sceditor/jquery.sceditor.bbcode.min.js": {
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/bbcodes_sceditor.js": {
+			"depends_on": [
+				"./jscripts/jquery.js",
+				"./jscripts/jquery.sceditor.bbcode.min.js"
+			]
+		},
+		"./jscripts/sceditor/plugins/undo.js": {
+			"depends_on": [
+				"./jscripts/jquery.sceditor.bbcode.min.js"
+			]
+		},
+		"./jscripts/post.js": {
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/inline_reports.js": {
+			"attached_to": [
+				{
+					"script": "modcp.php",
+					"actions": [
+						"reports"
+					]
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/usercp.js": {
+			"attached_to": [
+				{
+					"script": "private.php",
+					"actions": [
+						"send"
+					]
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"./jscripts/thread.js": {
+			"attached_to": [
+				{
+					"script": "showthread.php",
+					"actions": [
+						"thread"
+					]
+				}
+			],
+			"depends_on": [
+				"./jscripts/jquery.js"
+			]
+		},
+		"https://use.fontawesome.com/releases/v5.4.1/js/all.js": {
+			"attached_to": [
+				{
+					"script": "global"
+				}
+			],
+			"attributes": {
+				"defer": "defer",
+				"integrity": "sha384-L469/ELG4Bg9sDQbl0hvjMq8pOcqFgkSpwhwnslzvVVGpDjYJ6wJJyYjvG3u8XW7",
+				"crossorigin": "anonymous"
+			}
+		}
+	}
+}

--- a/inc/themes/core.default/frontend/templates/forumdisplay/forumdisplay.twig
+++ b/inc/themes/core.default/frontend/templates/forumdisplay/forumdisplay.twig
@@ -142,7 +142,7 @@
                                 {% if sorting.by == 'rating' %}{{ ascDesc }}{% endif %}
                             </strong>
                         </span>
-                        <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/rating.js?ver=1808"></script>
+                        {{ asset('jscripts/rating.js', static=true, attributes={'defer': 'defer'}) }}
                         <script type="text/javascript">
                         <!--
                             lang.stars = [];

--- a/inc/themes/core.default/frontend/templates/forumdisplay/forumdisplay.twig
+++ b/inc/themes/core.default/frontend/templates/forumdisplay/forumdisplay.twig
@@ -18,9 +18,6 @@
         lang.post_fetch_error = "{{ lang.post_fetch_error }}";
     // -->
     </script>
-    <!-- jeditable (jquery) -->
-    <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/jeditable/jeditable.min.js"></script>
-    <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/inline_edit.js?ver=1808"></script>
 {% endblock jscripts %}
 
 {% block body %}

--- a/inc/themes/core.default/frontend/templates/forumdisplay/inlinemoderation.twig
+++ b/inc/themes/core.default/frontend/templates/forumdisplay/inlinemoderation.twig
@@ -26,7 +26,7 @@
         {% endif %}
     {% endset %}
     {% if standardTools|trim or customTools %}
-        <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/inline_moderation.js?ver=1838"></script>
+        {{ asset('jscripts/inline_moderation.js', static=true) }}
         <form id="inlinemoderation_options" action="moderation.php" method="post">
             <input type="hidden" name="my_post_key" value="{{ mybb.post_code }}" />
             <input type="hidden" name="fid" value="{{ foruminfo.fid }}" />

--- a/inc/themes/core.default/frontend/templates/layouts/master.twig
+++ b/inc/themes/core.default/frontend/templates/layouts/master.twig
@@ -10,23 +10,21 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    {% for stylesheet in get_stylesheets() %}
-        {# <link rel="stylesheet" href="{{ stylesheet }}"> #}
+    {% for asset in attached_assets('style') %}
+        {{ include('partials/style.twig', {asset: asset}) }}
+    {% endfor %}
+
+    {% for asset in attached_assets('script') %}
+        {{ include('partials/script.twig', {asset: asset}) }}
     {% endfor %}
 
     {# TEMPORARY #}
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/jquery-jgrowl/1.4.8/jquery.jgrowl.min.css" />
     <link href="https://fonts.googleapis.com/css?family=Asap:400,600,600i|Open+Sans:300,400,700" rel="stylesheet">
-    {# <link href="{{ asset_url('assets/css/main.css') }}" rel="stylesheet"> #}
-    <link href="https://mybb.github.io/1.9-ui-framework/assets/css/main.css" rel="stylesheet">
-    {# <link href="http://localhost:4000/assets/css/main.css" rel="stylesheet"> #}
 
     <link rel="alternate" type="application/rss+xml" title="{{ lang.latest_threads }} (RSS 2.0)" href="{{ mybb.settings.bburl }}/syndication.php" />
     <link rel="alternate" type="application/atom+xml" title="{{ lang.latest_threads }} (Atom 1.0)" href="{{ mybb.settings.bburl }}/syndication.php?type=atom1.0" />
 
-    <script type="text/javascript" src="{{ asset_url('jscripts/jquery.js') }}"></script>
-    <script type="text/javascript" src="{{ asset_url('jscripts/jquery.plugins.min.js') }}"></script>
-    <script type="text/javascript" src="{{ asset_url('jscripts/general.js') }}"></script>
 
     <script type="text/javascript">
     <!--
@@ -75,8 +73,6 @@
     </script>
 
     {% block jscripts %}{% endblock %}
-
-    <script defer src="https://use.fontawesome.com/releases/v5.4.1/js/all.js" integrity="sha384-L469/ELG4Bg9sDQbl0hvjMq8pOcqFgkSpwhwnslzvVVGpDjYJ6wJJyYjvG3u8XW7" crossorigin="anonymous"></script>
 </head>
 <body>
 {% block header %}{% include 'partials/header.twig' %}{% endblock %}

--- a/inc/themes/core.default/frontend/templates/managegroup/managegroup.twig
+++ b/inc/themes/core.default/frontend/templates/managegroup/managegroup.twig
@@ -105,8 +105,8 @@
                 </button>
             </div>
         </section>
-        <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-        <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+        <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+        {{ asset('jscripts/select2/select2.min.js', static=true) }}
         <script type="text/javascript">
         <!--
         if({{ mybb.settings.use_xmlhttprequest }})
@@ -167,8 +167,8 @@
                     </button>
                 </div>
             </section>
-            <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-            <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+            <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+            {{ asset('jscripts/select2/select2.min.js', static=true) }}
             <script type="text/javascript">
             <!--
             if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/member/profile.twig
+++ b/inc/themes/core.default/frontend/templates/member/profile.twig
@@ -4,10 +4,6 @@
     <title>{{ trans('profile', memprofile.username) }} - {{ mybb.settings.bbname }}</title>
 {% endblock head %}
 
-{% block jscripts %}
-    <script type="text/javascript" src="{{ asset_url('jscripts/report.js') }}"></script>
-{% endblock jscripts %}
-
 {% block body %}
     <div class="profile">
         <header class="page-header profile__header">

--- a/inc/themes/core.default/frontend/templates/member/register.twig
+++ b/inc/themes/core.default/frontend/templates/member/register.twig
@@ -108,7 +108,7 @@
                         </div>
                     </section>
                     <link rel="stylesheet" href="{{ mybb.asset_url }}/jscripts/select2/select2.css">
-                    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+                    {{ asset('jscripts/select2/select2.min.js', static=true) }}
                     <script type="text/javascript">
                     <!--
                     if(use_xmlhttprequest == "1")
@@ -226,7 +226,7 @@
                                     lang.question_fetch_failure = "{{ lang.question_fetch_failure }}";
                                 // -->
                                 </script>
-                                <script type="text/javascript" src="{{ asset_url('jscripts/question.js') }}"></script>
+                                {{ asset('jscripts/question.js', static=true) }}
                                 <p class="field__description">{{ lang.question_note }}</p>
                                 <h2 class="field__name" id="question"><label for="answer">{{ registration.question }}</label></h2>
                                 <input type="text" class="textbox textbox--large" name="answer" value="" id="answer" />
@@ -258,6 +258,6 @@
             <input type="hidden" name="action" value="do_register" />
         </form>
         {{ validator_javascript|raw }}
-        <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/regvalidator.js?ver=1823"></script>
+        {{ asset('jscripts/regvalidator.js', static=true) }}
     </div>
 {% endblock body %}

--- a/inc/themes/core.default/frontend/templates/member/register.twig
+++ b/inc/themes/core.default/frontend/templates/member/register.twig
@@ -4,10 +4,6 @@
     <title>{{ lang.registration }} - {{ mybb.settings.bbname }}</title>
 {% endblock head %}
 
-{% block jscripts %}
-    <script type="text/javascript" src="{{ asset_url('jscripts/validate/jquery.validate.min.js') }}" defer></script>
-{% endblock jscripts %}
-
 {% block body %}
     <div class="page-content">
         <header class="page-header">

--- a/inc/themes/core.default/frontend/templates/memberlist/memberlist.twig
+++ b/inc/themes/core.default/frontend/templates/memberlist/memberlist.twig
@@ -99,8 +99,8 @@
         </form>
     </div>
 
-    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+    {{ asset('jscripts/select2/select2.min.js', static=true) }}
     <script type="text/javascript">
     <!--
     if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/memberlist/search.twig
+++ b/inc/themes/core.default/frontend/templates/memberlist/search.twig
@@ -83,8 +83,8 @@
         </form>
     </div>
 
-    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+    {{ asset('jscripts/select2/select2.min.js', static=true) }}
     <script type="text/javascript">
     <!--
     if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/misc/codebuttons.twig
+++ b/inc/themes/core.default/frontend/templates/misc/codebuttons.twig
@@ -1,7 +1,7 @@
 <link rel="stylesheet" href="{{ mybb.asset_url }}/jscripts/sceditor/themes/{{ theme.editortheme }}" type="text/css" media="all" />
-<script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/sceditor/jquery.sceditor.bbcode.min.js?ver=1832"></script>
-<script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/bbcodes_sceditor.js?ver=1832"></script>
-<script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/sceditor/plugins/undo.js?ver=1832"></script>
+{{ asset('jscripts/sceditor/jquery.sceditor.bbcode.min.js', static=true) }}
+{{ asset('jscripts/bbcodes_sceditor.js', static=true) }}
+{{ asset('jscripts/sceditor/plugins/undo.js', static=true) }}
 <script type="text/javascript">
     var partialmode = {{ mybb.settings.partialmode }},
     opt_editor = {

--- a/inc/themes/core.default/frontend/templates/misc/post_javascript.twig
+++ b/inc/themes/core.default/frontend/templates/misc/post_javascript.twig
@@ -13,4 +13,4 @@
     php_max_file_uploads = {{ php_max_file_uploads }};
     mybb_max_file_uploads = {{ mybb.settings.maxattachments }};
 </script>
-<script type="text/javascript" src="{{ asset_url('jscripts/post.js') }}"></script>
+{{ asset('jscripts/post.js', static=true) }}

--- a/inc/themes/core.default/frontend/templates/modcp/banuser.twig
+++ b/inc/themes/core.default/frontend/templates/modcp/banuser.twig
@@ -62,8 +62,8 @@
             </div>
         </section>
     </form>
-    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+    {{ asset('jscripts/select2/select2.min.js', static=true) }}
     <script type="text/javascript">
     <!--
     if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/modcp/finduser.twig
+++ b/inc/themes/core.default/frontend/templates/modcp/finduser.twig
@@ -97,7 +97,7 @@
         </section>
     </form>
     <link rel="stylesheet" href="{{ mybb.asset_url }}/jscripts/select2/select2.css?ver=1807" />
-    <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/select2/select2.min.js?ver=1806"></script>
+    {{ asset('jscripts/select2/select2.min.js', static=true) }}
     <script type="text/javascript">
     <!--
     if(use_xmlhttprequest == "1")

--- a/inc/themes/core.default/frontend/templates/modcp/reports.twig
+++ b/inc/themes/core.default/frontend/templates/modcp/reports.twig
@@ -4,10 +4,6 @@
     <title>{{ lang.report_center }} - {{ mybb.settings.bbname }}</title>
 {% endblock head %}
 
-{% block jscripts %}
-    <script type="text/javascript" src="{{ asset_url('jscripts/inline_reports.js') }}"></script>
-{% endblock jscripts %}
-
 {% block moderationHeader %}
     <header class="page-header">
         <h1 class="title title--page">{{ lang.report_center }}</h1>

--- a/inc/themes/core.default/frontend/templates/modcp/warninglogs.twig
+++ b/inc/themes/core.default/frontend/templates/modcp/warninglogs.twig
@@ -79,8 +79,8 @@
             </div>
         </section>
     </form>
-    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+    {{ asset('jscripts/select2/select2.min.js', static=true) }}
     <script type="text/javascript">
     <!--
     if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/partials/script.twig
+++ b/inc/themes/core.default/frontend/templates/partials/script.twig
@@ -1,0 +1,3 @@
+<script type="text/javascript" src="{{ asset.url }}"
+    {%- for name, value in asset.attributes %} {{ name }}="{{ value }}"{% endfor -%}
+></script>

--- a/inc/themes/core.default/frontend/templates/partials/style.twig
+++ b/inc/themes/core.default/frontend/templates/partials/style.twig
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="{{ asset.url }}"
+    {%- for name, value in asset.attributes %} {{ name }}="{{ value }}"{% endfor -%}
+>

--- a/inc/themes/core.default/frontend/templates/private/advanced_search.twig
+++ b/inc/themes/core.default/frontend/templates/private/advanced_search.twig
@@ -91,8 +91,8 @@
             </div>
         </div>
     </form>
-    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+    {{ asset('jscripts/select2/select2.min.js', static=true) }}
     <script type="text/javascript">
     <!--
     if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/private/send.twig
+++ b/inc/themes/core.default/frontend/templates/private/send.twig
@@ -4,10 +4,6 @@
     <title>{{ lang.compose_pm }} - {{ mybb.settings.bbname }}</title>
 {% endblock head %}
 
-{% block jscripts %}
-    <script type="text/javascript" src="{{ asset_url('jscripts/usercp.js') }}"></script>
-{% endblock jscripts %}
-
 {% block messengerHeader %}
     <header class="page-header">
         <h1 class="title title--page">{{ lang.compose_pm }}</h1>

--- a/inc/themes/core.default/frontend/templates/private/send.twig
+++ b/inc/themes/core.default/frontend/templates/private/send.twig
@@ -141,8 +141,8 @@
         }
     // -->
     </script>
-    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+    {{ asset('jscripts/select2/select2.min.js', static=true) }}
     <script type="text/javascript">
     <!--
     if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/reputation/reputation.twig
+++ b/inc/themes/core.default/frontend/templates/reputation/reputation.twig
@@ -8,7 +8,6 @@
         var delete_reputation_confirm = "{{ lang.delete_reputation_confirm }}";
     // -->
     </script>
-    <script type="text/javascript" src="{{ asset_url('jscripts/report.js') }}"></script>
 {% endblock head %}
 
 {% block body %}

--- a/inc/themes/core.default/frontend/templates/search/results_posts.twig
+++ b/inc/themes/core.default/frontend/templates/search/results_posts.twig
@@ -60,7 +60,7 @@
         {% if results.show_inline_moderation %}
             <div class="sort-results">
                 <h3 class="sort-results__title">{{ lang.inline_thread_moderation }}</h3>
-                <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/inline_moderation.js?ver=1838"></script>
+                {{ asset('jscripts/inline_moderation.js', static=true) }}
                 <form action="moderation.php" method="post" style="margin-top: 0; margin-bottom: 0;">
                     <input type="hidden" name="my_post_key" value="{{ mybb.post_code }}" />
                     <input type="hidden" name="tid" value="0" />

--- a/inc/themes/core.default/frontend/templates/search/results_threads.twig
+++ b/inc/themes/core.default/frontend/templates/search/results_threads.twig
@@ -60,7 +60,7 @@
             {% if results.show_inline_moderation %}
                 <div class="sort-results">
                     <h3 class="sort-results__title">{{ lang.inline_thread_moderation }}</h3>
-                    <script type="text/javascript" src="{{ mybb.asset_url }}/jscripts/inline_moderation.js?ver=1838"></script>
+                    {{ asset('jscripts/inline_moderation.js', static=true) }}
                     <form action="moderation.php" method="post">
                         <input type="hidden" name="my_post_key" value="{{ mybb.post_code }}" />
                         <input type="hidden" name="fid" value="0" />

--- a/inc/themes/core.default/frontend/templates/search/search.twig
+++ b/inc/themes/core.default/frontend/templates/search/search.twig
@@ -173,8 +173,8 @@
                 </div>
             </div>
         </form>
-        <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-        <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+        <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+        {{ asset('jscripts/select2/select2.min.js', static=true) }}
         <script type="text/javascript">
             <!--
             if({{ mybb.settings.use_xmlhttprequest }})

--- a/inc/themes/core.default/frontend/templates/showthread/moderation.twig
+++ b/inc/themes/core.default/frontend/templates/showthread/moderation.twig
@@ -66,7 +66,7 @@
     </div>
     {% if thread.showinlinemodoptions %}
         <div class="page-tools__item thread-moderation__inline">
-            <script type="text/javascript" src="{{ asset_url('jscripts/inline_moderation.js') }}"></script>
+            {{ asset('jscripts/inline_moderation.js', static=true) }}
             <form action="moderation.php" method="post" style="margin-top: 0; margin-bottom: 0;" id="inlinemoderation_options">
                 <input type="hidden" name="my_post_key" value="{{ mybb.post_code }}" />
                 <input type="hidden" name="tid" value="{{ thread.tid }}" />

--- a/inc/themes/core.default/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.default/frontend/templates/showthread/showthread.twig
@@ -27,9 +27,6 @@
         lang.restore_thread = "{{ lang.restore_thread }}";
     // -->
     </script>
-    <script type="text/javascript" src="{{ asset_url('jscripts/report.js') }}" defer></script>
-    <script type="text/javascript" src="{{ asset_url('jscripts/jeditable/jeditable.min.js') }}" defer></script>
-    <script type="text/javascript" src="{{ asset_url('jscripts/thread.js') }}" defer></script>
 {% endblock jscripts %}
 
 {% block body %}
@@ -216,7 +213,6 @@
                     lang.ratings_update_error = "{{ lang.ratings_update_error }}";
                 // -->
                 </script>
-                <script type="text/javascript" src="{{ asset_url('jscripts/rating.js') }}"></script>
                 <div class="inline_rating">
                     <strong class="float_left" style="padding-right: 10px;">{{ lang.thread_rating }}</strong>
                     <ul class="star_rating{{ thread.not_rated }}" id="rating_thread_{{ thread.tid }}">

--- a/inc/themes/core.default/frontend/templates/usercp/editlists.twig
+++ b/inc/themes/core.default/frontend/templates/usercp/editlists.twig
@@ -3,7 +3,7 @@
 {% block head %}
     <title>{{ lang.edit_lists }} - {{ mybb.settings.bbname }}</title>
     {# TO DO: FIX JS #}
-    {# <script type="text/javascript" src="{{ asset_url('jscripts/usercp.js') }}" defer></script> #}
+    {# <script type="text/javascript" src="{{ asset_url('jscripts/usercp.js', static=true) }}" defer></script> #}
 {% endblock head %}
 
 {% block accountHeader %}
@@ -40,8 +40,8 @@
                         </div>
                     </div>
                     {# TO DO: fix autocomplete (breaks layout) #}
-                    {# <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css') }}">
-                    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js') }}"></script>
+                    {# <link rel="stylesheet" href="{{ asset_url('jscripts/select2/select2.css', static=true) }}">
+                    <script type="text/javascript" src="{{ asset_url('jscripts/select2/select2.min.js', static=true) }}"></script>
                     <script type="text/javascript">
                         <!--
                         if(use_xmlhttprequest == "1")

--- a/inc/themes/core.default/manifest.json
+++ b/inc/themes/core.default/manifest.json
@@ -1,0 +1,7 @@
+{
+	"type": "mybb-theme",
+	"version": "1.9.0",
+	"extra": {
+		"title": "Base"
+	}
+}

--- a/inc/views/debug/components.twig
+++ b/inc/views/debug/components.twig
@@ -34,6 +34,14 @@
     </ul>
 {% endmacro %}
 
+{% macro text(data) %}
+    <ul>
+        <li>
+            <pre><code>{{ data }}</code></pre>
+        </li>
+    </ul>
+{% endmacro %}
+
 {% macro proportionGraph(data) %}
     {% set total = data|reduce((carry, value) => carry + value, 0) %}
 

--- a/inc/views/debug/index.twig
+++ b/inc/views/debug/index.twig
@@ -24,6 +24,8 @@
                         {{ components.definitionList(data) }}
                     {% elseif type == 'list' %}
                         {{ components.list(data) }}
+                    {% elseif type == 'text' %}
+                        {{ components.text(data) }}
                     {% elseif type == 'proportionGraph' %}
                         {{ components.proportionGraph(data) }}
                     {% elseif type == 'stopwatchGroupEvents' %}
@@ -49,7 +51,11 @@
             </section>
 
             <section>
-                {{ _self.visualize(data.status, 'definitionList', 'Status') }}
+                {{ _self.visualize(data.application, 'definitionList', 'MyBB Status') }}
+            </section>
+
+            <section>
+                {{ _self.visualize(data.server, 'definitionList', 'Server Status') }}
             </section>
 
             <section>
@@ -59,6 +65,9 @@
             <section>
                 <h2>Cache</h2>
                 {{ _self.visualize(data.cache, 'cacheCalls', 'Cache Calls (<code>' ~ mybb.config.cache_store ~ '</code>)') }}
+                {{ _self.visualize(data.cacheThemeletBuild, 'stopwatchGroupEvents', 'Themelet Cache Build') }}
+                {{ _self.visualize(data.cacheThemeletRead, 'stopwatchGroupEvents', 'Themelet Cache Read') }}
+                {{ _self.visualize(data.cacheThemeletWrite, 'stopwatchGroupEvents', 'Themelet Cache Write') }}
             </section>
 
             <section>
@@ -79,8 +88,10 @@
                 <h2>View</h2>
                 {{ _self.visualize(data.dbTemplates, 'list', 'DB Templates Used (Loaded for this Page)') }}
                 {{ _self.visualize(data.dbTemplatesUncached, 'list', 'DB Templates Requiring Additional Calls (Not Cached at Startup)') }}
+                {{ _self.visualize(data.viewHierarchicalResolution, 'stopwatchGroupEvents', 'Hierarchical Resolution') }}
                 {{ _self.visualize(data.twigTemplateEvents, 'stopwatchGroupEvents', 'Twig Templates') }}
-                {{ _self.visualize(data.assetPublishEvents, 'stopwatchGroupEvents','Asset Publishing') }}
+                {{ _self.visualize(data.twigProfile, 'text', 'Twig Profile') }}
+                {{ _self.visualize(data.assetPublishEvents, 'stopwatchGroupEvents', 'Asset Publishing') }}
             </section>
         </article>
     </body>

--- a/tests/Unit/Utilities/DecoratorTest.php
+++ b/tests/Unit/Utilities/DecoratorTest.php
@@ -1,0 +1,686 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Utilities;
+
+use MyBB\Utilities\Decorator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use MyBB\Tests\Unit\Utilities\Fixtures\Component\Component;
+use MyBB\Tests\Unit\Utilities\Fixtures\Component\Decorator\ComponentDecorator;
+use MyBB\Tests\Unit\Utilities\Fixtures\Component\Decorator\ComponentDecoratorA;
+use MyBB\Tests\Unit\Utilities\Fixtures\Component\Decorator\ComponentDecoratorB;
+
+final class DecoratorTest extends TestCase
+{
+    public static function decoratorReturnCases(): array
+    {
+        return [
+            [
+                'decorated' => new ComponentDecoratorA(
+                    new Component(),
+                ),
+                'decorator' => ComponentDecoratorA::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorA::class,
+                ],
+            ],
+            [
+                'decorated' => new ComponentDecoratorB(
+                    new ComponentDecoratorA(
+                        new Component(),
+                    ),
+                ),
+                'decorator' => ComponentDecoratorB::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorB::class,
+                ],
+            ],
+            [
+                'decorated' => new ComponentDecoratorB(
+                    new ComponentDecoratorA(
+                        new ComponentDecoratorA(
+                            new Component(),
+                        ),
+                    ),
+                ),
+                'decorator' => ComponentDecoratorA::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorA::class,
+                ],
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'decorator' => ComponentDecoratorA::class,
+                'expectedClassInstances' => [],
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorA::class,
+                ],
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorA::class,
+                ],
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorA::class,
+                ],
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'decorator' => ComponentDecoratorB::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorB::class,
+                ],
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expectedClassInstances' => [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorA::class,
+                ],
+            ],
+        ];
+    }
+
+    public static function decorationStatusCases(): array
+    {
+        return [
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'decorator' => ComponentDecoratorA::class,
+                'expected' => false,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expected' => true,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'decorator' => ComponentDecoratorB::class,
+                'expected' => false,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expected' => true,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expected' => true,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'decorator' => ComponentDecoratorB::class,
+                'expected' => true,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'decorator' => ComponentDecoratorA::class,
+                'expected' => true,
+            ],
+        ];
+    }
+
+    public static function nestedNavigationCases(): array
+    {
+        return [
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'expectedClassInstance' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'expectedClassInstance' => ComponentDecoratorA::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'expectedClassInstance' => ComponentDecoratorA::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'expectedClassInstance' => ComponentDecoratorB::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'expectedClassInstance' => ComponentDecoratorB::class,
+            ],
+        ];
+    }
+
+    public static function decoratedCallCases(): array
+    {
+        return [
+            // undecoratedMethod()
+            [
+                'decorated' => new Component(),
+                'method' => 'undecoratedMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'undecoratedMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'undecoratedMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'method' => 'undecoratedMethod',
+                'expected' => Component::class,
+            ],
+
+            // decoratedMethod()
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'cascadeMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'decoratedMethod',
+                'expected' => ComponentDecoratorA::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'method' => 'decoratedMethod',
+                'expected' => ComponentDecoratorB::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'decoratedMethod',
+                'expected' => ComponentDecoratorA::class,
+            ],
+
+            // addedCommonMethod()
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'addedCommonMethod',
+                'expected' => null,
+                'exception' => \BadMethodCallException::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'addedCommonMethod',
+                'expected' => ComponentDecoratorA::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'method' => 'addedCommonMethod',
+                'expected' => ComponentDecoratorB::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'addedCommonMethod',
+                'expected' => ComponentDecoratorA::class,
+            ],
+
+            // addedMethodA()
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'addedMethodA',
+                'expected' => null,
+                'exception' => \BadMethodCallException::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'addedMethodA',
+                'expected' => ComponentDecoratorA::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'method' => 'addedMethodA',
+                'expected' => ComponentDecoratorA::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'addedMethodA',
+                'expected' => ComponentDecoratorA::class,
+            ],
+
+            // addedMethodB()
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'addedMethodB',
+                'expected' => null,
+                'exception' => \BadMethodCallException::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'addedMethodB',
+                'expected' => null,
+                'exception' => \BadMethodCallException::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'method' => 'addedMethodB',
+                'expected' => ComponentDecoratorB::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'addedMethodB',
+                'expected' => ComponentDecoratorB::class,
+            ],
+
+            // immediateDecoratedMethod()
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'immediateDecoratedMethod',
+                'expected' => null,
+                'exception' => \BadMethodCallException::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'immediateDecoratedMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'method' => 'immediateDecoratedMethod',
+                'expected' => ComponentDecoratorA::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorB::class,
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'immediateDecoratedMethod',
+                'expected' => ComponentDecoratorB::class,
+            ],
+
+            // cascadeMethod()
+            [
+                'decorated' => new Component(),
+                'method' => 'cascadeMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'cascadeMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                ]),
+                'method' => 'cascadeMethod',
+                'expected' => Component::class,
+            ],
+            [
+                'decorated' => ComponentDecorator::decorate(new Component(), [
+                    ComponentDecoratorA::class,
+                    ComponentDecoratorB::class,
+                ]),
+                'method' => 'cascadeMethod',
+                'expected' => Component::class,
+            ],
+
+            // protectedMethod()
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'protectedMethod',
+                'expected' => null,
+                'exception' => \BadMethodCallException::class,
+            ],
+
+            // privateMethod()
+            [
+                'decorated' => ComponentDecorator::decorate(new Component()),
+                'method' => 'privateMethod',
+                'expected' => null,
+                'exception' => \BadMethodCallException::class,
+            ],
+        ];
+    }
+
+    public static function optionsCases(): array
+    {
+        return [
+            [
+                'decorated' => function () {
+                    $decorated = new ComponentDecoratorB(new Component());
+
+                    $decorated->setOption('value');
+
+                    return $decorated;
+                },
+                'method' => 'optionDependentMethod',
+                'expected' => 'value',
+            ],
+            [
+                'decorated' => function () {
+                    $decorator = new ComponentDecoratorB();
+
+                    $decorator->setOption('value');
+
+                    $decorated = ComponentDecorator::decorate(new Component(), [
+                        ComponentDecoratorA::class,
+                        $decorator,
+                    ]);
+
+                    return $decorated;
+                },
+                'method' => 'optionDependentMethod',
+                'expected' => 'value',
+            ],
+            [
+                'decorated' => function () {
+                    $decorated = ComponentDecorator::decorate(new Component(), [
+                        ComponentDecoratorA::class,
+                        ComponentDecoratorB::class,
+                    ]);
+
+                    ComponentDecoratorB::getInstancesDecorating($decorated)[0]->setOption('value');
+
+                    return $decorated;
+                },
+                'method' => 'optionDependentMethod',
+                'expected' => 'value',
+            ],
+        ];
+    }
+
+    public static function exceptionCases(): array
+    {
+        return [
+            // disallowed abstract class call
+            [
+                'callback' => fn () => Decorator::decorate(new Component()),
+                'exception' => \BadMethodCallException::class,
+            ],
+            [
+                'callback' => fn () => Decorator::decorates(new Component()),
+                'exception' => \BadMethodCallException::class,
+            ],
+            [
+                'callback' => fn () => Decorator::getInstancesDecorating(
+                    ComponentDecorator::decorate(new Component())
+                ),
+                'exception' => \BadMethodCallException::class,
+            ],
+
+            // disallowed base decorator class call
+            [
+                'callback' => fn () => ComponentDecorator::decorates(new Component()),
+                'exception' => \BadMethodCallException::class,
+            ],
+
+            // disallowed concrete decorator class call
+            [
+                'callback' => fn () => ComponentDecoratorA::decorate(new Component(), [
+                    ComponentDecoratorB::class,
+                ]),
+                'exception' => \BadMethodCallException::class,
+            ],
+
+            // invalid decorator
+            [
+                'callback' => fn () => ComponentDecorator::decorate(new Component(), [
+                    'nonexistentClass',
+                ]),
+                'exception' => \InvalidArgumentException::class,
+            ],
+            [
+                'callback' => fn () => ComponentDecorator::decorate(new Component(), [
+                    new \stdClass(),
+                ]),
+                'exception' => \InvalidArgumentException::class,
+            ],
+            [
+                'callback' => fn () => ComponentDecorator::decorate(new Component(), [
+                    \stdClass::class,
+                ]),
+                'exception' => \InvalidArgumentException::class,
+            ],
+            [
+                'callback' => fn () => ComponentDecorator::decorate(
+                    new Component(),
+                    [
+                        Decorator::class,
+                    ],
+                ),
+                'exception' => \InvalidArgumentException::class,
+            ],
+
+            // call to protected members via magic methods
+            [
+                'callback' => function () {
+                    $decoratedComponent = ComponentDecorator::decorate(new Component());
+
+                    $decoratedComponent->getDecorated();
+                },
+                'exception' => \BadMethodCallException::class,
+            ],
+
+            // assigning decorator instance to more than one stack
+            [
+                'callback' => function () {
+                    $decorator = new ComponentDecoratorB();
+
+                    ComponentDecorator::decorate(new Component(), [
+                        $decorator,
+                    ]);
+                    ComponentDecorator::decorate(new Component(), [
+                        $decorator,
+                    ]);
+                },
+                'exception' => \LogicException::class,
+            ],
+        ];
+    }
+
+    /**
+     * @param class-string<Decorator> $decorator
+     */
+    #[DataProvider('decoratorReturnCases')]
+    public function testDecoratorReturn(Decorator $decorated, string $decorator, $expectedClassInstances)
+    {
+        $result = $decorator::getInstancesDecorating($decorated);
+
+        static::assertIsArray($result);
+        static::assertContainsOnly('object', $result);
+
+        $classes = array_map('get_class', $result);
+
+        static::assertEquals($expectedClassInstances, $classes);
+    }
+
+    /**
+     * @param class-string<Decorator> $decorator
+     */
+    #[DataProvider('decorationStatusCases')]
+    public function testDecorationStatus(Decorator $decorated, string $decorator, bool $expected)
+    {
+        $result = $decorator::decorates($decorated);
+
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * @param class-string<Decorator> $expectedClassInstance
+     */
+    #[DataProvider('nestedNavigationCases')]
+    public function testNestedNavigation(ComponentDecorator $decorated, string $expectedClassInstance)
+    {
+        $result = $decorated->getDecoratedObject();
+
+        static::assertInstanceOf($expectedClassInstance, $result);
+    }
+
+    #[DataProvider('decoratedCallCases')]
+    public function testDecoratedCall(object $decorated, string $method, string $expected = null, string $exception = null)
+    {
+        if ($exception !== null) {
+            $this->expectException($exception);
+        }
+
+        $result = $decorated->$method();
+
+        if ($expected !== null) {
+            static::assertEquals($expected, $result);
+        }
+    }
+
+    #[DataProvider('optionsCases')]
+    public function testOptions(object $decorated, string $method, string $expected = null, string $exception = null)
+    {
+        if ($exception !== null) {
+            $this->expectException($exception);
+        }
+
+        if (is_callable($decorated)) {
+            $decorated = $decorated();
+        }
+
+        $result = $decorated->$method();
+
+        if ($expected !== null) {
+            static::assertEquals($expected, $result);
+        }
+    }
+
+    /**
+     * @param class-string<\Exception> $exception
+     */
+    #[DataProvider('exceptionCases')]
+    public function testException(callable $callback, string $exception)
+    {
+        $this->expectException($exception);
+
+        $callback();
+    }
+
+    public function testDecorationException()
+    {
+        $method = 'noopMethod';
+        $class = ComponentDecoratorA::class;
+
+        $this->expectExceptionMessage('`' . $method . '()` cannot be called with `' . $class . '`');
+
+        $decorated = ComponentDecorator::decorate(new Component(), [
+            ComponentDecoratorA::class,
+        ]);
+
+        $decorated->$method();
+    }
+}

--- a/tests/Unit/Utilities/Fixtures/Component/Component.php
+++ b/tests/Unit/Utilities/Fixtures/Component/Component.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Tests\Unit\Utilities\Fixtures\Component;
+
+class Component implements ComponentInterface
+{
+    public function undecoratedMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    public function decoratedMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    public function cascadeMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    protected function protectedMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    private function privateMethod(): string
+    {
+        return __CLASS__;
+    }
+}

--- a/tests/Unit/Utilities/Fixtures/Component/ComponentInterface.php
+++ b/tests/Unit/Utilities/Fixtures/Component/ComponentInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Tests\Unit\Utilities\Fixtures\Component;
+
+interface ComponentInterface {}

--- a/tests/Unit/Utilities/Fixtures/Component/Decorator/ComponentDecorator.php
+++ b/tests/Unit/Utilities/Fixtures/Component/Decorator/ComponentDecorator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Tests\Unit\Utilities\Fixtures\Component\Decorator;
+
+use MyBB\Utilities\Decorator;
+use MyBB\Tests\Unit\Utilities\Fixtures\Component\ComponentInterface;
+
+class ComponentDecorator extends Decorator implements ComponentInterface {}

--- a/tests/Unit/Utilities/Fixtures/Component/Decorator/ComponentDecoratorA.php
+++ b/tests/Unit/Utilities/Fixtures/Component/Decorator/ComponentDecoratorA.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Tests\Unit\Utilities\Fixtures\Component\Decorator;
+
+use MyBB\Tests\Unit\Utilities\Fixtures\Component\ComponentInterface;
+
+class ComponentDecoratorA extends ComponentDecorator implements ComponentInterface
+{
+    public function decoratedMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    public function immediateDecoratedMethod(): string
+    {
+        return $this->getDecorated()->decoratedMethod();
+    }
+
+    public function cascadeMethod(): string
+    {
+        return $this->getDecorated()->cascadeMethod();
+    }
+
+    public function addedCommonMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    public function addedMethodA(): string
+    {
+        return __CLASS__;
+    }
+
+    public function noopMethod(): void
+    {
+        throw self::decoratedCallException();
+    }
+
+    public function getDecoratedObject(): object
+    {
+        return $this->getDecorated();
+    }
+
+    protected function protectedMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    private function privateMethod(): string
+    {
+        return __CLASS__;
+    }
+}

--- a/tests/Unit/Utilities/Fixtures/Component/Decorator/ComponentDecoratorB.php
+++ b/tests/Unit/Utilities/Fixtures/Component/Decorator/ComponentDecoratorB.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Tests\Unit\Utilities\Fixtures\Component\Decorator;
+
+use MyBB\Tests\Unit\Utilities\Fixtures\Component\ComponentInterface;
+
+class ComponentDecoratorB extends ComponentDecorator implements ComponentInterface
+{
+    private string $option;
+
+    public function decoratedMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    public function immediateDecoratedMethod(): string
+    {
+        return $this->getDecorated()->decoratedMethod();
+    }
+
+    public function cascadeMethod(): string
+    {
+        return $this->getDecorated()->cascadeMethod();
+    }
+
+    public function addedCommonMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    public function addedMethodB(): string
+    {
+        return __CLASS__;
+    }
+
+    public function getDecoratedObject(): object
+    {
+        return $this->getDecorated();
+    }
+
+    public function optionDependentMethod(): string
+    {
+        return $this->option;
+    }
+
+    public function setOption(string $value): void
+    {
+        $this->option = $value;
+    }
+
+    protected function protectedMethod(): string
+    {
+        return __CLASS__;
+    }
+
+    private function privateMethod(): string
+    {
+        return __CLASS__;
+    }
+}

--- a/tests/Unit/View/LocatorTest.php
+++ b/tests/Unit/View/LocatorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace MyBB\View;
+
+use MyBB\View\Locator\StaticLocator;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\ThemeletLocator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class LocatorTest extends TestCase
+{
+    public static function composeStringCases(): array
+    {
+        return [
+            [
+                StaticLocator::composeString([
+                    'path' => 'general.js',
+                ]),
+                './general.js',
+            ],
+            [
+                ThemeletLocator::composeString([
+                    'type' => ResourceType::STYLE,
+                    'namespace' => 'frontend',
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ]),
+                '@frontend/styles/main/header.css',
+            ],
+            [
+                ThemeletLocator::composeString([
+                    'type' => ResourceType::STYLE,
+                    'namespace' => 'frontend',
+                    'filename' => 'header.css',
+                ]),
+                '@frontend/styles/header.css',
+            ],
+            [
+                ThemeletLocator::composeString([
+                    'type' => ResourceType::STYLE,
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ]),
+                'styles/main/header.css',
+            ],
+            [
+                ThemeletLocator::composeString([
+                    'namespace' => 'frontend',
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ]),
+                '@frontend/main/header.css',
+            ],
+            [
+                ThemeletLocator::composeString([
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ]),
+                'main/header.css',
+            ],
+        ];
+    }
+
+    #[DataProvider('composeStringCases')]
+    public function testComposeString(string $string, string $expectedString)
+    {
+        $this->assertSame($expectedString, $string);
+    }
+
+    public static function decomposeStringCases(): array
+    {
+        return [
+            [
+                '/a/b/c.css',
+                [],
+                StaticLocator::class,
+                [
+                    'path' => '/a/b/c.css',
+                ],
+            ],
+            [
+                '@frontend/styles/main/header.css',
+                [],
+                ThemeletLocator::class,
+                [
+                    'type' => ResourceType::STYLE,
+                    'namespace' => 'frontend',
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ],
+            ],
+            [
+                '@frontend/main/header.css',
+                [
+                    'type' => ThemeletLocator::COMPONENT_UNSET,
+                ],
+                ThemeletLocator::class,
+                [
+                    'namespace' => 'frontend',
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ],
+            ],
+            [
+                'styles/main/header.css',
+                [
+                    'namespace' => ThemeletLocator::COMPONENT_UNSET,
+                ],
+                ThemeletLocator::class,
+                [
+                    'type' => ResourceType::STYLE,
+                    'namespace' => null,
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ],
+            ],
+            [
+                'main/header.css',
+                [
+                    'type' => ThemeletLocator::COMPONENT_UNSET,
+                    'namespace' => ThemeletLocator::COMPONENT_UNSET,
+                ],
+                ThemeletLocator::class,
+                [
+                    'type' => null,
+                    'namespace' => null,
+                    'group' => 'main',
+                    'filename' => 'header.css',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('decomposeStringCases')]
+    public function testDecomposeString(string $string, array $directives, string $expectedClass, array $expectedProperties)
+    {
+        $locator = Locator::fromString($string, $directives);
+
+        $this->assertInstanceOf($expectedClass, $locator);
+
+        foreach ($expectedProperties as $name => $value) {
+            $this->assertSame($value, $locator->$name);
+        }
+    }
+}


### PR DESCRIPTION
Internal logic for the 1.9 theme system (_View_).

Adds generic utilities (`MyBB\Utilities`), new Extension-related code (`MyBB\Extensions`), abstraction for file-based inheritable entities (`MyBB\Cargo`), and View modules (`MyBB\View`) and runtime integration.

Relevant remaining work:
- [x] **Deferred asset management**

  `rybakit/twig-deferred-extension`, used in #4601 to append assets in `<head>` using `asset()` in Twig templates, appears not functional on recent Twig versions (rybakit/twig-deferred-extension#20), and custom logic may be necessary

- [x] **Move `MyBB\template()` to `MyBB\View\template()`**

- [x] **Use `asset(...)` for style assets**

- [x] #3673


Resolves #3689

References:
- [`view/ARCHITECTURE.md`](https://github.com/dvz/mybb/blob/feature-1.9-view/inc/src/View/ARCHITECTURE.md)
- https://github.com/mybb/meta/blob/main/architecture/mybb-1.9-theme-system.md#asset-management

Next steps:
- **Database theme information**

  Adjust database table structures, and replace the hardcoded base theme package name with [information from the database](https://github.com/mybb/meta/blob/main/architecture/mybb-1.9-theme-system.md#theme-runtime-information)

  #4953

- **Adjust ACP Theme management UI (installed Themes, legacy resources)**
  - #4954
