### PR TITLE
Add missing indexes for SQLite

### DIFF
--- a/inc/db_pdo.php
+++ b/inc/db_pdo.php
@@ -167,7 +167,7 @@ class dbpdoEngine
 	 */
 	public function error_number($query)
 	{
-		if(!method_exists($query, "errorCode"))
+		if(!is_object($query) || !method_exists($query, "errorCode"))
 		{
 			return 0;
 		}

--- a/inc/schemas/pgsql_db_tables.php
+++ b/inc/schemas/pgsql_db_tables.php
@@ -573,6 +573,7 @@ $tables[] = "CREATE TABLE mybb_posts (
 );";
 
 $tables[] = "CREATE INDEX mybb_posts_tid_uid ON mybb_posts (tid, uid);";
+$tables[] = "CREATE INDEX mybb_posts_uid ON mybb_posts (uid);";
 $tables[] = "CREATE INDEX mybb_posts_visible ON mybb_posts (visible);";
 $tables[] = "CREATE INDEX mybb_posts_dateline ON mybb_posts (dateline);";
 $tables[] = "CREATE INDEX mybb_posts_ipaddress ON mybb_posts (ipaddress);";
@@ -732,6 +733,8 @@ $tables[] = "CREATE TABLE mybb_securitylog (
   dateline int NOT NULL default '0',
   type varchar(50) NOT NULL default ''
 );";
+
+$tables[] = "CREATE INDEX mybb_securitylog_uid ON mybb_securitylog (uid);";
 
 $tables[] = "CREATE TABLE mybb_searchlog (
   sid varchar(32) NOT NULL default '',
@@ -987,6 +990,7 @@ $tables[] = "CREATE TABLE mybb_threadsubscriptions (
   PRIMARY KEY (sid)
 );";
 
+$tables[] = "CREATE INDEX mybb_threadsubscriptions_uid ON mybb_threadsubscriptions (uid);";
 $tables[] = "CREATE INDEX mybb_threadsubscriptions_tid_notification ON mybb_threadsubscriptions (tid, notification);";
 
 $tables[] = "CREATE TABLE mybb_userfields (

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -17,6 +17,9 @@ $tables[] = "CREATE TABLE mybb_adminlog (
 	data TEXT NOT NULL
  );";
 
+$tables[] = "CREATE INDEX mybb_adminlog_module_action ON mybb_adminlog (module, action);";
+$tables[] = "CREATE INDEX mybb_adminlog_uid ON mybb_adminlog (uid);";
+
 $tables[] = "CREATE TABLE mybb_adminoptions (
 	uid int NOT NULL default '0',
 	cpstyle varchar(50) NOT NULL default '',
@@ -71,6 +74,8 @@ $tables[] = "CREATE TABLE mybb_announcements (
 	allowsmilies tinyint(1) NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_announcements_fid ON mybb_announcements (fid);";
+
 $tables[] = "CREATE TABLE mybb_attachments (
 	aid INTEGER PRIMARY KEY,
 	pid int(10) NOT NULL default '0',
@@ -85,6 +90,9 @@ $tables[] = "CREATE TABLE mybb_attachments (
 	visible tinyint(1) NOT NULL default '0',
 	thumbnail varchar(120) NOT NULL default ''
 );";
+
+$tables[] = "CREATE INDEX mybb_attachments_pid_visible ON mybb_attachments (pid, visible);";
+$tables[] = "CREATE INDEX mybb_attachments_uid ON mybb_attachments (uid);";
 
 $tables[] = "CREATE TABLE mybb_attachtypes (
 	atid INTEGER PRIMARY KEY,
@@ -125,6 +133,8 @@ $tables[] = "CREATE TABLE mybb_banfilters (
 	dateline int NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_banfilters_type ON mybb_banfilters (type);";
+
 $tables[] = "CREATE TABLE mybb_banned (
 	uid int NOT NULL default '0',
 	gid int NOT NULL default '0',
@@ -138,12 +148,18 @@ $tables[] = "CREATE TABLE mybb_banned (
 	reason varchar(255) NOT NULL default ''
 );";
 
