### PR TITLE
chore: remove obsolete sha1 fallback

### DIFF
--- a/inc/functions_serverstats.php
+++ b/inc/functions_serverstats.php
@@ -217,15 +217,7 @@ function build_server_stats($is_install=1, $prev_version='', $current_version=''
 
 	// We need a unique ID for the host so hash it to keep it private and send it over
 	$id = $_SERVER['HTTP_HOST'].time();
-
-	if(function_exists('sha1'))
-	{
-		$info['clientid'] = sha1($id);
-	}
-	else
-	{
-		$info['clientid'] = md5($id);
-	}
+	$info['clientid'] = sha1($id);
 
 	$string = "";
 	$amp = "";
@@ -295,4 +287,3 @@ function parse_php_info()
 	}
 	return $modules;
 }
-


### PR DESCRIPTION
### Removed

- Obsolete `sha1` fallback

Part of #4549 