### PR TITLE
Add missing SQLite primary and unique keys

### DIFF
--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -21,7 +21,7 @@ $tables[] = "CREATE INDEX mybb_adminlog_module_action ON mybb_adminlog (module, 
 $tables[] = "CREATE INDEX mybb_adminlog_uid ON mybb_adminlog (uid);";
 
 $tables[] = "CREATE TABLE mybb_adminoptions (
-	uid int NOT NULL default '0',
+	uid INTEGER PRIMARY KEY,
 	cpstyle varchar(50) NOT NULL default '',
 	cplanguage varchar(50) NOT NULL default '',
 	codepress tinyint(1) NOT NULL default '1',
@@ -636,7 +636,7 @@ $tables[] = "CREATE TABLE mybb_questions (
 );";
 
 $tables[] = "CREATE TABLE mybb_questionsessions (
-	sid varchar(32) NOT NULL default '',
+	sid varchar(32) NOT NULL default '' PRIMARY KEY,
 	qid int NOT NULL default '0',
 	dateline int NOT NULL default '0'
 );";
@@ -690,7 +690,7 @@ $tables[] = "CREATE TABLE mybb_securitylog (
 $tables[] = "CREATE INDEX mybb_securitylog_uid ON mybb_securitylog (uid);";
 
 $tables[] = "CREATE TABLE mybb_searchlog (
-	sid varchar(32) NOT NULL default '',
+	sid varchar(32) NOT NULL default '' PRIMARY KEY,
 	uid int NOT NULL default '0',
 	dateline int NOT NULL default '0',
 	ipaddress blob(16) NOT NULL default '',
@@ -702,7 +702,7 @@ $tables[] = "CREATE TABLE mybb_searchlog (
 );";
 
 $tables[] = "CREATE TABLE mybb_sessions (
-	sid varchar(32) NOT NULL default '',
+	sid varchar(32) NOT NULL default '' PRIMARY KEY,
 	uid int NOT NULL default '0',
 	ip blob(16) NOT NULL default '',
 	time int NOT NULL default '0',
@@ -927,7 +927,7 @@ $tables[] = "CREATE INDEX mybb_threadsubscriptions_uid ON mybb_threadsubscriptio
 $tables[] = "CREATE INDEX mybb_threadsubscriptions_tid_notification ON mybb_threadsubscriptions (tid, notification);";
 
 $tables[] = "CREATE TABLE mybb_userfields (
-	ufid int NOT NULL default '0',
+	ufid INTEGER PRIMARY KEY,
 	fid1 TEXT NOT NULL,
 	fid2 TEXT NOT NULL,
 	fid3 TEXT NOT NULL,

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -308,7 +308,8 @@ $tables[] = "CREATE TABLE mybb_forums (
 $tables[] = "CREATE TABLE mybb_forumsread (
 	fid int NOT NULL default '0',
 	uid int NOT NULL default '0',
-	dateline int(10) NOT NULL default '0'
+	dateline int(10) NOT NULL default '0',
+	UNIQUE (fid, uid)
 );";
 
 $tables[] = "CREATE INDEX mybb_forumsread_dateline ON mybb_forumsread (dateline);";
@@ -908,7 +909,8 @@ $tables[] = "CREATE INDEX mybb_threads_uid ON mybb_threads (uid);";
 $tables[] = "CREATE TABLE mybb_threadsread (
 	tid int NOT NULL default '0',
 	uid int NOT NULL default '0',
-	dateline int(10) NOT NULL default '0'
+	dateline int(10) NOT NULL default '0',
+	UNIQUE (tid, uid)
 );";
 
 $tables[] = "CREATE INDEX mybb_threadsread_dateline ON mybb_threadsread (dateline);";
@@ -1110,7 +1112,8 @@ $tables[] = "CREATE TABLE mybb_users (
 	loginattempts smallint(2) NOT NULL default '0',
 	loginlockoutexpiry int NOT NULL default '0',
 	usernotes TEXT NOT NULL,
-	sourceeditor tinyint(1) NOT NULL default '0'
+	sourceeditor tinyint(1) NOT NULL default '0',
+	UNIQUE (username)
 );";
 
 $tables[] = "CREATE INDEX mybb_users_usergroup ON mybb_users (usergroup);";

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -21,7 +21,7 @@ $upgrade_detail = array(
 function upgrade100_dbchanges()
 {
     global $db;
-    
+
     if ($db->type == 'sqlite') {
         $db->close_cursors();
     }
@@ -223,9 +223,15 @@ function upgrade100_indexes()
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_regip ON ".TABLE_PREFIX."users (regip);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_lastip ON ".TABLE_PREFIX."users (lastip);";
         $indexes[] = "CREATE INDEX IF NOT EXISTS ".TABLE_PREFIX."warnings_uid ON ".TABLE_PREFIX."warnings (uid);";
+    }
 
-        foreach ($indexes as $index) {
-            $db->write_query($index);
-        }
+    if ($db->type == 'sqlite') {
+        $indexes[] = "CREATE UNIQUE INDEX IF NOT EXISTS ".TABLE_PREFIX."forumsread_fid_uid_uq ON ".TABLE_PREFIX."forumsread (fid, uid);";
+        $indexes[] = "CREATE UNIQUE INDEX IF NOT EXISTS ".TABLE_PREFIX."threadsread_tid_uid_uq ON ".TABLE_PREFIX."threadsread (tid, uid);";
+        $indexes[] = "CREATE UNIQUE INDEX IF NOT EXISTS ".TABLE_PREFIX."users_username_uq ON ".TABLE_PREFIX."users (username);";
+    }
+
+    foreach ($indexes as $index) {
+        $db->write_query($index);
     }
 }


### PR DESCRIPTION
### Added

- Missing SQLite primary keys.
- Missing SQLite unique keys.
- SQLite migration to add unique keys.

### Changed

- Moved the foreach outside of the conditional in `upgrade100_indexes`.


Related to #5022

