### PR TITLE
Correct mistaken comparisons of $thread['closed'] with zero

### DIFF
--- a/inc/class_moderation.php
+++ b/inc/class_moderation.php
@@ -3028,7 +3028,7 @@ class Moderation
 			{
 				$open[] = $thread['tid'];
 			}
-			elseif($thread['closed'] == 0)
+			elseif(empty($thread['closed']))
 			{
 				$close[] = $thread['tid'];
 			}

--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -629,7 +629,7 @@ function build_postbit($post, $post_type=0)
 
 		// Quick Delete button
 		$can_delete_thread = $can_delete_post = 0;
-		if($mybb->user['uid'] == $post['uid'] && $thread['closed'] == 0)
+		if($mybb->user['uid'] == $post['uid'] && empty($thread['closed']))
 		{
 			if($forumpermissions['candeletethreads'] == 1 && $postcounter == 1)
 			{


### PR DESCRIPTION
In PHP 8, an empty string no longer compares equal to zero, and these comparisons mistakenly assume that it (still) does.

Resolves #4961

