### PR TITLE
refactor(acp): use local fonts in theme

### DIFF
--- a/admin/styles/default/fonts.css
+++ b/admin/styles/default/fonts.css
@@ -1,0 +1,20 @@
+@font-face {
+    font-family: 'Asap';
+    src: url('/jscripts/fonts/Asap/Asap-VariableFont_wght.ttf') format('truetype');
+    font-weight: 400 600;
+    font-style: normal;
+}
+  
+@font-face {
+    font-family: 'Asap';
+    src: url('/jscripts/fonts/Asap/Asap-Italic-VariableFont_wght.ttf') format('truetype');
+    font-weight: 400 600;
+    font-style: italic;
+}
+  
+@font-face {
+    font-family: 'Open Sans';
+    src: url('/jscripts/fonts/Open_Sans/OpenSans-VariableFont_wdth,wght.ttf') format('truetype');
+    font-weight: 400 700;
+    font-style: normal;
+}

--- a/admin/styles/default/fonts.css
+++ b/admin/styles/default/fonts.css
@@ -1,20 +1,20 @@
 @font-face {
     font-family: 'Asap';
-    src: url('/jscripts/fonts/Asap/Asap-VariableFont_wght.ttf') format('truetype');
+    src: url('../../../jscripts/fonts/Asap/Asap-VariableFont_wght.ttf') format('truetype');
     font-weight: 400 600;
     font-style: normal;
 }
-  
+
 @font-face {
     font-family: 'Asap';
-    src: url('/jscripts/fonts/Asap/Asap-Italic-VariableFont_wght.ttf') format('truetype');
+    src: url('../../../jscripts/fonts/Asap/Asap-Italic-VariableFont_wght.ttf') format('truetype');
     font-weight: 400 600;
     font-style: italic;
 }
-  
+
 @font-face {
     font-family: 'Open Sans';
-    src: url('/jscripts/fonts/Open_Sans/OpenSans-VariableFont_wdth,wght.ttf') format('truetype');
+    src: url('../../../jscripts/fonts/Open_Sans/OpenSans-VariableFont_wdth,wght.ttf') format('truetype');
     font-weight: 400 700;
     font-style: normal;
 }

--- a/admin/styles/default/login.css
+++ b/admin/styles/default/login.css
@@ -3,7 +3,7 @@
  * Login CSS
  */
 
-@import url('https://fonts.googleapis.com/css?family=Asap:400,600,600i|Open+Sans:400,700&display=swap');
+@import url('fonts.css');
 
 body {
 	font-family: 'Open Sans', sans-serif;

--- a/admin/styles/default/main.css
+++ b/admin/styles/default/main.css
@@ -3,7 +3,7 @@
  * Main CSS
  */
 
-@import url('https://fonts.googleapis.com/css?family=Asap:400,600,600i|Open+Sans:400,700&display=swap');
+@import url('fonts.css');
 
 body, td {
 	font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
### Changed

- Used locally available fonts (Asap, Open Sans) and moved their definition to a dedicated `fonts.css`.

Fixes #4838

