### PR TITLE
Fix error when trying to edit a user after purge

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -2530,7 +2530,7 @@ if($mybb->input['action'] == "editprofile")
 	// Fetch profile fields
 	$query = $db->simple_select("userfields", "*", "ufid='{$user['uid']}'");
 	$user_fields = $db->fetch_array($query);
-	if(count($user_fields) > 0)
+	if(!empty($user_fields))
 	{
 		$user = array_merge($user, $user_fields);
 	}


### PR DESCRIPTION
### Fixed

- When trying to edit a user after it has been purged, I got the following message: `count(): Argument #1 ($value) must be of type Countable|array, false given`. Due to `count` on `$user_fields` being empty.