### PR TITLE
fix(codebuttons): add fallback to empty theme.editortheme

### DIFF
--- a/inc/themes/core.base/frontend/templates/misc/codebuttons.twig
+++ b/inc/themes/core.base/frontend/templates/misc/codebuttons.twig
@@ -1,4 +1,4 @@
-{{ asset('jscripts/sceditor/themes/' ~ theme.editortheme, static=true) }}
+{{ asset('jscripts/sceditor/themes/' ~ (theme.editortheme ?: 'default.css'), static=true) }}
 {{ asset('jscripts/sceditor/jquery.sceditor.bbcode.min.js', static=true) }}
 {{ asset('jscripts/bbcodes_sceditor.js', static=true) }}
 {{ asset('jscripts/sceditor/plugins/undo.js', static=true) }}


### PR DESCRIPTION
### Added

- Fallback to `default.css` for `theme.editortheme` in `codebuttons.twig`.

![image](https://github.com/user-attachments/assets/a36fc6ee-b6f0-46d3-8149-425c43714b61)


