### PR TITLE
Refactor/return 403 status code for error_no_permission

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -884,10 +884,12 @@ function get_child_list($fid)
 /**
  * Produce a friendly error message page
  *
- * @param string $error The error message to be shown
+ * @param string $error_message The error message to be shown
  * @param string $title The title of the message shown in the title of the page and the error table
+ * @param string $error_page Optional additional error page
+ * @param int $status_code HTTP status code to send with the error page
  */
-function error($error_message = "", $title = "", $error_page = "")
+function error($error_message = "", $title = "", $error_page = "", $status_code = 200)
 {
 	global $db, $lang, $mybb, $plugins;
 
@@ -901,6 +903,8 @@ function error($error_message = "", $title = "", $error_page = "")
 		echo json_encode(array("errors" => array($error_message)));
 		exit;
 	}
+	
+	http_response_code($status_code);
 
 	$timenow = my_date('relative', TIME_NOW);
 	reset_breadcrumb();

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1027,7 +1027,7 @@ function error_no_permission()
 		'redirect_url' => $redirect_url
 	]);
 
-	error($error_message, $lang->error_nopermission, $error_page);
+	error($error_message, $lang->error_nopermission, $error_page, 403);
 }
 
 /**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -889,7 +889,7 @@ function get_child_list($fid)
  * @param string $error_page Optional additional error page
  * @param int $status_code HTTP status code to send with the error page
  */
-function error($error_message = "", $title = "", $error_page = "", $status_code = 200)
+function error(string $error_message = "", string $title = "", string $error_page = "", int $status_code = 200): never
 {
 	global $db, $lang, $mybb, $plugins;
 


### PR DESCRIPTION
### Added

- Added a `status_code` parameter to the `error` function, defaulting to 200, to avoid breaking existing behavior immediately.
- Added parameters and return type hints for the `error` function.

### Fixed

- Corrected the parameters description for the `error` function.

Part of #4959 
Resolves #2864 

