### PR TITLE
fix(acp): missing language key in ACP users management

### DIFF
--- a/inc/languages/english/admin/user_users.lang.php
+++ b/inc/languages/english/admin/user_users.lang.php
@@ -157,6 +157,7 @@ $l['new_password'] = "New Password";
 $l['new_password_desc'] = "Only required if changing";
 $l['confirm_new_password'] = "Confirm New Password";
 
+$l['contact_info'] = "Contact Information";
 $l['optional_profile_info'] = "Optional Profile Information";
 $l['custom_user_title'] = "Custom User Title";
 $l['custom_user_title_desc'] = "If empty, the group user title will be used";


### PR DESCRIPTION
### Fixed

- Missing language key used in users module: https://github.com/mybb/mybb/blob/8896f4ed0ba8caef6f45a701987c400da691e6e9/admin/modules/user/users.php#L1203