### PR TITLE
fix: incorrect references to closed|moved

### DIFF
--- a/inc/class_custommoderation.php
+++ b/inc/class_custommoderation.php
@@ -444,7 +444,7 @@ class CustomModeration extends Moderation
 				$query = $db->query("
 					SELECT u.uid, u.username, t.fid, t.subject, t.tid, t.firstpost, t.closed FROM ".TABLE_PREFIX."threads t
 					LEFT JOIN ".TABLE_PREFIX."users u ON t.uid=u.uid
-					WHERE tid IN ($tid_list) AND closed NOT LIKE 'moved|%'
+					WHERE tid IN ($tid_list) AND moved = '0'
 				");
 				require_once MYBB_ROOT."inc/datahandlers/post.php";
 

--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -1936,7 +1936,7 @@ class PostDataHandler extends DataHandler
 			// Update any moved thread links to have corresponding new subject.
 			if(isset($post['subject']))
 			{
-				$query = $db->simple_select("threads", "tid, closed", "closed='moved|".$this->tid."'");
+				$query = $db->simple_select("threads", "tid, closed", "moved='".$this->tid."'");
 				if($db->num_rows($query) > 0)
 				{
 					$update_data['subject'] = $db->escape_string($post['subject']);


### PR DESCRIPTION
### Fixed

- Replaced incorrect remaining references to `closed = 'moved|tid'`.