### PR TITLE
fix(parser): code blocks newlines and tabs/spaces

### DIFF
--- a/admin/inc/functions_themes.php
+++ b/admin/inc/functions_themes.php
@@ -1517,7 +1517,7 @@ function upgrade_css_120_to_140($css)
 		md5('blockquote cite span') => array("class_name" => 'blockquote cite span', "values" => "float: right;\n\tfont-weight: normal;"),
 		md5('.codeblock') => array("class_name" => '.codeblock', "values" => "background: #fff;\n\tborder: 1px solid #ccc;\n\tpadding: 4px;"),
 		md5('.codeblock .title') => array("class_name" => '.codeblock .title', "values" => "border-bottom: 1px solid #ccc;\n\tfont-weight: bold;\n\tmargin: 4px 0;"),
-		md5('.codeblock code') => array("class_name" => '.codeblock code', "values" => "overflow: auto;\n\theight: auto;\n\tmax-height: 200px;\n\tdisplay: block;\n\tfont-family: Monaco, Consolas, Courier, monospace;\n\tfont-size: 13px;"),
+		md5('.codeblock code') => array("class_name" => '.codeblock code', "values" => "overflow: auto;\n\theight: auto;\n\tmax-height: 200px;\n\tdisplay: block;\n\tfont-family: Monaco, Consolas, Courier, monospace;\n\tfont-size: 13px;\n\twhite-space: pre;\n\ttab-size: 4;"),
 		md5('.subject_new') => array("class_name" => '.subject_new', "values" => "font-weight: bold;"),
 		md5('.highlight') => array("class_name" => '.highlight', "values" => "background: #FFFFCC;\n\tpadding: 3px;"),
 		md5('.pm_alert') => array("class_name" => '.pm_alert', "values" => "background: #FFF6BF;\n\tborder: 1px solid #FFD324;\n\ttext-align: center;\n\tpadding: 5px 20px;\n\tfont-size: 11px;"),

--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -268,12 +268,26 @@ class postParser
 
 		if(!isset($this->options['nl2br']) || $this->options['nl2br'] != 0)
 		{
-			$message = nl2br($message);
-			// Fix up new lines and block level elements
-			$message = preg_replace("#(</?(?:html|head|body|div|p|form|table|thead|tbody|tfoot|tr|td|th|ul|ol|li|div|p|blockquote|cite|hr)[^>]*>)\s*<br />#i", "$1", $message);
-			$message = preg_replace("#(&nbsp;)+(</?(?:html|head|body|div|p|form|table|thead|tbody|tfoot|tr|td|th|ul|ol|li|div|p|blockquote|cite|hr)[^>]*>)#i", "$2", $message);
-		}
+			// Split the message into chunks, separating <code> blocks and plain text
+			$parts = preg_split("#(<code>.*?</code>)#is", $message, -1, PREG_SPLIT_DELIM_CAPTURE);
 
+			foreach($parts as &$part)
+			{
+				// Apply nl2br only to parts that are not code blocks
+				if (stripos($part, '<code>') !== 0) 
+				{
+					$part = nl2br($part);
+				}
+				
+				// Fix up new lines and block level elements
+				$part = preg_replace("#(</?(?:html|head|body|div|p|form|table|thead|tbody|tfoot|tr|td|th|ul|ol|li|div|p|blockquote|cite|hr)[^>]*>)\s*<br />#i", "$1", $part);
+				$part = preg_replace("#(&nbsp;)+(</?(?:html|head|body|div|p|form|table|thead|tbody|tfoot|tr|td|th|ul|ol|li|div|p|blockquote|cite|hr)[^>]*>)#i", "$2", $part);				
+			}
+
+			// Reassemble the message
+			$message = implode('', $parts);
+		}
+		
 		if($this->clear_needed)
 		{
 			$message .= '<br class="clear" />';
@@ -1051,9 +1065,7 @@ class postParser
 		$code = str_replace('$', '&#36;', $code);
 		$code = preg_replace('#\$([0-9])#', '\\\$\\1', $code);
 		$code = str_replace('\\', '&#92;', $code);
-		$code = str_replace("\t", '&nbsp;&nbsp;&nbsp;&nbsp;', $code);
-		$code = str_replace("  ", '&nbsp;&nbsp;', $code);
-
+		
 		eval("\$mycode_code = \"".$templates->get("mycode_code", 1, 0)."\";");
 		return $mycode_code;
 	}

--- a/install/resources/mybb_theme.xml
+++ b/install/resources/mybb_theme.xml
@@ -828,6 +828,8 @@ blockquote cite span.highlight {
 	display: block;
 	font-family: Monaco, Consolas, Courier, monospace;
 	font-size: 13px;
+	white-space: pre;
+	tab-size: 4;
 }
 
 .smilie {


### PR DESCRIPTION
### Added

- Added `white-space` and `tab-size` properties to `.codeblock code`.

### Changed

- Updated the logic around `nl2br` usage in `parse_message` to avoid using it for code blocks.

### Removed

- Replacements for tabs and spaces in `mycode_parse_code`.

---
Tested with spaces, tabs, mixed tabs and spaces, after upgrading the theme.
Resolves #2849 

