### PR TITLE
Fix/security log error admincp login

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -541,6 +541,7 @@ if(empty($mybb->usergroup['cancp']) && !$is_super_admin || !$mybb->user['uid'])
 	if($mybb->get_input('do') == 'login')
 	{
 		$login_message = $lang->error_mybb_not_admin_account;
+		log_security_action('failed_login_admincp', $uid);
 	}
 }
 
@@ -834,4 +835,3 @@ $lang->load("{$run_module}_{$page->active_action}", false, true);
 $plugins->run_hooks("admin_load");
 
 require $modules_dir."/".$run_module."/".$action_file;
-

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -4153,11 +4153,11 @@ function log_security_action($type, $uid = 0)
 {
 	global $mybb, $db;
 
-	// If no user id is specified, assume it is the current user
+	// If no user id is specified, try using the current user's ID
 	$uid = (int)$uid;
-	if($uid == 0)
+	if($uid == 0 && isset($mybb->user['uid']))
 	{
-		$uid = $mybb->user['uid'];
+		$uid = (int)$mybb->user['uid'];
 	}
 
 	$sql_array = array(


### PR DESCRIPTION
### Added

- Additional security log entry when a valid user without Admin CP permissions attempts to log in.

### Fixed

- SQL error caused by attempting to log into the Admin CP with a non-existent user.

### Example

![image](https://github.com/user-attachments/assets/62e0623f-09f5-4aed-b136-604a6804a318)

Resolves #4829