+$tables[] = "CREATE INDEX mybb_banned_uid ON mybb_banned (uid);";
+$tables[] = "CREATE INDEX mybb_banned_dateline ON mybb_banned (dateline);";
+
 $tables[] = "CREATE TABLE mybb_buddyrequests (
 	id INTEGER PRIMARY KEY,
 	uid int NOT NULL default '0',
 	touid int NOT NULL default '0',
 	date int NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_buddyrequests_uid ON mybb_buddyrequests (uid);";
+$tables[] = "CREATE INDEX mybb_buddyrequests_touid ON mybb_buddyrequests (touid);";
 
 $tables[] = "CREATE TABLE mybb_calendars (
 	cid INTEGER PRIMARY KEY,
@@ -175,6 +191,9 @@ $tables[] = "CREATE TABLE mybb_captcha (
 	dateline int NOT NULL default '0',
 	used tinyint(1) NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_captcha_imagehash ON mybb_captcha (imagehash);";
+$tables[] = "CREATE INDEX mybb_captcha_dateline ON mybb_captcha (dateline);";
 
 $tables[] = "CREATE TABLE mybb_datacache (
 	title varchar(50) NOT NULL default '' PRIMARY KEY,
@@ -209,6 +228,10 @@ $tables[] = "CREATE TABLE mybb_events (
 	repeats TEXT NOT NULL
 );";
 
+$tables[] = "CREATE INDEX mybb_events_cid ON mybb_events (cid);";
+$tables[] = "CREATE INDEX mybb_events_daterange ON mybb_events (starttime, endtime);";
+$tables[] = "CREATE INDEX mybb_events_private ON mybb_events (private);";
+
 $tables[] = "CREATE TABLE mybb_forumpermissions (
 	pid INTEGER PRIMARY KEY,
 	fid int NOT NULL default '0',
@@ -235,6 +258,8 @@ $tables[] = "CREATE TABLE mybb_forumpermissions (
 	canvotepolls tinyint(1) NOT NULL default '0',
 	cansearch tinyint(1) NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_forumpermissions_fid_gid ON mybb_forumpermissions (fid, gid);";
 
 $tables[] = "CREATE TABLE mybb_forums (
 	fid INTEGER PRIMARY KEY,
@@ -286,11 +311,15 @@ $tables[] = "CREATE TABLE mybb_forumsread (
 	dateline int(10) NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_forumsread_dateline ON mybb_forumsread (dateline);";
+
 $tables[] = "CREATE TABLE mybb_forumsubscriptions (
 	fsid INTEGER PRIMARY KEY,
 	fid smallint NOT NULL default '0',
 	uid int NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_forumsubscriptions_uid ON mybb_forumsubscriptions (uid);";
 
 $tables[] = "CREATE TABLE mybb_groupleaders (
 	lid INTEGER PRIMARY KEY,
@@ -398,6 +427,10 @@ $tables[] = "CREATE TABLE mybb_moderatorlog (
 	ipaddress blob(16) NOT NULL default ''
 );";
 
+$tables[] = "CREATE INDEX mybb_moderatorlog_uid ON mybb_moderatorlog (uid);";
+$tables[] = "CREATE INDEX mybb_moderatorlog_fid ON mybb_moderatorlog (fid);";
+$tables[] = "CREATE INDEX mybb_moderatorlog_tid ON mybb_moderatorlog (tid);";
+
 $tables[] = "CREATE TABLE mybb_moderators (
 	mid INTEGER PRIMARY KEY,
 	fid smallint NOT NULL default '0',
@@ -427,6 +460,8 @@ $tables[] = "CREATE TABLE mybb_moderators (
 	canmanagereportedposts tinyint(1) NOT NULL default '0',
 	canviewmodlog tinyint(1) NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_moderators_id_fid ON mybb_moderators (id, fid);";
 
 $tables[] = "CREATE TABLE mybb_modtools (
 	tid INTEGER PRIMARY KEY,
@@ -465,6 +500,8 @@ $tables[] = "CREATE TABLE mybb_polls (
 	maxoptions smallint NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_polls_tid ON mybb_polls (tid);";
+
 $tables[] = "CREATE TABLE mybb_pollvotes (
 	vid INTEGER PRIMARY KEY,
 	pid int NOT NULL default '0',
