### PR TITLE
fix: disallow HTTP access to inc/

### DIFF
--- a/htaccess-nginx.txt
+++ b/htaccess-nginx.txt
@@ -9,6 +9,10 @@ location /admin/backups {
     deny all;
 }
 
+location ~ /inc/ {
+    internal;
+}
+
 rewrite ^/forum-([0-9]+).html$ /forumdisplay.php?fid=$1 last;
 rewrite ^/forum-([0-9]+)-page-([0-9]+).html$ /forumdisplay.php?fid=$1&page=$2 last;
 rewrite ^/thread-([0-9]+).html$ /showthread.php?tid=$1 last;

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -65,3 +65,7 @@ Options -MultiViews +FollowSymlinks -Indexes
 	Order Deny,Allow
 	Deny from all
 </Files>
+
+<Location /inc/>
+    Require all denied
+</Location>


### PR DESCRIPTION
### Added

- `inc/` location rule to Nginx and Apache configuration examples.

Resolves #4676 

