### PR TITLE
Fix broken avatar visuals in profile and quick reply

### DIFF
--- a/inc/themes/core.base/frontend/styles/components/_avatars.scss
+++ b/inc/themes/core.base/frontend/styles/components/_avatars.scss
@@ -54,5 +54,7 @@
 
     &__image {
         border-radius: $radius;
+        height: 100%;
+        width: 100%;
     }
 }


### PR DESCRIPTION
### Changed

Changed `.avatar__image` to always fill its container.

Before:
<img width="2405" height="1121" alt="image" src="https://github.com/user-attachments/assets/6daf3972-ddb7-498a-9163-6685ec4053e7" />
<img width="2637" height="837" alt="image" src="https://github.com/user-attachments/assets/f44e9da1-209c-498b-8603-7c6522c603c1" />

After:
<img width="2405" height="1121" alt="image" src="https://github.com/user-attachments/assets/748cba36-da00-46b7-89cc-16e12c885503" />
<img width="2637" height="837" alt="image" src="https://github.com/user-attachments/assets/2046001f-75e9-49a1-8486-f639c38dde1e" />


Resolves #4940
