### PR TITLE
Fix error in ban insertion

### DIFF
--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -1889,7 +1889,8 @@ class UserDataHandler extends DataHandler
 
 		if($this->method == "insert")
 		{
-			$query = $db->simple_select("banned", "uid", "uid='{$ban['uid']}'");
+			$uid = (int)$ban['uid'];
+			$query = $db->simple_select("banned", "uid", "uid='{$uid}'");
 			if($db->fetch_field($query, "uid"))
 			{
 				$this->set_error('already_banned');


### PR DESCRIPTION
### Fixed

- When trying to ban a user, submitting the form without entering a username shows a stack trace instead of an error message indicating that the username is missing.