### PR TITLE
fix(acp): missing validation for forums/groups/calendars order fields

### DIFF
--- a/admin/modules/config/calendars.php
+++ b/admin/modules/config/calendars.php
@@ -426,13 +426,13 @@ if($mybb->input['action'] == "update_order" && $mybb->request_method == "post")
 
 	foreach($mybb->input['disporder'] as $cid => $order)
 	{
-		if(is_numeric($order) && (int)$order >= 0) 
+		if(is_numeric($order) && (int)$order >= 0)
 		{
 			$update_query = array(
 				"disporder" => (int)$order
 			);
 			$db->update_query("calendars", $update_query, "cid='".(int)$cid."'");
-		}			
+		}
 	}
 
 	$plugins->run_hooks("admin_config_calendars_update_order_commit");

--- a/admin/modules/config/calendars.php
+++ b/admin/modules/config/calendars.php
@@ -426,10 +426,13 @@ if($mybb->input['action'] == "update_order" && $mybb->request_method == "post")
 
 	foreach($mybb->input['disporder'] as $cid => $order)
 	{
-		$update_query = array(
-			"disporder" => (int)$order
-		);
-		$db->update_query("calendars", $update_query, "cid='".(int)$cid."'");
+		if(is_numeric($order) && (int)$order >= 0) 
+		{
+			$update_query = array(
+				"disporder" => (int)$order
+			);
+			$db->update_query("calendars", $update_query, "cid='".(int)$cid."'");
+		}			
 	}
 
 	$plugins->run_hooks("admin_config_calendars_update_order_commit");

--- a/admin/modules/config/report_reasons.php
+++ b/admin/modules/config/report_reasons.php
@@ -294,7 +294,10 @@ if(!$mybb->input['action'])
 		{
 			foreach($mybb->input['disporder'] as $rid => $order)
 			{
-				$db->update_query("reportreasons", array('disporder' => (int)$order), "rid='".(int)$rid."'");
+				if(is_numeric($order) && (int)$order >= 0)
+				{
+					$db->update_query("reportreasons", array('disporder' => (int)$order), "rid='".(int)$rid."'");
+				}
 			}
 
 			$plugins->run_hooks("admin_config_report_reasons_start_commit");
@@ -356,7 +359,7 @@ if(!$mybb->input['action'])
 		$form_container->output_cell(htmlspecialchars_uni($reasons['title']));
 		$form_container->output_cell(htmlspecialchars_uni($reasons['appliesto']));
 		$form_container->output_cell("<div>{$icon}</div>", array("class" => "align_center"));
-		$form_container->output_cell("<input type=\"text\" name=\"disporder[{$reasons['rid']}]\" value=\"{$reasons['disporder']}\" class=\"text_input align_center\" style=\"width: 80%;\" />", array("class" => "align_center"));
+		$form_container->output_cell("<input type=\"number\" name=\"disporder[{$reasons['rid']}]\" value=\"{$reasons['disporder']}\" min=\"0\" class=\"text_input align_center\" style=\"width: 80%;\" />", array("class" => "align_center"));
 		$popup = new PopupMenu("reasons_{$reasons['rid']}", $lang->options);
 		$popup->add_item($lang->edit_reason, "index.php?module=config-report_reasons&amp;action=edit&amp;rid={$reasons['rid']}");
 		$popup->add_item($lang->delete_reason, "index.php?module=config-report_reasons&amp;action=delete&amp;rid={$reasons['rid']}&amp;my_post_key={$mybb->post_code}", "return AdminCP.deleteConfirmation(this, '{$lang->confirm_reason_deletion}')");

--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -2322,7 +2322,7 @@ if(!$mybb->input['action'])
 			{
 				foreach($mybb->input['disporder'] as $update_fid => $order)
 				{
-					if(is_numeric($order) && (int)$order >= 0) 
+					if(is_numeric($order) && (int)$order >= 0)
 					{
 						$db->update_query("forums", array('disporder' => (int)$order), "fid='".(int)$update_fid."'");
 					}

--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -2322,7 +2322,10 @@ if(!$mybb->input['action'])
 			{
 				foreach($mybb->input['disporder'] as $update_fid => $order)
 				{
-					$db->update_query("forums", array('disporder' => (int)$order), "fid='".(int)$update_fid."'");
+					if(is_numeric($order) && (int)$order >= 0) 
+					{
+						$db->update_query("forums", array('disporder' => (int)$order), "fid='".(int)$update_fid."'");
+					}
 				}
 
 				$plugins->run_hooks("admin_forum_management_start_disporder_commit");
@@ -3032,4 +3035,3 @@ function retrieve_single_permissions_row($gid, $fid)
 	$form_container->construct_row();
 	return $form_container->output_row_cells(0, true);
 }
-

--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -1407,7 +1407,7 @@ if(!$mybb->input['action'])
 		{
 			foreach($mybb->input['disporder'] as $gid => $order)
 			{
-				if(is_numeric($order) && (int)$order >= 0) 
+				if(is_numeric($order) && (int)$order >= 0)
 				{
 					$db->update_query("usergroups", array('disporder' => (int)$order), "gid='".(int)$gid."'");
 				}

--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -1379,7 +1379,7 @@ if($mybb->input['action'] == "disporder" && $mybb->request_method == "post")
 	{
 		$gid = (int)$gid;
 		$order = (int)$order;
-		if($gid != 0 && $order != 0)
+		if($gid != 0 && $order > 0)
 		{
 			$sql_array = array(
 				'disporder' => $order,
@@ -1407,7 +1407,10 @@ if(!$mybb->input['action'])
 		{
 			foreach($mybb->input['disporder'] as $gid => $order)
 			{
-				$db->update_query("usergroups", array('disporder' => (int)$order), "gid='".(int)$gid."'");
+				if(is_numeric($order) && (int)$order >= 0) 
+				{
+					$db->update_query("usergroups", array('disporder' => (int)$order), "gid='".(int)$gid."'");
+				}
 			}
 
 			$plugins->run_hooks("admin_user_groups_start_commit");
@@ -1538,7 +1541,7 @@ if(!$mybb->input['action'])
 
 		if($usergroup['showforumteam'] == 1)
 		{
-			$form_container->output_cell($form->generate_numeric_field("disporder[{$usergroup['gid']}]", "{$usergroup['disporder']}", array('class' => 'align_center', 'style' => 'width:80%')), array("class" => "align_center"));
+			$form_container->output_cell($form->generate_numeric_field("disporder[{$usergroup['gid']}]", "{$usergroup['disporder']}", array('min' => 0, 'class' => 'align_center', 'style' => 'width:80%')), array("class" => "align_center"));
 		}
 		else
 		{


### PR DESCRIPTION
### Fixed

- Added `min` option to `generate_numeric_field` for groups management (already present for forums management).
- Added extra check to make sure the value is numeric and non negative integer for calendars/groups/forums management.

Resolves #4866

