### PR TITLE
Fix template and styling for message edition

### DIFF
--- a/inc/themes/core.base/frontend/styles/pages/_posts.scss
+++ b/inc/themes/core.base/frontend/styles/pages/_posts.scss
@@ -67,6 +67,12 @@ $post-spacing: 25px;
         }
     }
 
+    &__edit-reason {
+        color: $alt-font-color-1;
+        margin-#{$left}: 4px;
+        font-size: 0.8em;
+    }
+
     &__ip-address {
         float: $right;
         font-size: 0.8em;

--- a/inc/themes/core.base/frontend/templates/postbit/postbit.twig
+++ b/inc/themes/core.base/frontend/templates/postbit/postbit.twig
@@ -95,10 +95,9 @@
             <input type="checkbox" class="checkbox post__inline-mod" name="inlinemod_{{ post.pid }}" id="inlinemod_{{ post.pid }}" value="1" {% if post.inlinechecked %}checked="checked"{% endif %}/>
         {% endif %}
 
-        {# TO DO : CLEAN UP EDITED MESSAGE #}
         {% if post.editedmsg %}
             <a href="#" class="post__edit-log" title="" id="edited_by_{{ post.pid }}">{{ include('partials/icon.twig', {icon: 'pencil-alt', class: ''}, with_context = false) }}</a>
-            <span class="edited_post" style="display: none;">({{ post.editnote|raw }} {{ post.editedprofilelink|raw }}.{% if post.editreason %} <em>{{ lang.postbit_editreason }}: {{ post.editreason }}</em>{% endif %})</span>
+            <span class="post__edit-reason">({{ post.editnote|raw }} {{ post.editedprofilelink|raw }}.{% if post.editreason %} <em>{{ lang.postbit_editreason }}: {{ post.editreason }}</em>{% endif %})</span>
         {% endif %}
 
         {# IP address #}


### PR DESCRIPTION
### Changed

- Updated the postbit template and related stylesheet to properly display the `edited by` message and reason.

### Example

<img width="1285" height="159" alt="image" src="https://github.com/user-attachments/assets/6fae79a1-fe85-460f-860f-9f7345b52fc8" />
