### PR TITLE
fix(time): incorrect deprecated tag

### DIFF
--- a/inc/functions_time.php
+++ b/inc/functions_time.php
@@ -448,8 +448,6 @@ global $_month_table_normal,$_month_table_leaf;
 
 function adodb_tz_offset(
 	$gmt,
-	#[Deprecated]
-	$isphp5
 )
 {
 	$zhrs = abs($gmt)/3600;


### PR DESCRIPTION
### Fixed

- Error when opening the calendar: ``` Fatal error: Attribute "Deprecated" cannot target parameter (allowed targets: function, method, class constant) in /var/www/html/inc/functions_time.php on line 449```. `#[Deprecated]`, as explained in the error message, cannot be used for a function parameter. Introduced in https://github.com/mybb/mybb/pull/4882

### Removed

- Removed  the `$isphp5` parameter as well because the only two calls to this function already dropped it (e.g., `$dates .= ' '.adodb_tz_offset($gmt);`). Or is it used by plugins maybe? If that is the case I will restore the parameter.
