### PR TITLE
Fix forum moderators display

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -208,7 +208,7 @@ foreach($parentlistexploded as $mfid)
 					$moderator['profilelink'] = get_profile_link($moderator['id']);
 					$moderator['username'] = format_name(htmlspecialchars_uni($moderator['username']), $moderator['usergroup'], $moderator['displaygroup']);
 
-					$moderator['users'][$moderator['id']] = $moderator;
+					$moderators['users'][$moderator['id']] = $moderator;
 				}
 			}
 		}

--- a/inc/themes/core.base/frontend/templates/forumbit/depth_2/forum.twig
+++ b/inc/themes/core.base/frontend/templates/forumbit/depth_2/forum.twig
@@ -5,12 +5,12 @@
         <p class="forum__moderators">
             {{ lang.forumbit_moderated_by }}
             {% for moderator in moderators %}
-                {% if loop.last != true %}{{ lang.comma }} {% endif %}
                 {% if moderator.type == 'group' %}
                     {{ moderator.title }}
                 {% elseif moderator.type == 'user' %}
                     <a href="{{ moderator.profilelink }}">{{ moderator.username }}</a>
                 {% endif %}
+                {% if loop.last != true %}{{ lang.comma }} {% endif %}
             {% endfor %}
         </p>
     {% endif %}

--- a/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
@@ -34,7 +34,7 @@
             <p>{{ lang.moderated_by }}
                 <strong>
                     {% for moderator in moderators.users %}
-                        <a href="{{ moderator.profilelink }}">{{ moderator.username }}</a>{% if loop.last == false %}{{ lang.comma }} {% endif %}
+                        <a href="{{ moderator.profilelink|raw }}">{{ moderator.username|raw }}</a>{% if loop.last == false %}{{ lang.comma }} {% endif %}
                     {% endfor %}
                     {% if moderators.groups %}{{ lang.comma }} {% endif %}
                     {% for moderator in moderators.groups %}


### PR DESCRIPTION
### Fixed

- In `forumdisplay.php`, the variable was incorrectly converted to `$moderator` instead of `$moderators` during the removal of `eval()`.
- In `forum.twig`, the comma was placed in the wrong position.
- In `forumdisplay.twig`, the HTML for user moderators (profile link and display name) was not being parsed. I used `|raw` as a temporary fix, but we should probably refactor (`format_name()`?) to avoid relying on `|raw`.

Resolves #5082
