### PR TITLE
Fix offset error in calendar weekview

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -2220,6 +2220,7 @@ if($mybb->input['action'] == "weekview")
 	$days = [];
 	while($weekday_date <= $week_to_stamp)
 	{
+		$day = [];
 		$weekday = gmdate("w", $weekday_date);
 		$day['weekday_month'] = $weekday_month = gmdate("n", $weekday_date);
 		$weekday_year = gmdate("Y", $weekday_date);


### PR DESCRIPTION
### Fixed

- Fixed a stacktrace when accessing the week view in the calendar. The issue was caused by `$day` not being initialized as an array before assigning keys inside the loop.