### PR TITLE
fix: incorrect closed status in moderation

### DIFF
--- a/inc/class_moderation.php
+++ b/inc/class_moderation.php
@@ -1120,7 +1120,7 @@ class Moderation
 					"lastposter" => $db->escape_string($thread['lastposter']),
 					"views" => 0,
 					"replies" => 0,
-					"closed" => 2,
+					"closed" => 0,
 					"moved" => $tid,
 					"sticky" => $thread['sticky'],
 					"visible" => (int)$thread['visible'],


### PR DESCRIPTION
### Fixed

- Incorrect status for `closed` (2 instead of 0).

Resolves #4966

