### PR TITLE
fix: undefined $posticons when post icons are not allowed in a forum

### DIFF
--- a/editpost.php
+++ b/editpost.php
@@ -603,6 +603,7 @@ if(!$mybb->input['action'] || $mybb->input['action'] == "editpost")
 	$plugins->run_hooks("editpost_action_start");
 
 	$preview = '';
+	$posticons = '';
 
 	if($forum['allowpicons'] != 0)
 	{

--- a/newreply.php
+++ b/newreply.php
@@ -922,6 +922,7 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 	}
 	${$subscription_method.'subscribe'} = "checked=\"checked\" ";
 
+	$posticons = '';
 	if($forum['allowpicons'] != 0)
 	{
 		$posticons = get_post_icons();

--- a/newthread.php
+++ b/newthread.php
@@ -106,6 +106,8 @@ if($mybb->settings['bbcodeinserter'] != 0 && $forum['allowmycode'] != 0 && (!$my
 	}
 }
 
+$posticons = '';
+
 // Does this forum allow post icons? If so, fetch the post icons.
 if($forum['allowpicons'] != 0)
 {


### PR DESCRIPTION
### Fixed

- Errors when post icons are not allowed forum a forum:
  - when creating a new thread
  - when replying to an existing thread
  - when editing an existing message

Resolves #4888 

