### PR TITLE
Remove reference to usercp2.php in subscribed threads template

### DIFF
--- a/inc/themes/core.base/frontend/templates/usercp/subscribed_threads.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/subscribed_threads.twig
@@ -56,7 +56,7 @@
         </div>
         <div class="page-controls">
             <div class="page-buttons">
-                <a href="usercp2.php?action=removesubscriptions&amp;my_post_key={{ mybb.post_code }}" class="button">
+                <a href="usercp.php?action=removesubscriptions&amp;my_post_key={{ mybb.post_code }}" class="button">
                     {{ include('partials/icon.twig', {icon: 'trash', class: 'button__icon'}, with_context = false) }}
                     <span class="button__text">{{ lang.remove_all_subscriptions }}</span>
                 </a>


### PR DESCRIPTION
### Changed

- Replaced the reference to `usercp2.php` with `usercp.php`.
