### PR TITLE
fix: SQL error when accessing private inbox

### DIFF
--- a/private.php
+++ b/private.php
@@ -2029,7 +2029,7 @@ if(!$mybb->input['action'])
 	$private['orderarrow'][$sortby] = true;
 
 	// Do Multi Pages
-	$query = $db->simple_select("privatemessages", "COUNT(*) AS total", "uid='{$mybb->user['uid']}' AND folder='{$folder}'{$unread_cond}");
+	$query = $db->simple_select("privatemessages", "COUNT(*) AS total", "uid='{$mybb->user['uid']}' AND folder='{$fid}'{$unread_cond}");
 	$pmscount = $db->fetch_field($query, "total");
 
 	if(!$mybb->settings['threadsperpage'] || (int)$mybb->settings['threadsperpage'] < 1)


### PR DESCRIPTION
When trying to access the private messages inbox, got the following error:
```
SQL Error
    0 - ERROR: invalid input syntax for type smallint: "Array" LINE 1: ...l FROM mybb_privatemessages WHERE uid='1' AND folder='Array' ^
Query
    SELECT COUNT(*) AS total FROM mybb_privatemessages WHERE uid='1' AND folder='Array'
```

### Fixed

- Used `fid` instead of `folder`.