### PR TITLE
Fix language fallback to respect ACP default and user profile settings

### DIFF
--- a/global.php
+++ b/global.php
@@ -89,7 +89,10 @@ elseif(!$mybb->user['uid'] && !empty($mybb->cookies['mybblang']) && $lang->langu
 }
 else
 {
-	$mybb->settings['bblanguage'] = 'english';
+	if(empty($mybb->settings['bblanguage']) || !$lang->language_exists($mybb->settings['bblanguage']))
+	{
+		$mybb->settings['bblanguage'] = 'english';
+	}
 }
 
 // Load language


### PR DESCRIPTION
### Fixed

- Ensured the forum respects the ACP default and user profile language instead of always falling back to English.

Resolves #5043

