### PR TITLE
Fix #4960: Undefined array key when spider visits a search results page

### DIFF
--- a/inc/class_session.php
+++ b/inc/class_session.php
@@ -450,6 +450,7 @@ class session
 		$mybb->user['displaygroup'] = $mybb->user['usergroup'];
 		$mybb->user['additionalgroups'] = '';
 		$mybb->user['invisible'] = 0;
+		$mybb->user['lastvisit'] = $spider['lastvisit'];
 
 		// Set spider language
 		if($spider['language'] && $lang->language_exists($spider['language']))


### PR DESCRIPTION
The warning message fixed is...

Undefined array key "lastvisit"

...and is triggered by line 975 of search.php.

Resolves #4960

