### PR TITLE
fix: avoid warning for undefined ['QUERY_STRING']

### DIFF
--- a/admin/inc/class_page.php
+++ b/admin/inc/class_page.php
@@ -422,7 +422,7 @@ EOF;
 		}
 		// Make query string nice and pretty so that user can go to his/her preferred destination
 		$query_string = '';
-		if($_SERVER['QUERY_STRING'])
+		if(isset($_SERVER['QUERY_STRING']) && $_SERVER['QUERY_STRING'] != '')
 		{
 			$query_string = '?'.preg_replace('#adminsid=(.{32})#i', '', $_SERVER['QUERY_STRING']);
 			$query_string = preg_replace('#my_post_key=(.{32})#i', '', $query_string);


### PR DESCRIPTION
When logging in and going directly to ACP on PHP 8.x, getting the following error:
```
Undefined array key "QUERY_STRING" - Line: 425 - File: admin/inc/class_page.php PHP 8.3.6 (Linux)
```

- Made sure QUERY_STRING exists and is not an empty string.

