### PR TITLE
fix(installer): duplicate port in suggested board URL

### DIFF
--- a/inc/src/Maintenance/functions_data.php
+++ b/inc/src/Maintenance/functions_data.php
@@ -950,8 +950,12 @@ function getSuggestedBoardUrl(): ?string
         $url = httpRequestOverSecureTransport() ? 'https' : 'http';
         $url .= '://' . $_SERVER['HTTP_HOST'];
 
-        if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 443])) {
-            $url .= ':' . (int)$_SERVER['SERVER_PORT'];
+        if (
+            !empty($_SERVER['SERVER_PORT']) &&
+            !in_array($_SERVER['SERVER_PORT'], [80, 443]) &&
+            !str_contains($_SERVER['HTTP_HOST'], ':')
+        ) {
+            $url .= ':' . (int) $_SERVER['SERVER_PORT'];
         }
 
         if (!empty($_SERVER['SCRIPT_NAME'])) {

--- a/inc/src/Maintenance/functions_data.php
+++ b/inc/src/Maintenance/functions_data.php
@@ -955,7 +955,7 @@ function getSuggestedBoardUrl(): ?string
             !in_array($_SERVER['SERVER_PORT'], [80, 443]) &&
             !str_contains($_SERVER['HTTP_HOST'], ':')
         ) {
-            $url .= ':' . (int) $_SERVER['SERVER_PORT'];
+            $url .= ':' . (int)$_SERVER['SERVER_PORT'];
         }
 
         if (!empty($_SERVER['SCRIPT_NAME'])) {


### PR DESCRIPTION
### Fixed

- Duplicate non standard port when port is already present in `$_SERVER['HTTP_HOST']`.

### Example

![image](https://github.com/user-attachments/assets/5244cea2-f87f-4653-a38c-5f5fb2ec6187)

