### PR TITLE
chore: remove deprecated libxml_disable_entity_loader

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -2014,7 +2014,6 @@ class postParser
 		$stopwatchPeriod = app(Stopwatch::class)->start(group: 'core.parser.validate');
 
 		libxml_use_internal_errors(true);
-		@libxml_disable_entity_loader(true);
 
 		simplexml_load_string('<root>'.$output.'</root>', 'SimpleXMLElement', 524288 /* LIBXML_PARSEHUGE */);
 


### PR DESCRIPTION
### Removed

- Deprecated `libxml_disable_entity_loader()` in PHP 8.0+ ([reference](https://www.php.net/manual/en/migration80.deprecated.php#migration80.deprecated.libxml)).

Part of #4549 

