### PR TITLE
Fix footer language selector display by checking options array

### DIFF
--- a/global.php
+++ b/global.php
@@ -892,7 +892,7 @@ if($mybb->settings['showlanguageselect'] != 0)
 {
 	$mybb->settings['footer']['langselect']['options'] = $lang->get_languages();
 
-	if(count($mybb->settings['footer']['langselect']) > 1)
+	if(count($mybb->settings['footer']['langselect']['options']) > 1)
 	{
 		$mybb->settings['footer']['langselect']['current_url'] = get_current_location(true, 'language');
 	}

--- a/inc/themes/core.base/frontend/templates/partials/footer.twig
+++ b/inc/themes/core.base/frontend/templates/partials/footer.twig
@@ -4,7 +4,7 @@
     <footer class="footer">
         <div class="wrapper wrapper--footer">
             <div class="footer__selectors">
-                {% if mybb.settings.footer.langselect is iterable and mybb.settings.footer.langselect|length > 1 %}
+                {% if mybb.settings.footer.langselect.options is iterable and mybb.settings.footer.langselect.options|length > 1 %}
                     <div class="language">
                         <form method="post" action="{{ mybb.settings.footer.langselect.current_url.location }}" id="lang_select">
                             <input type="hidden" name="my_post_key" value="{{ mybb.post_code }}" />


### PR DESCRIPTION
### Fixed

- Fixed the footer language selector so it correctly appears when multiple languages are available.

Resolves #5042

