### PR TITLE
fix: add resource check before calling fgets() in unescape_binary()

### DIFF
--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -648,6 +648,11 @@ class PostgresPdoDbDriver extends AbstractPdoDbDriver
 	{
 		// binary fields are treated as streams
 		/** @var resource $string */
+		if (!is_resource($string))
+		{
+			return '';
+		}
+	
 		return fgets($string);
 	}
 


### PR DESCRIPTION
### Fixed

- Added resource check in `unescape_binary()`

![image](https://github.com/user-attachments/assets/31ec20e2-fcbc-4c03-a643-7d2d5a6f6f4f)

