### PR TITLE
Fix signature save logic

### DIFF
--- a/usercp.php
+++ b/usercp.php
@@ -68,7 +68,7 @@ if($mybb->input['action'] == "do_editsig" && $mybb->request_method == "post")
 		$error = inline_error($userhandler->get_friendly_errors());
 	}
 
-	if(isset($error) || !empty($mybb->input['preview']))
+	if(!empty($error) || !empty($mybb->input['preview']))
 	{
 		$mybb->input['action'] = "editsig";
 	}


### PR DESCRIPTION
Fixes an issue where updating a signature does not work in 1.9. The cause was the first `do_editsig` condition overwriting `$mybb->input['action']` even when there were no errors, preventing the second block from executing and saving the signature.