### PR TITLE
Add missing asset inclusion to showthread template

### DIFF
--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -206,6 +206,7 @@
             </div>
         </div>
 
+        {{ asset('jscripts/thread.js', static=true) }}
         <section class="post-list" id="posts">
             {{ posts|raw }}
         </section>


### PR DESCRIPTION
### Added

- Added missing reference to the `thread.js` asset, which prevented thread actions such as *Quick Edit*, *Quote*, and others from working.