### PR TITLE
feat: add groups legend management

### DIFF
--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -926,6 +926,7 @@ if($mybb->input['action'] == "edit")
 				"canbereported" => $mybb->get_input('canbereported', MyBB::INPUT_INT),
 				"canbeinvisible" => $mybb->get_input('canbeinvisible', MyBB::INPUT_INT),
 				"canchangewebsite" => $mybb->get_input('canchangewebsite', MyBB::INPUT_INT),
+				"showinlegend" => $mybb->get_input('showinlegend', MyBB::INPUT_INT),
 				"showforumteam" => $mybb->get_input('showforumteam', MyBB::INPUT_INT),
 				"usereputationsystem" => $mybb->get_input('usereputationsystem', MyBB::INPUT_INT),
 				"cangivereputations" => $mybb->get_input('cangivereputations', MyBB::INPUT_INT),
@@ -1072,6 +1073,7 @@ if($mybb->input['action'] == "edit")
 
 	$general_options = array();
 	$general_options[] = $form->generate_check_box("showmemberlist", 1, $lang->member_list, array("checked" => $mybb->get_input('showmemberlist', MyBB::INPUT_INT)));
+	$general_options[] = $form->generate_check_box("showinlegend", 1, $lang->show_in_legend, array("checked" => $mybb->get_input('showinlegend', MyBB::INPUT_INT)));	
 	if($usergroup['gid'] != "1" && $usergroup['gid'] != "5")
 	{
 		$general_options[] = $form->generate_check_box("showforumteam", 1, $lang->forum_team, array("checked" => $mybb->get_input('showforumteam', MyBB::INPUT_INT)));
@@ -1387,6 +1389,8 @@ if($mybb->input['action'] == "disporder" && $mybb->request_method == "post")
 			$db->update_query('usergroups', $sql_array, "gid = '{$gid}'");
 		}
 	}
+	
+	$cache->update_usergroups();
 
 	// Log admin action
 	log_admin_action();

--- a/inc/languages/english/admin/user_groups.lang.php
+++ b/inc/languages/english/admin/user_groups.lang.php
@@ -80,6 +80,7 @@ $l['group_image'] = "Group Image";
 $l['group_image_desc'] = "Here you can set a group image which will show on each post made by users in this group. Please use <strong>{lang}</strong> to represent the user's chosen language if translated group images are available";
 $l['general_options'] = "General Options";
 $l['member_list'] = "Yes, show users of this group on the member list";
+$l['show_in_legend'] = "Yes, show this group in the legend on the forum home page";
 $l['forum_team'] = "Yes, show this group on the 'forum team' page";
 $l['is_banned_group'] = "Yes, this is a banned group<br /><small>If this group is a 'banned' user group, users will be able to be 'banned' in to this user group.</small>";
 $l['publicly_joinable_options'] = "Publicly Joinable Options";

--- a/inc/schemas/mysql_db_tables.php
+++ b/inc/schemas/mysql_db_tables.php
@@ -1029,6 +1029,7 @@ $tables[] = "CREATE TABLE mybb_usergroups (
   canbereported tinyint(1) NOT NULL default '0',
   canbeinvisible tinyint(1) NOT NULL default '1',
   canchangewebsite tinyint(1) NOT NULL default '1',
+  showinlegend tinyint(1) NOT NULL default '0',
   showforumteam tinyint(1) NOT NULL default '0',
   usereputationsystem tinyint(1) NOT NULL default '0',
   cangivereputations tinyint(1) NOT NULL default '0',

--- a/inc/schemas/pgsql_db_tables.php
+++ b/inc/schemas/pgsql_db_tables.php
@@ -983,6 +983,7 @@ $tables[] = "CREATE TABLE mybb_usergroups (
   canbereported smallint NOT NULL default '0',
   canbeinvisible smallint NOT NULL default '1',
   canchangewebsite smallint NOT NULL default '1',
+  showinlegend smallint NOT NULL default '0',
   showforumteam smallint NOT NULL default '0',
   usereputationsystem smallint NOT NULL default '0',
   cangivereputations smallint NOT NULL default '0',

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -913,6 +913,7 @@ $tables[] = "CREATE TABLE mybb_usergroups (
 	canbereported tinyint(1) NOT NULL default '0',
 	canbeinvisible tinyint(1) NOT NULL default '1',
 	canchangewebsite tinyint(1) NOT NULL default '1',
