### PR TITLE
Add usercount to usergroups cache and pagination to ACP groups module

### DIFF
--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -1403,6 +1403,25 @@ if($mybb->input['action'] == "disporder" && $mybb->request_method == "post")
 
 if(!$mybb->input['action'])
 {
+	$query = $db->simple_select("usergroups", "COUNT(gid) as usergroups");
+	$total_rows = $db->fetch_field($query, "usergroups");
+	$pagenum = $mybb->get_input('page', MyBB::INPUT_INT);
+	if($pagenum)
+	{
+		$start = ($pagenum-1) * 20;
+		$pages = ceil($total_rows / 20);
+		if($pagenum > $pages)
+		{
+			$start = 0;
+			$pagenum = 1;
+		}
+	}
+	else
+	{
+		$start = 0;
+		$pagenum = 1;
+	}
+
 	$plugins->run_hooks("admin_user_groups_start");
 
 	if($mybb->request_method == "post")
@@ -1500,7 +1519,7 @@ if(!$mybb->input['action'])
 	$form_container->output_row_header($lang->order, array("class" => "align_center", 'width' => '5%'));
 	$form_container->output_row_header($lang->controls, array("class" => "align_center"));
 
-	$query = $db->simple_select("usergroups", "*", "", array('order_by' => 'disporder'));
+	$query = $db->simple_select("usergroups", "*", "", array('limit_start' => $start, 'limit' => 20, 'order_by' => 'disporder'));
 	while($usergroup = $db->fetch_array($query))
 	{
 		if($usergroup['type'] > 1)
@@ -1590,6 +1609,6 @@ if(!$mybb->input['action'])
 <img src="styles/default/images/icons/default.png" alt="{$lang->default_user_group}" style="vertical-align: middle;" /> {$lang->default_user_group}
 </fieldset>
 LEGEND;
-
+	echo "<br />".draw_admin_pagination($pagenum, "20", $total_rows, "index.php?module=user-groups&amp;page={page}");
 	$page->output_footer();
 }

--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -1450,43 +1450,6 @@ if(!$mybb->input['action'])
 
 	$form = new Form("index.php?module=user-groups", "post", "groups");
 
-	$primaryusers = $secondaryusers = array();
-
-	$query = $db->query("
-		SELECT g.gid, COUNT(u.uid) AS users
-		FROM ".TABLE_PREFIX."users u
-		LEFT JOIN ".TABLE_PREFIX."usergroups g ON (g.gid=u.usergroup)
-		GROUP BY g.gid
-	");
-	while($groupcount = $db->fetch_array($query))
-	{
-		$primaryusers[$groupcount['gid']] = $groupcount['users'];
-	}
-
-	switch($db->type)
-	{
-		case "pgsql":
-		case "sqlite":
-			$query = $db->query("
-				SELECT g.gid, COUNT(u.uid) AS users
-				FROM ".TABLE_PREFIX."users u
-				LEFT JOIN ".TABLE_PREFIX."usergroups g ON (','|| u.additionalgroups|| ',' LIKE '%,'|| g.gid|| ',%')
-				WHERE g.gid != '0' AND g.gid is not NULL GROUP BY g.gid
-			");
-			break;
-		default:
-			$query = $db->query("
-				SELECT g.gid, COUNT(u.uid) AS users
-				FROM ".TABLE_PREFIX."users u
-				LEFT JOIN ".TABLE_PREFIX."usergroups g ON (CONCAT(',', u.additionalgroups, ',') LIKE CONCAT('%,', g.gid, ',%'))
-				WHERE g.gid != '0' AND g.gid is not NULL GROUP BY g.gid
-			");
-	}
-	while($groupcount = $db->fetch_array($query))
-	{
-		$secondaryusers[$groupcount['gid']] = $groupcount['users'];
-	}
-
 	$query = $db->query("
 		SELECT g.gid, COUNT(r.uid) AS users
 		FROM ".TABLE_PREFIX."joinrequests r
@@ -1549,16 +1512,15 @@ if(!$mybb->input['action'])
 
 		$form_container->output_cell("<div class=\"float_right\">{$icon}</div><div><strong><a href=\"index.php?module=user-groups&amp;action=edit&amp;gid={$usergroup['gid']}\">".format_name(htmlspecialchars_uni($usergroup['title']), $usergroup['gid'])."</a></strong>{$join_requests}<br /><small>".htmlspecialchars_uni($usergroup['description'])."{$leaders_list}</small></div>");
 
-		if(!isset($primaryusers[$usergroup['gid']]))
+		$groupscache = $cache->read('usergroups');
+
+		if(!is_array($groupscache))
 		{
-			$primaryusers[$usergroup['gid']] = 0;
+			$cache->update_usergroups();
+			$groupscache = $cache->read('usergroups');
 		}
-		if(!isset($secondaryusers[$usergroup['gid']]))
-		{
-			$secondaryusers[$usergroup['gid']] = 0;
-		}
-		$numusers = $primaryusers[$usergroup['gid']];
-		$numusers += $secondaryusers[$usergroup['gid']];
+
+		$numusers = isset($groupscache[$usergroup['gid']]['usercount']) ? $groupscache[$usergroup['gid']]['usercount'] : 0;
 
 		$form_container->output_cell(my_number_format($numusers), array("class" => "align_center"));
 

--- a/inc/class_datacache.php
+++ b/inc/class_datacache.php
@@ -532,6 +532,26 @@ class datacache
 		while($g = $db->fetch_array($query))
 		{
 			$gs[$g['gid']] = $g;
+			$gs[$g['gid']]['usercount'] = 0;
+		}
+
+		// Build usercount cache for each group
+		$query = $db->simple_select('users', 'usergroup, additionalgroups');
+		while($user = $db->fetch_array($query))
+		{
+			$groups = array($user['usergroup']);
+			if(!empty($user['additionalgroups']))
+			{
+				$groups = array_merge($groups, explode(',', $user['additionalgroups']));
+			}
+
+			foreach($groups as $gid)
+			{
+				if(isset($gs[$gid]))
+				{
+					$gs[$gid]['usercount']++;
+				}
+			}
 		}
 
 		$this->update("usergroups", $gs);


### PR DESCRIPTION
### Added
- Pagination to the Admin CP User-Groups module.

### Changed
- Updated the `update_usergroups()` cache function to include `usercount` for each group.
- Replaced the user count SQL queries in the Admin CP User-Groups module with a lookup from the cache.

Resolves #4436