### PR TITLE
fix(captcha): cloudflare turnstile twig template and class

### DIFF
--- a/inc/class_captcha.php
+++ b/inc/class_captcha.php
@@ -106,7 +106,7 @@ class captcha
 	{
 		global $mybb, $plugins;
 
-		$this->type = $mybb->settings['captchaimage'];
+		$this->type = (int) $mybb->settings['captchaimage'];
 
 		$args = array(
 			'this' => &$this,
@@ -219,15 +219,10 @@ class captcha
 
 	function build_cfturnstile()
 	{
-		global $lang, $mybb, $templates, $theme;
-
-		// This will build a hCaptcha
-		$server = $this->server;
-		$public_key = $mybb->settings['cfturnstilepublickey'];
-		$captcha_theme = $mybb->settings['cfturnstiletheme'];
-		$captcha_size = $mybb->settings['cfturnstilesize'];
-
-		eval("\$this->html = \"".$templates->get($this->captcha_template, 1, 0)."\";");
+		$this->html = \MyBB\View\template('misc/captcha/'.$this->captcha_template.'.twig', [
+			'server' => $this->server,
+			'type' => $this->type
+		]);
 	}
 
 	/**

--- a/inc/themes/core.base/frontend/templates/misc/captcha/post.twig
+++ b/inc/themes/core.base/frontend/templates/misc/captcha/post.twig
@@ -100,7 +100,7 @@
         <div class="section__container">
             <div class="row row--form field">
                 <p class="field__description">{{ lang.verification_note_cfturnstile }}</p>
-                <script type="text/javascript" src="{{ server }}"></script><div class="h-captcha" data-sitekey="{{ mybb.settings.cfturnstilepublickey }}" data-theme="{{ mybb.settings.cfturnstiletheme }}" data-size="{{ mybb.settings.cfturnstilesize }}"></div>
+                <script type="text/javascript" src="{{ server }}"></script><div class="cf-turnstile" data-sitekey="{{ mybb.settings.cfturnstilepublickey }}" data-theme="{{ mybb.settings.cfturnstiletheme }}" data-size="{{ mybb.settings.cfturnstilesize }}"></div>
             </div>
         </div>
     </section>

--- a/inc/themes/core.base/frontend/templates/misc/captcha/register.twig
+++ b/inc/themes/core.base/frontend/templates/misc/captcha/register.twig
@@ -69,7 +69,7 @@
         <div class="section__container">
             <div class="row row--form field">
                 <p class="field__description">{{ lang.verification_note_cfturnstile }}</p>
-                <script type="text/javascript" src="{{ server }}"></script><div class="h-captcha" data-sitekey="{{ mybb.settings.cfturnstilepublickey }}" data-theme="{{ mybb.settings.cfturnstiletheme }}" data-size="{{ mybb.settings.cfturnstilesize }}"></div>
+                <script type="text/javascript" src="{{ server }}"></script><div class="cf-turnstile" data-sitekey="{{ mybb.settings.cfturnstilepublickey }}" data-theme="{{ mybb.settings.cfturnstiletheme }}" data-size="{{ mybb.settings.cfturnstilesize }}"></div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Fixed

- Incorrect class for the turnstile html element.
- Incorrect template call for turnstile in `captcha::build_cfturnstile()`.
- Incorrect type for `captcha::type`, which is supposed to be an integer but receives `$mybb->settings['captchaimage']` which is a string. This makes the `$this->type === self::CFTURNSTILE` comparison invalid.

Resolves #4659

