### PR TITLE
fix(datacache): type error in build_forum_permissions

### DIFF
--- a/inc/class_datacache.php
+++ b/inc/class_datacache.php
@@ -644,7 +644,14 @@ class datacache
 	 */
 	private function build_forum_permissions($permissions=array(), $pid=0)
 	{
-		$usergroups = array_keys($this->read("usergroups", true));
+		$usergroups = $this->read("usergroups", true);
+
+		if($usergroups === false) 
+		{
+			$usergroups = array(); 
+		}
+		
+		$usergroups = array_keys($usergroups); 
 		if(!empty($this->forum_permissions_forum_cache[$pid]))
 		{
 			foreach($this->forum_permissions_forum_cache[$pid] as $main)


### PR DESCRIPTION
### Fixed

- Type error for array_keys when `$this->read()` returns `false`.

Resolves #4731 

