### PR TITLE
chore: don't use E_STRICT for PHP >= 7.0

### DIFF
--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -63,7 +63,6 @@ class errorHandler {
 		E_USER_WARNING					=> 'User Warning',
 		E_USER_NOTICE					=> 'User Notice',
 		E_USER_DEPRECATED	 			=> 'User Deprecated Warning',
-		E_STRICT						=> 'Runtime Notice',
 		E_RECOVERABLE_ERROR				=> 'Catchable Fatal Error',
 		MYBB_SQL 						=> 'MyBB SQL Error',
 		MYBB_TEMPLATE					=> 'MyBB Template Error',
@@ -104,7 +103,6 @@ class errorHandler {
 		E_DEPRECATED,
 		E_NOTICE,
 		E_USER_NOTICE,
-		E_STRICT
 	);
 
 	/**


### PR DESCRIPTION
### Removed

- E_STRICT

This was already addressed in [mybb/mybb#4869](https://github.com/mybb/mybb/pull/4869) for the 1.8.x branch, but I'm not sure what the plans are for handling this in 1.9 (rebase, cherry-pick, or something else).
