### PR TITLE
chore: remove obsolete array_column fallback

### DIFF
--- a/admin/inc/functions.php
+++ b/admin/inc/functions.php
@@ -815,33 +815,6 @@ function print_selection_javascript()
 </script>";
 }
 
-if(!function_exists('array_column'))
-{
-	function array_column($input, $column_key)
-	{
-		$values = array();
-
-		if(!is_array($input))
-		{
-			$input = array($input);
-		}
-
-		foreach($input as $val)
-		{
-			if(is_array($val) && isset($val[$column_key]))
-			{
-				$values[] = $val[$column_key];
-			}
-			elseif(is_object($val) && isset($val->$column_key))
-			{
-				$values[] = $val->$column_key;
-			}
-		}
-
-		return $values;
-	}
-}
-
 /**
  * Output the auto redirect block.
  *

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8793,31 +8793,6 @@ function my_escape_csv($string, $escape_active_content = true)
 	return $string;
 }
 
-// Fallback function for 'array_column', PHP < 5.5.0 compatibility
-if(!function_exists('array_column'))
-{
-	function array_column($input, $column_key)
-	{
-		$values = array();
- 		if(!is_array($input))
-		{
-			$input = array($input);
-		}
- 		foreach($input as $val)
-		{
-			if(is_array($val) && isset($val[$column_key]))
-			{
-				$values[] = $val[$column_key];
-			}
-			elseif(is_object($val) && isset($val->$column_key))
-			{
-				$values[] = $val->$column_key;
-			}
-		}
- 		return $values;
-	}
-}
-
 /**
  * Performs a timing attack safe string comparison.
  *


### PR DESCRIPTION
### Removed

- `array_column` fallbacks for PHP < 5.5.

Part of #4549 