### PR TITLE
Update insert_query_multiple to ensure fields/values are ordered

### DIFF
--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -185,24 +185,29 @@ class MysqlPdoDbDriver extends AbstractPdoDbDriver
 		}
 
 		// Field names
-		$fields = array_keys($array[array_key_first($array)]);
-		$fields = "`".implode("`,`", $fields)."`";
+		$fields_array = array_keys($array[array_key_first($array)]);
+		$fields = "`" . implode("`,`", $fields_array) . "`";
 
 		$insert_rows = array();
 		foreach ($array as $values) {
-			foreach ($values as $field => $value) {
-				if (isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
-					if($value[0] != 'X') { // Not escaped?
+			$ordered_values = array();
+			foreach($fields_array as $field)
+			{
+				$value = $values[$field] ?? null;
+
+				if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
+				{
+					if($value !== null && $value[0] != 'X') // Not escaped?
+					{
 						$value = $this->escape_binary($value);
 					}
-
-					$values[$field] = $value;
+					$ordered_values[$field] = $value;
 				} else {
-					$values[$field] = $this->quote_val($value);
+					$ordered_values[$field] = $this->quote_val($value);
 				}
 			}
 
-			$insert_rows[] = "(".implode(",", $values).")";
+			$insert_rows[] = "(" . implode(",", $ordered_values) . ")";
 		}
 
 		$insert_rows = implode(", ", $insert_rows);

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -791,29 +791,31 @@ class DB_MySQLi implements DB_Base
 			return;
 		}
 		// Field names
-		$fields = array_keys($array[array_key_first($array)]);
-		$fields = "`".implode("`,`", $fields)."`";
+		$fields_array = array_keys($array[array_key_first($array)]);
+		$fields = "`" . implode("`,`", $fields_array) . "`";
 
 		$insert_rows = array();
 		foreach($array as $values)
 		{
-			foreach($values as $field => $value)
+			$ordered_values = array();
+			foreach($fields_array as $field)
 			{
+				$value = $values[$field] ?? null;
+
 				if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
 				{
-					if($value[0] != 'X') // Not escaped?
+					if($value !== null && $value[0] != 'X') // Not escaped?
 					{
 						$value = $this->escape_binary($value);
 					}
-
-					$values[$field] = $value;
+					$ordered_values[$field] = $value;
 				}
 				else
 				{
-					$values[$field] = $this->quote_val($value);
+					$ordered_values[$field] = $this->quote_val($value);
 				}
 			}
-			$insert_rows[] = "(".implode(",", $values).")";
+			$insert_rows[] = "(" . implode(",", $ordered_values) . ")";
 		}
 		$insert_rows = implode(", ", $insert_rows);
 

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -792,24 +792,26 @@ class DB_PgSQL implements DB_Base
 			return;
 		}
 		// Field names
-		$fields = array_keys($array[array_key_first($array)]);
-		$fields = implode(",", $fields);
+		$fields_array = array_keys($array[array_key_first($array)]);
+		$fields = implode(",", $fields_array);
 
 		$insert_rows = array();
 		foreach($array as $values)
 		{
-			foreach($values as $field => $value)
+			$ordered_values = array();
+			foreach($fields_array as $field)
 			{
+				$value = $values[$field] ?? null;
 				if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
 				{
-					$values[$field] = $value;
+					$ordered_values[$field] = $value;
 				}
 				else
 				{
-					$values[$field] = $this->quote_val($value);
+					$ordered_values[$field] = $this->quote_val($value);
 				}
 			}
-			$insert_rows[] = "(".implode(",", $values).")";
+			$insert_rows[] = "(" . implode(",", $ordered_values) . ")";
 		}
 		$insert_rows = implode(", ", $insert_rows);
 

--- a/inc/db_pgsql_pdo.php
+++ b/inc/db_pgsql_pdo.php
@@ -156,17 +156,23 @@ class PostgresPdoDbDriver extends AbstractPdoDbDriver
 
 	public function insert_query_multiple($table, $array)
 	{
-		if (!is_array($array) || empty($array)){
+		if(!is_array($array) || empty($array))
+		{
 			return;
 		}
 
 		// Field names
-		$fields = array_keys($array[array_key_first($array)]);
-		$fields = implode(",", $fields);
+		$fields_array = array_keys($array[array_key_first($array)]);
+		$fields = implode(",", $fields_array);
 
 		$insert_rows = array();
 		foreach ($array as $values) {
-			$insert_rows[] = "(".$this->build_value_string($table, $values).")";
+			$ordered_values = array();
+			foreach($fields_array as $field)
+			{
+				$ordered_values[$field] = $values[$field] ?? null;
+			}
+			$insert_rows[] = "(" . $this->build_value_string($table, $ordered_values) . ")";
 		}
 
 		$insert_rows = implode(", ", $insert_rows);

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -702,29 +702,31 @@ class DB_SQLite implements DB_Base
 			return;
 		}
 		// Field names
-		$fields = array_keys($array[array_key_first($array)]);
-		$fields = implode(",", $fields);
+		$fields_array = array_keys($array[array_key_first($array)]);
+		$fields = implode(",", $fields_array);
 
 		$insert_rows = array();
 		foreach($array as $values)
 		{
-			foreach($values as $field => $value)
+			$ordered_values = array();
+			foreach($fields_array as $field)
 			{
+				$value = $values[$field] ?? null;
+
 				if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
 				{
-					if($value[0] != 'X') // Not escaped?
+					if($value !== null && $value[0] != 'X') // Not escaped?
 					{
 						$value = $this->escape_binary($value);
 					}
-
-					$values[$field] = $value;
+					$ordered_values[$field] = $value;
 				}
 				else
 				{
-					$values[$field] = $this->quote_val($value);
+					$ordered_values[$field] = $this->quote_val($value);
 				}
 			}
-			$insert_rows[] = "(".implode(",", $values).")";
+			$insert_rows[] = "(" . implode(",", $ordered_values) . ")";
 		}
 		$insert_rows = implode(", ", $insert_rows);
 


### PR DESCRIPTION
### Changed

- Updated `insert_query_multiple` to make sure fields/values are properly ordered.  Tested with PostgreSQL 17, MariaDB and SQLite.

Resolves #4969

