### PR TITLE
chore(settings): remove unused php mail additional settings

### DIFF
--- a/admin/modules/config/settings.php
+++ b/admin/modules/config/settings.php
@@ -2006,7 +2006,6 @@ function print_setting_peekers()
 		'new Peeker($(".setting_enablepms"), $("#row_setting_pmsallowhtml, #row_setting_pmsallowmycode, #row_setting_pmsallowsmilies, #row_setting_pmsallowimgcode, #row_setting_pmsallowvideocode, #row_setting_pmquickreply, #row_setting_pmfloodsecs, #row_setting_showpmip, #row_setting_maxpmquotedepth"), 1, true)',
 		'new Peeker($(".setting_smilieinserter"), $("#row_setting_smilieinsertertot, #row_setting_smilieinsertercols"), 1, true)',
 		'new Peeker($("#setting_mail_handler"), $("#row_setting_smtp_host, #row_setting_smtp_port, #row_setting_smtp_user, #row_setting_smtp_pass, #row_setting_secure_smtp"), "smtp", false)',
-		'new Peeker($("#setting_mail_handler"), $("#row_setting_mail_parameters"), "mail", false)',
 		'new Peeker($("#setting_captchaimage"), $("#row_setting_recaptchapublickey, #row_setting_recaptchaprivatekey"), /(4|5|8)/, false)',
 		'new Peeker($("#setting_captchaimage"), $("#row_setting_recaptchascore"), /(8)/, false)',
 		'new Peeker($("#setting_captchaimage"), $("#row_setting_hcaptchapublickey, #row_setting_hcaptchaprivatekey"), /(6|7)/, false)',

--- a/inc/seeds/settings.xml
+++ b/inc/seeds/settings.xml
@@ -2328,14 +2328,6 @@ smtp=SMTP mail]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
-		<setting name="mail_parameters">
-			<title>Additional Parameters for PHP's mail()</title>
-			<description><![CDATA[<strong>Not supported.</strong> Additional parameters can be set in the <a href="https://docs.mybb.com/1.8/faq/mail/#additional-parameters-for-phps-mail">Configuration File</a> instead.]]></description>
-			<disporder>7</disporder>
-			<optionscode><![CDATA[text]]></optionscode>
-			<settingvalue><![CDATA[]]></settingvalue>
-			<isdefault>1</isdefault>
-		</setting>
 		<setting name="mail_logging">
 			<title>Mail Logging</title>
 			<description><![CDATA[This setting allows you to set how to log outgoing emails sent via the 'Send Thread to a Friend' feature. In some countries it is illegal to log all content.]]></description>


### PR DESCRIPTION
### Removed

- PHP mail additional parameters setting.

### Migration

`delete from mybb_settings where name = 'mail_parameters';` to be added to #4831 

Resolves #4592 

