### PR TITLE
Fix recipients error in private message preview

### DIFF
--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -846,13 +846,13 @@ function build_postbit($post, $post_type=0)
 	$post['showbcc'] = false;
 	if($post_type == 2)
 	{
-		if(count($post['bcc_recipients']) > 0)
+		if(isset($post['bcc_recipients']) && count($post['bcc_recipients']) > 0)
 		{
 			$post['showbcc'] = true;
 			$post['bcc_recipients'] = implode(', ', $post['bcc_recipients']);
 		}
 
-		if(count($post['to_recipients']) > 0)
+		if(isset($post['to_recipients']) && count($post['to_recipients']) > 0)
 		{
 			$post['to_recipients'] = implode($lang->comma, $post['to_recipients']);
 		}


### PR DESCRIPTION
### Changed

- Added a check to make sure `bcc_recipients` and `to_recipients` are set.

### Issue

If you try to preview a private message without having set any recipients, the board will display an error:
```
Error Type
    Uncaught Exception (47)
Error Message
    count(): Argument #1 ($value) must be of type Countable|array, null given
Location
    inc/functions_post.php:849
Code

    845.	
    846.		$post['showbcc'] = false;
    847.		if($post_type == 2)
    848.		{
    849.			if(count($post['bcc_recipients']) > 0)
    850.			{
    851.				$post['showbcc'] = true;
```

