### PR TITLE
fix: set group permissions when gid is passed to forum_permissions()

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1644,6 +1644,10 @@ function forum_permissions($fid=0, $uid=0, $gid=0)
 			$groupperms = $mybb->usergroup;
 		}
 	}
+	else 
+	{
+		$groupperms = usergroup_permissions($gid);
+	}	
 
 	if(!is_array($forum_cache))
 	{


### PR DESCRIPTION
### Fixed

- Defined `$groupperms` when `$gid` is passed to `forum_permissions` (e.g., https://github.com/mybb/mybb/blob/feature/admin/modules/forum/management.php#L725)

Resolves #4850 