@@ -473,6 +510,8 @@ $tables[] = "CREATE TABLE mybb_pollvotes (
 	dateline int NOT NULL default '0',
 	ipaddress blob(16) NOT NULL default ''
 );";
+
+$tables[] = "CREATE INDEX mybb_pollvotes_pid_uid ON mybb_pollvotes (pid, uid);";
 
 $tables[] = "CREATE TABLE mybb_posts (
 	pid INTEGER PRIMARY KEY,
@@ -494,6 +533,12 @@ $tables[] = "CREATE TABLE mybb_posts (
 	visible tinyint(1) NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_posts_tid_uid ON mybb_posts (tid, uid);";
+$tables[] = "CREATE INDEX mybb_posts_visible ON mybb_posts (visible);";
+$tables[] = "CREATE INDEX mybb_posts_dateline ON mybb_posts (dateline);";
+$tables[] = "CREATE INDEX mybb_posts_ipaddress ON mybb_posts (ipaddress);";
+$tables[] = "CREATE INDEX mybb_posts_tid_dateline ON mybb_posts (tid, dateline);";
+
 $tables[] = "CREATE TABLE mybb_privatemessages (
 	pmid INTEGER PRIMARY KEY,
 	uid int NOT NULL default '0',
@@ -514,6 +559,9 @@ $tables[] = "CREATE TABLE mybb_privatemessages (
 	readtime int NOT NULL default '0',
 	ipaddress blob(16) NOT NULL default ''
 );";
+
+$tables[] = "CREATE INDEX mybb_privatemessages_uid_folder ON mybb_privatemessages (uid, folder);";
+$tables[] = "CREATE INDEX mybb_privatemessages_toid ON mybb_privatemessages (toid);";
 
 $tables[] = "CREATE TABLE mybb_profilefields (
 	fid INTEGER PRIMARY KEY,
@@ -607,6 +655,9 @@ $tables[] = "CREATE TABLE mybb_reportedcontent (
 	lastreport int NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_reportedcontent_reportstatus ON mybb_reportedcontent (reportstatus);";
+$tables[] = "CREATE INDEX mybb_reportedcontent_lastreport ON mybb_reportedcontent (lastreport);";
+
 $tables[] = "CREATE TABLE mybb_reportreasons (
 	rid INTEGER PRIMARY KEY,
 	title varchar(250) NOT NULL default '',
@@ -624,6 +675,8 @@ $tables[] = "CREATE TABLE mybb_reputation (
 	dateline int NOT NULL default '0',
 	comments TEXT NOT NULL
 );";
+
+$tables[] = "CREATE INDEX mybb_reputation_uid ON mybb_reputation (uid);";
 
 $tables[] = "CREATE TABLE mybb_securitylog (
 	uid int NOT NULL default '0',
@@ -657,6 +710,11 @@ $tables[] = "CREATE TABLE mybb_sessions (
 	location2 int(10) NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_sessions_location ON mybb_sessions (location1, location2);";
+$tables[] = "CREATE INDEX mybb_sessions_time ON mybb_sessions (time);";
+$tables[] = "CREATE INDEX mybb_sessions_uid ON mybb_sessions (uid);";
+$tables[] = "CREATE INDEX mybb_sessions_ip ON mybb_sessions (ip);";
+
 $tables[] = "CREATE TABLE mybb_settinggroups (
 	gid INTEGER PRIMARY KEY,
 	name varchar(100) NOT NULL default '',
@@ -677,6 +735,8 @@ $tables[] = "CREATE TABLE mybb_settings (
 	gid smallint NOT NULL default '0',
 	isdefault tinyint(1) NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_settings_gid ON mybb_settings (gid);";
 
 $tables[] = "CREATE TABLE mybb_smilies (
 	sid INTEGER PRIMARY KEY,
@@ -754,6 +814,8 @@ $tables[] = "CREATE TABLE mybb_templates (
 	dateline int(10) NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_templates_sid_title ON mybb_templates (sid, title);";
+
 $tables[] = "CREATE TABLE mybb_templatesets (
 	sid INTEGER PRIMARY KEY,
 	title varchar(120) NOT NULL default ''