+	showinlegend tinyint(1) NOT NULL default '0',
 	showforumteam tinyint(1) NOT NULL default '0',
 	usereputationsystem tinyint(1) NOT NULL default '0',
 	cangivereputations tinyint(1) NOT NULL default '0',

--- a/inc/seeds/settings.xml
+++ b/inc/seeds/settings.xml
@@ -661,10 +661,18 @@ min=0]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
+		<setting name="showgroupslegend">
+			<title>Show groups legend?</title>
+			<description><![CDATA[Display the list of user groups next to the members list.]]></description>
+			<disporder>9</disporder>
+			<optionscode><![CDATA[yesno]]></optionscode>
+			<settingvalue><![CDATA[1]]></settingvalue>
+			<isdefault>1</isdefault>			
+		</setting>		
 		<setting name="showindexstats">
 			<title>Show Small Stats Section</title>
 			<description><![CDATA[Do you want to show the total number of threads, posts, members, and the last member on the forum home?]]></description>
-			<disporder>9</disporder>
+			<disporder>10</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
 			<isdefault>1</isdefault>
@@ -672,7 +680,7 @@ min=0]]></optionscode>
 		<setting name="showforumviewing">
 			<title>Show x viewing forum</title>
 			<description><![CDATA[Displays the currently active users viewing each forum.]]></description>
-			<disporder>10</disporder>
+			<disporder>11</disporder>
 			<optionscode><![CDATA[yesno]]></optionscode>
 			<settingvalue><![CDATA[0]]></settingvalue>
 			<isdefault>1</isdefault>

--- a/inc/seeds/usergroups.xml
+++ b/inc/seeds/usergroups.xml
@@ -61,6 +61,7 @@
 		<canbereported><![CDATA[0]]></canbereported>
 		<canbeinvisible><![CDATA[0]]></canbeinvisible>
 		<canchangewebsite><![CDATA[0]]></canchangewebsite>
+		<showinlegend><![CDATA[0]]></showinlegend>
 		<showforumteam><![CDATA[0]]></showforumteam>
 		<usereputationsystem><![CDATA[0]]></usereputationsystem>
 		<cangivereputations><![CDATA[0]]></cangivereputations>
@@ -154,6 +155,7 @@
 		<canbereported><![CDATA[1]]></canbereported>
 		<canbeinvisible><![CDATA[1]]></canbeinvisible>
 		<canchangewebsite><![CDATA[1]]></canchangewebsite>
+		<showinlegend><![CDATA[0]]></showinlegend>
 		<showforumteam><![CDATA[0]]></showforumteam>
 		<usereputationsystem><![CDATA[1]]></usereputationsystem>
 		<cangivereputations><![CDATA[1]]></cangivereputations>
@@ -247,6 +249,7 @@
 		<canbereported><![CDATA[0]]></canbereported>
 		<canbeinvisible><![CDATA[1]]></canbeinvisible>
 		<canchangewebsite><![CDATA[1]]></canchangewebsite>
+		<showinlegend><![CDATA[1]]></showinlegend>
 		<showforumteam><![CDATA[1]]></showforumteam>
 		<usereputationsystem><![CDATA[1]]></usereputationsystem>
 		<cangivereputations><![CDATA[1]]></cangivereputations>
@@ -340,6 +343,7 @@
 		<canbereported><![CDATA[0]]></canbereported>
 		<canbeinvisible><![CDATA[1]]></canbeinvisible>
 		<canchangewebsite><![CDATA[1]]></canchangewebsite>
+		<showinlegend><![CDATA[1]]></showinlegend>
 		<showforumteam><![CDATA[1]]></showforumteam>
 		<usereputationsystem><![CDATA[1]]></usereputationsystem>
 		<cangivereputations><![CDATA[1]]></cangivereputations>
@@ -433,6 +437,7 @@
 		<canbereported><![CDATA[1]]></canbereported>
 		<canbeinvisible><![CDATA[1]]></canbeinvisible>
 		<canchangewebsite><![CDATA[0]]></canchangewebsite>
+		<showinlegend><![CDATA[0]]></showinlegend>
 		<showforumteam><![CDATA[0]]></showforumteam>
 		<usereputationsystem><![CDATA[0]]></usereputationsystem>
 		<cangivereputations><![CDATA[0]]></cangivereputations>
@@ -526,6 +531,7 @@
 		<canbereported><![CDATA[0]]></canbereported>
 		<canbeinvisible><![CDATA[1]]></canbeinvisible>
 		<canchangewebsite><![CDATA[1]]></canchangewebsite>
