### PR TITLE
fix: avoid uninitialized altRowState error

### DIFF
--- a/inc/src/Twig/Extensions/ThemeExtension.php
+++ b/inc/src/Twig/Extensions/ThemeExtension.php
@@ -21,7 +21,7 @@ class ThemeExtension extends AbstractExtension implements GlobalsInterface
     /**
      * @var string $altRowState
      */
-    private string $altRowState;
+    private ?string $altRowState = null;
 
     /**
      * Create a new instance of the ThemeExtension.


### PR DESCRIPTION
### Changed

- Avoid uninitialized property error in `ThemeExtension`.

![image](https://github.com/user-attachments/assets/084a9790-44ba-4b0a-a90a-494b3c30e037)