@@ -779,6 +841,8 @@ $tables[] = "CREATE TABLE mybb_themestylesheets(
 	lastmodified int NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_themestylesheets_tid ON mybb_themestylesheets (tid);";
+
 $tables[] = "CREATE TABLE mybb_threadprefixes (
 	pid INTEGER PRIMARY KEY,
 	prefix varchar(120) NOT NULL default '',
@@ -795,9 +859,13 @@ $tables[] = "CREATE TABLE mybb_threadratings (
 	ipaddress blob(16) NOT NULL default ''
 );";
 
+$tables[] = "CREATE INDEX mybb_threadratings_tid ON mybb_threadratings (tid);";
+
 $tables[] = "CREATE TABLE mybb_threadviews (
 	tid int NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_threadviews_tid ON mybb_threadviews (tid);";
 
 $tables[] = "CREATE TABLE mybb_threads (
 	tid INTEGER PRIMARY KEY,
@@ -828,11 +896,19 @@ $tables[] = "CREATE TABLE mybb_threads (
 	deletetime int(10) NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_threads_fid ON mybb_threads (fid, visible, sticky);";
+$tables[] = "CREATE INDEX mybb_threads_dateline ON mybb_threads (dateline);";
+$tables[] = "CREATE INDEX mybb_threads_lastpost ON mybb_threads (lastpost, fid);";
+$tables[] = "CREATE INDEX mybb_threads_firstpost ON mybb_threads (firstpost);";
+$tables[] = "CREATE INDEX mybb_threads_uid ON mybb_threads (uid);";
+
 $tables[] = "CREATE TABLE mybb_threadsread (
 	tid int NOT NULL default '0',
 	uid int NOT NULL default '0',
 	dateline int(10) NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_threadsread_dateline ON mybb_threadsread (dateline);";
 
 $tables[] = "CREATE TABLE mybb_threadsubscriptions (
 	sid INTEGER PRIMARY KEY,
@@ -841,6 +917,8 @@ $tables[] = "CREATE TABLE mybb_threadsubscriptions (
 	notification tinyint(1) NOT NULL default '0',
 	dateline int NOT NULL default '0'
 );";
+
+$tables[] = "CREATE INDEX mybb_threadsubscriptions_tid_notification ON mybb_threadsubscriptions (tid, notification);";
 
 $tables[] = "CREATE TABLE mybb_userfields (
 	ufid int NOT NULL default '0',
@@ -1031,6 +1109,10 @@ $tables[] = "CREATE TABLE mybb_users (
 	sourceeditor tinyint(1) NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_users_usergroup ON mybb_users (usergroup);";
+$tables[] = "CREATE INDEX mybb_users_regip ON mybb_users (regip);";
+$tables[] = "CREATE INDEX mybb_users_lastip ON mybb_users (lastip);";
+
 $tables[] = "CREATE TABLE mybb_usertitles (
 	utid INTEGER PRIMARY KEY,
 	posts int NOT NULL default '0',
@@ -1069,3 +1151,4 @@ $tables[] = "CREATE TABLE mybb_warnings (
 	notes TEXT NOT NULL
 );";
 
+$tables[] = "CREATE INDEX mybb_warnings_uid ON mybb_warnings (uid);";

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -534,6 +534,7 @@ $tables[] = "CREATE TABLE mybb_posts (
 );";
 
 $tables[] = "CREATE INDEX mybb_posts_tid_uid ON mybb_posts (tid, uid);";
+$tables[] = "CREATE INDEX mybb_posts_uid ON mybb_posts (uid);";
 $tables[] = "CREATE INDEX mybb_posts_visible ON mybb_posts (visible);";
 $tables[] = "CREATE INDEX mybb_posts_dateline ON mybb_posts (dateline);";
 $tables[] = "CREATE INDEX mybb_posts_ipaddress ON mybb_posts (ipaddress);";
@@ -684,6 +685,8 @@ $tables[] = "CREATE TABLE mybb_securitylog (
 	dateline int NOT NULL default '0',
 	type varchar(50) NOT NULL default ''
  );";
+ 
+$tables[] = "CREATE INDEX mybb_securitylog_uid ON mybb_securitylog (uid);";
 
 $tables[] = "CREATE TABLE mybb_searchlog (
 	sid varchar(32) NOT NULL default '',
