### PR TITLE
fix: incorrect htaccess configuration for inc/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ install/lock*
 error.log
 .htaccess
 !admin/backups/.htaccess
+!inc/.htaccess
 .htgroup
 .htpasswd
 

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -65,7 +65,3 @@ Options -MultiViews +FollowSymlinks -Indexes
 	Order Deny,Allow
 	Deny from all
 </Files>
-
-<Location /inc/>
-    Require all denied
-</Location>

--- a/inc/.htaccess
+++ b/inc/.htaccess
@@ -1,0 +1,7 @@
+<IfModule !mod_authz_core.c>
+  Order deny,allow
+  Deny from all
+</IfModule>
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>


### PR DESCRIPTION
### Fixed

- Removed incorrect `inc` location configuration in main htaccess example and instead duplicated `/admin/backups/.htaccess` to `/inc/.htaccess`.

