### PR TITLE
Add support for Redis authentication

### DIFF
--- a/inc/cachehandlers/redis.php
+++ b/inc/cachehandlers/redis.php
@@ -74,6 +74,27 @@ class redisCacheHandler implements CacheHandlerInterface
 			die;
 		}
 
+		// Authenticate if credentials are provided
+		if(!empty($mybb->config['redis']['password']))
+		{
+			// Redis 6+ supports ACLs (username+password), fallback to password only
+			if(!empty($mybb->config['redis']['username']))
+			{
+				$auth = $this->redis->auth([$mybb->config['redis']['username'], $mybb->config['redis']['password']]);
+			}
+			else
+			{
+				$auth = $this->redis->auth($mybb->config['redis']['password']);
+			}
+
+			if(!$auth)
+			{
+				$message = "Unable to authenticate to the redis server. Check your credentials.";
+				$error_handler->trigger($message, MYBB_CACHEHANDLER_LOAD_ERROR);
+				die;
+			}
+		}
+
 		// Set a unique identifier for all queries in case other forums are using the same redis server
 		$this->unique_id = md5(MYBB_ROOT);
 

--- a/inc/src/Maintenance/functions_data.php
+++ b/inc/src/Maintenance/functions_data.php
@@ -110,6 +110,8 @@ function writeConfigurationFile(array $config): void
 
     \$config['redis']['host'] = 'localhost';
     \$config['redis']['port'] = 6379;
+    \$config['redis']['username'] = '';
+    \$config['redis']['password'] = '';
 
     /**
      * Super Administrators


### PR DESCRIPTION
### Added

- Added support for Redis authentication (password-only or username/password when using ACLs).
- Added two new configuration parameters: `username` and `password`.

### Tested

- Tested with both authentication methods on Redis 8.

Resolves #4357