@@ -918,6 +921,7 @@ $tables[] = "CREATE TABLE mybb_threadsubscriptions (
 	dateline int NOT NULL default '0'
 );";
 
+$tables[] = "CREATE INDEX mybb_threadsubscriptions_uid ON mybb_threadsubscriptions (uid);";
 $tables[] = "CREATE INDEX mybb_threadsubscriptions_tid_notification ON mybb_threadsubscriptions (tid, notification);";
 
 $tables[] = "CREATE TABLE mybb_userfields (

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -21,6 +21,10 @@ $upgrade_detail = array(
 function upgrade100_dbchanges()
 {
     global $db;
+    
+    if ($db->type == 'sqlite') {
+        $db->close_cursors();
+    }
 
     // Drop deprecated columns
     if ($db->field_exists("google", "users")) {

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -191,6 +191,7 @@ function upgrade100_indexes()
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."polls_tid ON ".TABLE_PREFIX."polls (tid);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."pollvotes_pid_uid ON ".TABLE_PREFIX."pollvotes (pid, uid);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_tid_uid ON ".TABLE_PREFIX."posts (tid, uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_uid ON ".TABLE_PREFIX."posts (uid);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_visible ON ".TABLE_PREFIX."posts (visible);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_dateline ON ".TABLE_PREFIX."posts (dateline);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_ipaddress ON ".TABLE_PREFIX."posts (ipaddress);";
@@ -200,6 +201,7 @@ function upgrade100_indexes()
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."reportedcontent_reportstatus ON ".TABLE_PREFIX."reportedcontent (reportstatus);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."reportedcontent_lastreport ON ".TABLE_PREFIX."reportedcontent (lastreport);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."reputation_uid ON ".TABLE_PREFIX."reputation (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."securitylog_uid ON ".TABLE_PREFIX."securitylog (uid);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."sessions_location ON ".TABLE_PREFIX."sessions (location1, location2);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."sessions_time ON ".TABLE_PREFIX."sessions (time);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."sessions_uid ON ".TABLE_PREFIX."sessions (uid);";
@@ -215,6 +217,7 @@ function upgrade100_indexes()
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threads_firstpost ON ".TABLE_PREFIX."threads (firstpost);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threads_uid ON ".TABLE_PREFIX."threads (uid);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadsread_dateline ON ".TABLE_PREFIX."threadsread (dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadsubscriptions_uid ON ".TABLE_PREFIX."threadsubscriptions (uid);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadsubscriptions_tid_notification ON ".TABLE_PREFIX."threadsubscriptions (tid, notification);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_usergroup ON ".TABLE_PREFIX."users (usergroup);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_regip ON ".TABLE_PREFIX."users (regip);";

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -159,3 +159,70 @@ function upgrade100_dbchanges()
     // Remove deprecated settings
     $db->delete_query("settings", "name='mail_parameters'");
 }
+
+function upgrade100_indexes()
+{
+    global $db;
+    $indexes = [];
+
+    if (in_array($db->type, array('sqlite', 'pgsql'))) {
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."adminlog_module_action ON ".TABLE_PREFIX."adminlog (module, action);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."adminlog_uid ON ".TABLE_PREFIX."adminlog (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."announcements_fid ON ".TABLE_PREFIX."announcements (fid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."attachments_pid_visible ON ".TABLE_PREFIX."attachments (pid, visible);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."attachments_uid ON ".TABLE_PREFIX."attachments (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."banfilters_type ON ".TABLE_PREFIX."banfilters (type);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."banned_uid ON ".TABLE_PREFIX."banned (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."banned_dateline ON ".TABLE_PREFIX."banned (dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."buddyrequests_uid ON ".TABLE_PREFIX."buddyrequests (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."buddyrequests_touid ON ".TABLE_PREFIX."buddyrequests (touid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."captcha_imagehash ON ".TABLE_PREFIX."captcha (imagehash);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."captcha_dateline ON ".TABLE_PREFIX."captcha (dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."events_cid ON ".TABLE_PREFIX."events (cid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."events_daterange ON ".TABLE_PREFIX."events (starttime, endtime);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."events_private ON ".TABLE_PREFIX."events (private);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."forumpermissions_fid_gid ON ".TABLE_PREFIX."forumpermissions (fid, gid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."forumsread_dateline ON ".TABLE_PREFIX."forumsread (dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."forumsubscriptions_uid ON ".TABLE_PREFIX."forumsubscriptions (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."moderatorlog_uid ON ".TABLE_PREFIX."moderatorlog (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."moderatorlog_fid ON ".TABLE_PREFIX."moderatorlog (fid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."moderatorlog_tid ON ".TABLE_PREFIX."moderatorlog (tid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."moderators_id_fid ON ".TABLE_PREFIX."moderators (id, fid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."polls_tid ON ".TABLE_PREFIX."polls (tid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."pollvotes_pid_uid ON ".TABLE_PREFIX."pollvotes (pid, uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_tid_uid ON ".TABLE_PREFIX."posts (tid, uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_visible ON ".TABLE_PREFIX."posts (visible);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_dateline ON ".TABLE_PREFIX."posts (dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_ipaddress ON ".TABLE_PREFIX."posts (ipaddress);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."posts_tid_dateline ON ".TABLE_PREFIX."posts (tid, dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."privatemessages_uid_folder ON ".TABLE_PREFIX."privatemessages (uid, folder);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."privatemessages_toid ON ".TABLE_PREFIX."privatemessages (toid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."reportedcontent_reportstatus ON ".TABLE_PREFIX."reportedcontent (reportstatus);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."reportedcontent_lastreport ON ".TABLE_PREFIX."reportedcontent (lastreport);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."reputation_uid ON ".TABLE_PREFIX."reputation (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."sessions_location ON ".TABLE_PREFIX."sessions (location1, location2);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."sessions_time ON ".TABLE_PREFIX."sessions (time);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."sessions_uid ON ".TABLE_PREFIX."sessions (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."sessions_ip ON ".TABLE_PREFIX."sessions (ip);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."settings_gid ON ".TABLE_PREFIX."settings (gid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."templates_sid_title ON ".TABLE_PREFIX."templates (sid, title);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."themestylesheets_tid ON ".TABLE_PREFIX."themestylesheets (tid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadratings_tid ON ".TABLE_PREFIX."threadratings (tid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadviews_tid ON ".TABLE_PREFIX."threadviews (tid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threads_fid ON ".TABLE_PREFIX."threads (fid, visible, sticky);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threads_dateline ON ".TABLE_PREFIX."threads (dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threads_lastpost ON ".TABLE_PREFIX."threads (lastpost, fid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threads_firstpost ON ".TABLE_PREFIX."threads (firstpost);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threads_uid ON ".TABLE_PREFIX."threads (uid);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadsread_dateline ON ".TABLE_PREFIX."threadsread (dateline);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadsubscriptions_tid_notification ON ".TABLE_PREFIX."threadsubscriptions (tid, notification);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_usergroup ON ".TABLE_PREFIX."users (usergroup);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_regip ON ".TABLE_PREFIX."users (regip);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_lastip ON ".TABLE_PREFIX."users (lastip);";
+        $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."warnings_uid ON ".TABLE_PREFIX."warnings (uid);";
+
+        foreach ($indexes as $index) {
+            $db->write_query($index);
+        }
+    }
+}

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -39,7 +39,7 @@ function upgrade100_dbchanges()
     // Add userfields columns
     foreach (["fid4", "fid5", "fid6"] as $fid) {
         if (!$db->field_exists($fid, "userfields")) {
-            $db->add_column("userfields", $fid, "text NOT NULL");
+            $db->add_column("userfields", $fid, "text NOT NULL DEFAULT ''");
         }
     }
 


### PR DESCRIPTION
### Added

- Added missing indexes to the SQLite schema.
- Added missing index creation to the 1.9 upgrade script.

### Fixed

- SQLite migrations not working due to:
  - Missing call to `close_cursors`.
  - New `fid4`, `fid5`, `fid6` columns set as `NOT NULL` without a default value.
  - `error_number` throwing an exception because `rename_column` in `db_sqlite.php` returns a boolean, not a PDO object.

### Tested

- Verified CLI upgrade.
- Verified GUI update.

Resolves #3772
