### PR TITLE
fix(acp): incorrect permissions displayed for child forum creation

### DIFF
--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -1199,23 +1199,21 @@ if($mybb->input['action'] == "add")
 	foreach($usergroups as $usergroup)
 	{
 		$perms = array();
-		if(!empty($mybb->input['default_permissions'][$usergroup['gid']]))
+
+		if(isset($existing_permissions) && is_array($existing_permissions) && $existing_permissions[$usergroup['gid']])
 		{
-			if(isset($existing_permissions) && is_array($existing_permissions) && $existing_permissions[$usergroup['gid']])
-			{
-				$perms = $existing_permissions[$usergroup['gid']];
-				$default_checked = false;
-			}
-			elseif(is_array($cached_forum_perms) && isset($forum_data['fid']) && !empty($cached_forum_perms[$forum_data['fid']][$usergroup['gid']]))
-			{
-				$perms = $cached_forum_perms[$forum_data['fid']][$usergroup['gid']];
-				$default_checked = true;
-			}
-			else if(is_array($cached_forum_perms) && isset($forum_data['fid']) && !empty($cached_forum_perms[$forum_data['pid']][$usergroup['gid']]))
-			{
-				$perms = $cached_forum_perms[$forum_data['pid']][$usergroup['gid']];
-				$default_checked = true;
-			}
+			$perms = $existing_permissions[$usergroup['gid']];
+			$default_checked = false;
+		}
+		elseif(is_array($cached_forum_perms) && isset($forum_data['fid']) && !empty($cached_forum_perms[$forum_data['fid']][$usergroup['gid']]))
+		{
+			$perms = $cached_forum_perms[$forum_data['fid']][$usergroup['gid']];
+			$default_checked = true;
+		}
+		else if(is_array($cached_forum_perms) && isset($forum_data['pid']) && !empty($cached_forum_perms[$forum_data['pid']][$usergroup['gid']]))
+		{
+			$perms = $cached_forum_perms[$forum_data['pid']][$usergroup['gid']];
+			$default_checked = true;
 		}
 
 		if(!$perms)
@@ -3032,4 +3030,3 @@ function retrieve_single_permissions_row($gid, $fid)
 	$form_container->construct_row();
 	return $form_container->output_row_cells(0, true);
 }
-


### PR DESCRIPTION
### Changed

Initially, I wanted to replicate the behavior from the [edit action](https://github.com/mybb/mybb/blob/feature/admin/modules/forum/management.php#L1750), but the code inside the if and else blocks is nearly identical. Turns out `$mybb->input['default_permissions']` is null in the `add` scenario (did not check others), so the condition isn’t necessary.

Tested with:
- Adding a new forum (no parent): default group permissions are displayed
- Adding a new child forum: inherited permissions from parent are displayed
- Editing a forum: correct permissions for the forum are displayed
- Copying a forum: correct permissions are copied to the new forum

### Fixed

- Permissions display when adding a new child sub-forum (incorrect `fid` reference in `pid` condition).

Resolves #329