+		<showinlegend><![CDATA[1]]></showinlegend>
 		<showforumteam><![CDATA[1]]></showforumteam>
 		<usereputationsystem><![CDATA[1]]></usereputationsystem>
 		<cangivereputations><![CDATA[1]]></cangivereputations>
@@ -619,6 +625,7 @@
 		<canbereported><![CDATA[0]]></canbereported>
 		<canbeinvisible><![CDATA[1]]></canbeinvisible>
 		<canchangewebsite><![CDATA[0]]></canchangewebsite>
+		<showinlegend><![CDATA[0]]></showinlegend>
 		<showforumteam><![CDATA[0]]></showforumteam>
 		<usereputationsystem><![CDATA[0]]></usereputationsystem>
 		<cangivereputations><![CDATA[0]]></cangivereputations>

--- a/inc/themes/core.base/frontend/templates/index/index.twig
+++ b/inc/themes/core.base/frontend/templates/index/index.twig
@@ -32,6 +32,14 @@
                         {% if user.invisible == 1 and (mybb.usergroup.canviewwolinvis == 1 or user.uid == mybb.user.uid) %}*{% endif %}
                     {% endfor %}
                 </p>
+                {% if mybb.settings.showgroupslegend %}
+                <hr>
+                <p class="board-statistics__body board-statistics__body--groups">
+                {% for group in groups %}
+                    {{ group.display|raw }}{% if not loop.last %} &bull; {% endif %}
+                {% endfor %}
+                </p>
+                {% endif %}                
             </div>
         {% endif %}
         {% if birthdays or hiddencount %}

--- a/inc/themes/core.base/frontend/templates/index/index.twig
+++ b/inc/themes/core.base/frontend/templates/index/index.twig
@@ -32,7 +32,7 @@
                         {% if user.invisible == 1 and (mybb.usergroup.canviewwolinvis == 1 or user.uid == mybb.user.uid) %}*{% endif %}
                     {% endfor %}
                 </p>
-                {% if mybb.settings.showgroupslegend %}
+                {% if mybb.settings.showgroupslegend and groups %}
                 <hr>
                 <p class="board-statistics__body board-statistics__body--groups">
                 {% for group in groups %}

--- a/index.php
+++ b/index.php
@@ -65,6 +65,32 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 			}
 		}
 	}
+	
+	$groups = [];
+	if($mybb->settings['showgroupslegend'] != 0)
+	{
+		$groups_cache = $cache->read('usergroups');
+		if($groups_cache === false)
+		{
+			// If the groups cache is not available, rebuild it.
+			$cache->update_usergroups();
+			$groups_cache = $cache->read('usergroups');
+		}
+
+		foreach($groups_cache as $group)
+		{
+			if($group['showinlegend'])
+			{
+				$groups[] = array(
+					'disporder' => $group['disporder'],
+					'display' => format_name($group['title'], $group['gid']),
+				);
+			}
+		}
+		usort($groups, function($a, $b) {
+			return $a['disporder'] - $b['disporder'];
+		});
+	}
 
 	$query = $db->simple_select("sessions", "COUNT(DISTINCT ip) AS guestcount", "uid = 0 AND SUBSTR(sid,4,1) != '=' AND time > $timesearch");
 	$guestcount = $db->fetch_field($query, "guestcount");
@@ -395,6 +421,7 @@ $plugins->run_hooks('index_end');
 
 output_page(\MyBB\View\template('index/index.twig', [
 	'forums' => $forums,
+	'groups' => $groups,
 	'users' => $doneusers,
 	'bots' => $donebots,
 	'birthdays' => $birthdays,


### PR DESCRIPTION
This is an attempt to integrate a groups legend into the "Who's online" block on the index page. It’s certainly not perfect and may need to be updated or improved, but for now, it’s working well for me.

### Added

- Added a new setting (defaults to 1) to control whether the groups legend is displayed.
- Added a new toggle in the groups management page to decide if a group should appear in the legend. Defaults to 1 for Administrators, Super Moderators, and Moderators.
- Added a new element in the Twig index view to display the groups legend above the members list, if enabled.

### Example

Index page:
![image](https://github.com/user-attachments/assets/f2dac55a-9222-442e-bad6-830612e2f8f1)

Setting in the ACP > Forum Home Options:
![image](https://github.com/user-attachments/assets/f8b23dc5-da98-4154-98e1-fe5143ae1e8f)

Group management:
![image](https://github.com/user-attachments/assets/0f91f44a-c3a8-4285-af1e-6a0da627fa7c)

Feedback and suggestions are welcome.
