### PR TITLE
Remove unnecessary <br /> tag in avatar help text

### DIFF
--- a/usercp.php
+++ b/usercp.php
@@ -2011,7 +2011,7 @@ if($mybb->input['action'] == "avatar")
 	if($mybb->settings['maxavatardims'] != "")
 	{
 		list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
-		$extranotes[] = "<br />".$lang->sprintf($lang->avatar_note_dimensions, $maxwidth, $maxheight);
+		$extranotes[] = $lang->sprintf($lang->avatar_note_dimensions, $maxwidth, $maxheight);
 	}
 
 	if($mybb->settings['avatarsize'])


### PR DESCRIPTION
### Removed

- Removed unnecessary `<br />` in avatar help text (My Account > Profile > Avatar).

Before:
<img width="1573" height="449" alt="image" src="https://github.com/user-attachments/assets/593cbbbe-e4ff-4270-9361-35a7ac56dd7f" />

After:
<img width="1573" height="449" alt="image" src="https://github.com/user-attachments/assets/dc88d9af-f062-469a-9dfc-0cdaf5a0fdb5" />

