### PR TITLE
fix: undefined attach_add_options variable in editpost

### DIFF
--- a/editpost.php
+++ b/editpost.php
@@ -696,13 +696,13 @@ if(!$mybb->input['action'] || $mybb->input['action'] == "editpost")
 			$lang->attach_usage = "";
 		}
 
-		$attach_update_options = '';
-
+		$attach_add_options = '';
 		if($mybb->settings['maxattachments'] == 0 || ($mybb->settings['maxattachments'] != 0 && $attachcount < $mybb->settings['maxattachments']) && !$noshowattach)
 		{
 			eval("\$attach_add_options = \"".$templates->get("post_attachments_add")."\";");
 		}
 
+		$attach_update_options = '';
 		if(($mybb->usergroup['caneditattachments'] || $forumpermissions['caneditattachments']) && $attachcount > 0)
 		{
 			eval("\$attach_update_options = \"".$templates->get("post_attachments_update")."\";");


### PR DESCRIPTION
- Defined  `$attach_add_options`.
- Moved `$attach_update_options` to match what is done in `newreply.php` and `newthread.php`.

Resolves #4847

