### PR TITLE
Add setting to configure default mail format

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -614,9 +614,15 @@ function &get_my_mailhandler($use_buitlin = false)
  * @param string $return_email The email address to return to. Defaults to admin return email address.
  * @return bool True if the mail is sent, false otherwise.
  */
-function my_mail($to, $subject, $message, $from = "", $charset = "", $headers = "", $keep_alive = false, $format = "text", $message_text = "", $return_email = "")
+function my_mail($to, $subject, $message, $from = "", $charset = "", $headers = "", $keep_alive = false, $format = "", $message_text = "", $return_email = "")
 {
 	global $mybb, $plugins;
+
+	// Default to ACP setting if no format was explicitly passed
+	if(empty($format))
+	{
+		$format = !empty($mybb->settings['mail_format']) ? $mybb->settings['mail_format'] : 'text';
+	}
 
 	// Get our mail handler.
 	$mail = &get_my_mailhandler();

--- a/inc/seeds/settings.xml
+++ b/inc/seeds/settings.xml
@@ -2401,6 +2401,16 @@ min=1]]></optionscode>
 			<settingvalue><![CDATA[10]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
+		<setting name="mail_format">
+			<title>Email format</title>
+			<disporder>11</disporder>
+			<optionscode><![CDATA[select
+text=Plain text only
+html=HTML only
+both=Plain text + HTML]]></optionscode>
+			<settingvalue><![CDATA[text]]></settingvalue>		
+			<isdefault>1</isdefault>
+		</setting>
 	</settinggroup>
 	<settinggroup name="contactsettings" title="Contact Settings" description="The various options to change the behaviour of the contact page (contact.php)." disporder="25" isdefault="1">
 		<setting name="contact">


### PR DESCRIPTION
### Added
- New `mail_format` setting (defaults to `text`).

### Changed
- `my_mail` no longer enforces the `text` format; it now falls back to the `mail_format` setting when not explicitly defined.

Resolves #4808
