### PR TITLE
fix: support IP addresses in mycode_auto_url

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1695,19 +1695,23 @@ class postParser
 		// Don't create links within existing links (handled up-front in the callback function).
 		$message = preg_replace_callback(
 			"~
-				<a\\s[^>]*>.*?</a>|								# match and return existing links
-				(?<=^|[\s\(\)\[\>])								# character preceding the link
+				<a\\s[^>]*>.*?</a>|													# match and return existing links
+				(?<=^|[\s\(\)\[\>])													# character preceding the link
 				(?P<prefix>
-					(?:http|https|ftp|news|irc|ircs|irc6)://|	# scheme, or
-					(?:www|ftp)\.								# common subdomain
+					(?:http|https|ftp|news|irc|ircs|irc6)://|						# scheme, or
+					(?:www|ftp)\.													# common subdomain
 				)
 				(?P<link>
-					(?:[^\/\"\s\<\[\.]+\.)*[\w]+				# host
-					(?::[0-9]+)?								# port
-					(?:/(?:[^\"\s<\[&]|\[\]|&(?:amp|lt|gt);)*)?	# path, query, fragment; exclude unencoded characters
-					[\w\/\)]
+					(?:
+						\[[0-9a-fA-F:]+(?:%[0-9a-zA-Z._-]+)?\]|						# IPv6 address with optional zone
+						(?:(?:\d{1,3}\.){3}\d{1,3})|								# IPv4 address
+						(?:[^\/\"\s<\[\]\.]+\.)*[\w-]+								# domain name
+					)
+					(?::[0-9]+)?													# optional port number
+					(?:/(?:[^\"\s<\[&]|\[\]|&(?:amp|lt|gt);)*|[?#][^\"\s<\[&]*)?	# optional path, query or fragment (excluding unencoded characters)
 				)
-				(?![^<>]*?>)									# not followed by unopened > (within HTML tags)
+				(?<![.,?!])															# exclude trailing punctuation
+				(?![^<>]*?>)														# not followed by unopened > (within HTML tags)
 			~iusx",
 			array($this, 'mycode_auto_url_callback'),
 			$message

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1710,7 +1710,7 @@ class postParser
 					(?::[0-9]+)?													# optional port number
 					(?:/(?:[^\"\s<\[&]|\[\]|&(?:amp|lt|gt);)*|[?#][^\"\s<\[&]*)?	# optional path, query or fragment (excluding unencoded characters)
 				)
-				(?<![.,?!])															# exclude trailing punctuation
+				(?<![.,;:`'\"?!])													# exclude trailing punctuation
 				(?![^<>]*?>)														# not followed by unopened > (within HTML tags)
 			~iusx",
 			array($this, 'mycode_auto_url_callback'),

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1695,25 +1695,25 @@ class postParser
 		// Don't create links within existing links (handled up-front in the callback function).
 		$message = preg_replace_callback(
 			"~
-				<a\\s[^>]*>.*?</a>|													# match and return existing links
-				(?<=^|[\s\(\)\[\>])													# character preceding the link
+				<a\\s[^>]*>.*?</a>|									# match and return existing links
+				(?<=^|[\s\(\)\[\>])									# character preceding the link
 				(?P<prefix>
-					(?:http|https|ftp|news|irc|ircs|irc6)://|						# scheme, or
-					(?:www|ftp)\.													# common subdomain
+					(?:http|https|ftp|news|irc|ircs|irc6)://|		# scheme, or
+					(?:www|ftp)\.									# common subdomain
 				)
 				(?P<link>
 					(?:
-						\[[0-9a-fA-F:]+(?:%[0-9a-zA-Z._-]+)?\]|						# IPv6 address with optional zone
-						(?:(?:\d{1,3}\.){3}\d{1,3})|								# IPv4 address
-						(?:[^\/\"\s<\[\]\.]+\.)*[\w-]+								# domain name
+						\[[0-9a-fA-F:]+(?:%[0-9a-zA-Z._-]+)?\]|		# IPv6 address with optional zone
+						(?:(?:\d{1,3}\.){3}\d{1,3})|				# IPv4 address
+						(?:[^\/\"\s<\[\]\.]+\.)*[\w-]+				# domain name
 					)
-					(?::[0-9]+)?													# optional port number
-					(?:/[^\"\s<\[&?#]*)?  											# optional path
-					(?:\?(?:[^\"\s<\[?#]|&(?:amp|lt|gt);)*)?						# optional query
-					(?:\#(?:[^\"\s<\[]|&(?:amp|lt|gt);)*)?							# optional fragment									
+					(?::[0-9]+)?									# optional port number
+					(?:/[^\"\s<\[\]&?#]*)?							# optional path
+					(?:\?(?:[^\"\s<\[\]?#]|\[\]|&(?:amp|lt|gt);)*)?	# optional query
+					(?:\#(?:[^\"\s<\[\]]|&(?:	|lt|gt);)*)?		# optional fragment
 				)
-				(?<![.,;:`'\"?!])													# exclude trailing punctuation
-				(?![^<>]*?>)														# not followed by unopened > (within HTML tags)
+				(?<![.,;:`'\"?!])									# exclude trailing punctuation
+				(?![^<>]*?>)										# not followed by unopened > (within HTML tags)
 			~iusx",
 			array($this, 'mycode_auto_url_callback'),
 			$message

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1708,7 +1708,9 @@ class postParser
 						(?:[^\/\"\s<\[\]\.]+\.)*[\w-]+								# domain name
 					)
 					(?::[0-9]+)?													# optional port number
-					(?:/(?:[^\"\s<\[&]|\[\]|&(?:amp|lt|gt);)*|[?#][^\"\s<\[&]*)?	# optional path, query or fragment (excluding unencoded characters)
+					(?:/[^\"\s<\[&?#]*)?  											# optional path
+					(?:\?(?:[^\"\s<\[?#]|&(?:amp|lt|gt);)*)?						# optional query
+					(?:\#(?:[^\"\s<\[]|&(?:amp|lt|gt);)*)?							# optional fragment									
 				)
 				(?<![.,;:`'\"?!])													# exclude trailing punctuation
 				(?![^<>]*?>)														# not followed by unopened > (within HTML tags)

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1710,7 +1710,7 @@ class postParser
 					(?::[0-9]+)?									# optional port number
 					(?:/[^\"\s<\[\]&?#]*)?							# optional path
 					(?:\?(?:[^\"\s<\[\]?#]|\[\]|&(?:amp|lt|gt);)*)?	# optional query
-					(?:\#(?:[^\"\s<\[\]]|&(?:	|lt|gt);)*)?		# optional fragment
+					(?:\#(?:[^\"\s<\[\]]|&(?:amp|lt|gt);)*)?		# optional fragment
 				)
 				(?<![.,;:`'\"?!])									# exclude trailing punctuation
 				(?![^<>]*?>)										# not followed by unopened > (within HTML tags)

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1695,25 +1695,28 @@ class postParser
 		// Don't create links within existing links (handled up-front in the callback function).
 		$message = preg_replace_callback(
 			"~
-				<a\\s[^>]*>.*?</a>|									# match and return existing links
-				(?<=^|[\s\(\)\[\>])									# character preceding the link
+				<a\\s[^>]*>.*?</a>|								# match and return existing links
+				(?<=^|[\s\(\)\[\>])								# character preceding the link
 				(?P<prefix>
-					(?:http|https|ftp|news|irc|ircs|irc6)://|		# scheme, or
-					(?:www|ftp)\.									# common subdomain
+					(?:http|https|ftp|news|irc|ircs|irc6)://|	# scheme, or
+					(?:www|ftp)\.								# common subdomain
 				)
 				(?P<link>
 					(?:
-						\[[0-9a-fA-F:]+(?:%[0-9a-zA-Z._-]+)?\]|		# IPv6 address with optional zone
-						(?:(?:\d{1,3}\.){3}\d{1,3})|				# IPv4 address
-						(?:[^\/\"\s<\[\]\.]+\.)*[\w-]+				# domain name
+						\[[0-9a-fA-F:]+(?:%[0-9a-zA-Z._-]+)?\]|	# IPv6 address with optional zone
+						(?:(?:\d{1,3}\.){3}\d{1,3})|			# IPv4 address
+						(?:[^\/\"\s<\[\]\.]+\.)*[\w-]+			# domain name
 					)
-					(?::[0-9]+)?									# optional port number
-					(?:/[^\"\s<\[\]&?#]*)?							# optional path
-					(?:\?(?:[^\"\s<\[\]?#]|\[\]|&(?:amp|lt|gt);)*)?	# optional query
-					(?:\#(?:[^\"\s<\[\]]|&(?:amp|lt|gt);)*)?		# optional fragment
+					(?::[0-9]+)?								# optional port number
+					(?:/[^\"\s<\[\]&?#]*)?						# optional path
+					(?:\?(?:[^\"\s<\[\]?#]|\[\])*)?				# optional query
+					(?:\#(?:[^\"\s<\[\]])*)?					# optional fragment
 				)
-				(?<![.,;:`'\"?!])									# exclude trailing punctuation
-				(?![^<>]*?>)										# not followed by unopened > (within HTML tags)
+				(?:
+					(?<=&amp;)|(?<=&lt;)|(?<=&gt;)|				# allow trailing entities
+					(?<![.,:`'\"?!])(?<!&)						# exclude other trailing punctuation
+				)
+				(?![^<>]*?>)									# not followed by unopened > (within HTML tags)
 			~iusx",
 			array($this, 'mycode_auto_url_callback'),
 			$message


### PR DESCRIPTION
### Changed

- Modified the expression for `mycode_auto_url` to support additional IPv4/IPv6 parsing:
  - Added `[?#][^\"\s<\[&]*` as an alternative for path/query/fragment parsing.
  - Introduced a negative lookbehind (`(?<![.,;:'\"?!])`) to account for the removal of `[\w\/\)]` (trailing punctuation).
- Updated host expression:
  - Explicitly allowed dashes in domain labels.
  - Explicitly excluded closing bracket from valid characters.
- Split the path/query/fragment expression for better readability.

### Fixed
- Fixed handling of query/fragment without a preceding / (e.g., example.com?query, example.com#fragment).
- Fixed IPv4 address-only URLs that end with a single digit (e.g., 1.2.3.4).
- Fixed IPv6 addresses.

Resolves #3813 
Resolves #4727 