### PR TITLE
Add support settings to language properties form

### DIFF
--- a/admin/modules/config/languages.php
+++ b/admin/modules/config/languages.php
@@ -68,6 +68,12 @@ if($mybb->input['action'] == "edit_properties")
 // The language authors website
 \$langinfo['website'] = \"{$langinfo['website']}\";
 
+// The support website link
+\$langinfo['support_link'] = \"{$newlanginfo['support_link']}\";
+
+// The support website name
+\$langinfo['support_name'] = \"{$newlanginfo['support_name']}\";
+
 // Compatible version of MyBB
 \$langinfo['version'] = \"{$langinfo['version']}\";
 
@@ -151,6 +157,8 @@ if($mybb->input['action'] == "edit_properties")
 		$mybb->input['info']['name'] = $langinfo['name'];
 		$mybb->input['info']['htmllang'] = $langinfo['htmllang'];
 		$mybb->input['info']['charset'] = $langinfo['charset'];
+		$mybb->input['info']['support_link'] = $langinfo['support_link'];
+		$mybb->input['info']['support_name'] = $langinfo['support_name'];
 	}
 
 	$form_container = new FormContainer($lang->edit_properties);
@@ -160,6 +168,8 @@ if($mybb->input['action'] == "edit_properties")
 	$form_container->output_row($lang->charset." <em>*</em>", "", $form->generate_text_box('info[charset]', $mybb->input['info']['charset'], array('id' => 'charset')), 'charset');
 	$form_container->output_row($lang->rtl." <em>*</em>", "", $form->generate_yes_no_radio('info[rtl]', $mybb->input['info']['rtl'], array('id' => 'rtl')), 'rtl');
 	$form_container->output_row($lang->admin." <em>*</em>", "", $form->generate_yes_no_radio('info[admin]', $mybb->input['info']['admin'], array('id' => 'admin')), 'admin');
+	$form_container->output_row($lang->support_link, "", $form->generate_text_box('info[support_link]', $mybb->input['info']['support_link'], array('id' => 'support_link')), 'support_link');
+	$form_container->output_row($lang->support_name, "", $form->generate_text_box('info[support_name]', $mybb->input['info']['support_name'], array('id' => 'support_name')), 'support_name');
 
 	// Check if file is writable, before allowing submission
 	if(!is_writable($file))

--- a/inc/languages/english.php
+++ b/inc/languages/english.php
@@ -23,8 +23,8 @@ $langinfo['website'] = "https://mybb.com/";
 // The support website link
 //$langinfo['support_link'] = "";
 
-// The additional website name
-//$langinfo['additional_name'] = " ";
+// The support website name
+//$langinfo['support_name'] = " ";
 
 // Compatible version of MyBB
 $langinfo['version'] = "1839";

--- a/inc/languages/english/admin/config_languages.lang.php
+++ b/inc/languages/english/admin/config_languages.lang.php
@@ -28,6 +28,8 @@ $l['language_in_html'] = "Language in &lt;html&gt; tag";
 $l['charset'] = "Character Set";
 $l['admin'] = "Contains Admin CP language variables?";
 $l['rtl'] = "Right-To-Left?";
+$l['support_link'] = "Support Website Link";
+$l['support_name'] = "Support Website Name";
 
 $l['quickphrases_agreement'] = 'Registration Agreement - Title';
 $l['quickphrases_agreement_1'] = 'Registration Agreement - Paragraph 1';


### PR DESCRIPTION
### Added

- Added fields for `support_link` and `support_name` to the languages properties form.

### Changed

- Renamed `additional_name` to `support_name` to match the rest of the code (`additional_name` not used anywhere else).

Resolves #4382

