### PR TITLE
Disable home icon in footer when home settings are not set

### DIFF
--- a/inc/themes/core.base/frontend/templates/partials/footer.twig
+++ b/inc/themes/core.base/frontend/templates/partials/footer.twig
@@ -71,12 +71,14 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <li class="footer-menu__item">
-                            <a href="{{ mybb.settings.homeurl }}" class="footer-menu__link">
-                                {{ include('partials/icon.twig', {icon: 'home', class: 'footer-menu__icon'}, with_context = false) }}
-                                <span class="footer-menu__text">{{ mybb.settings.homename }}</span>
-                            </a>
-                        </li>
+                        {% if mybb.settings.homeurl and mybb.settings.homename %}
+                            <li class="footer-menu__item">
+                                <a href="{{ mybb.settings.homeurl }}" class="footer-menu__link">
+                                    {{ include('partials/icon.twig', {icon: 'home', class: 'footer-menu__icon'}, with_context = false) }}
+                                    <span class="footer-menu__text">{{ mybb.settings.homename }}</span>
+                                </a>
+                            </li>
+                        {% endif %}
                         <li class="footer-menu__item">
                             <a href="#top" class="footer-menu__link">
                                 {{ include('partials/icon.twig', {icon: 'arrow-up', class: 'footer-menu__icon'}, with_context = false) }}


### PR DESCRIPTION
- Added extra condition to `footer.twig` to avoid displaying home icon when related settings (homename and homeurl) are not set.


Resolves #5020

