### PR TITLE
Add Theme instance internals

### DIFF
--- a/global.php
+++ b/global.php
@@ -114,8 +114,10 @@ if(function_exists('mb_internal_encoding') && !empty($lang->settings['charset'])
 	@mb_internal_encoding($lang->settings['charset']);
 }
 
-// Select the board theme to use.
-$loadstyle = '';
+// Select the Theme model to use.
+$repository = \MyBB\app(\MyBB\Database\Repositories\ThemeRepository::class);
+$tid = null;
+$theme_model = null;
 $load_from_forum = $load_from_user = 0;
 $style = array();
 
@@ -168,7 +170,7 @@ if(isset($mybb->user['style']) && (int)$mybb->user['style'] != 0)
 {
 	$mybb->user['style'] = (int)$mybb->user['style'];
 
-	$loadstyle = "tid = '{$mybb->user['style']}'";
+	$tid = $mybb->user['style'];
 	$load_from_user = 1;
 }
 
@@ -238,23 +240,16 @@ if(isset($style['style']) && $style['style'] > 0)
 	// This theme is forced upon the user, overriding their selection
 	if($style['overridestyle'] == 1 || !isset($mybb->user['style']))
 	{
-		$loadstyle = "tid = '{$style['style']}'";
+		$tid = $style['style'];
 	}
 }
 
-// After all of that no theme? Load the board default
-if(empty($loadstyle))
+// Fetch the theme to load
+if($tid != null)
 {
-	$loadstyle = "def='1'";
-}
+	$theme_model = $repository->find($tid);
 
-// Fetch the theme to load from the cache
-if($loadstyle != "def='1'")
-{
-	$query = $db->simple_select('themes', 'name, tid, properties, stylesheets, allowedgroups', $loadstyle, array('limit' => 1));
-	$theme = $db->fetch_array($query);
-
-	if($theme && !$load_from_forum && !is_member($theme['allowedgroups']) && $theme['allowedgroups'] != 'all')
+	if($theme_model && !$load_from_forum && !$theme_model->allowedForUser($mybb->user))
 	{
 		if($load_from_user == 1)
 		{
@@ -266,24 +261,19 @@ if($loadstyle != "def='1'")
 			my_unsetcookie('mybbtheme');
 		}
 
-		$loadstyle = "def='1'";
+		$tid = null;
 	}
 }
 
-if($loadstyle == "def='1'")
+if($tid == null)
 {
-	if(!$cache->read('default_theme'))
-	{
-		$cache->update_default_theme();
-	}
-
-	$theme = $cache->read('default_theme');
+	$theme_model = $repository->findDefault();
 
 	$load_from_forum = $load_from_user = 0;
 }
 
-// No theme was found - we attempt to load the master or any other theme
-if(!isset($theme['tid']) || isset($theme['tid']) && !$theme['tid'])
+// No Theme model was found - load fallback values
+if(!$theme_model)
 {
 	// Missing theme was from a forum, run a query to set any forums using the theme to the default
 	if($load_from_forum == 1)
@@ -296,13 +286,14 @@ if(!isset($theme['tid']) || isset($theme['tid']) && !$theme['tid'])
 		$db->update_query('users', array('style' => 0), "style = '{$mybb->user['style']}'");
 	}
 
-	// Attempt to load the master or any other theme if the master is not available
-	$query = $db->simple_select('themes', 'name, tid, properties, stylesheets', '', array('order_by' => 'tid', 'limit' => 1));
-	$theme = $db->fetch_array($query);
+	$theme_model = $repository->getFallback();
 }
+
+$theme = $repository->getArray($theme_model);
+
 $theme = @array_merge((array)$theme, (array)my_unserialize($theme['properties']));
 
-// Fetch all necessary stylesheets
+// Fetch all legacy stylesheets
 $stylesheets = '';
 $theme['stylesheets'] = my_unserialize($theme['stylesheets']);
 $stylesheet_scripts = array("global", basename($_SERVER['PHP_SELF']));
@@ -471,13 +462,14 @@ if(!preg_match("#^(\.\.?(/|$)|([a-z0-9]+)://)#i", $theme['logo']) && substr($the
 // TODO initialize theme properties from package & load set values from DB
 $theme['editortheme'] = 'mybb.css';
 
-// TODO determine package name from DB/cache; `core.base` already registered by default
-$packageName = \MyBB\View\DEFAULT_THEME_PACKAGE;
-
-\MyBB\app()->instance(
-	\MyBB\Extensions\Theme\Theme::class,
-	\MyBB\App(\MyBB\Extensions\Theme\Repository::class)->get($packageName),
-);
+if($theme_model->package->exists())
+{
+	// override initial binding
+	\MyBB\app()->instance(
+		\MyBB\Extensions\Theme\Theme::class,
+		$theme_model->package,
+	);
+}
 
 $view = \MyBB\app(\MyBB\View\Runtime\Runtime::class);
 

--- a/inc/class_datacache.php
+++ b/inc/class_datacache.php
@@ -963,7 +963,7 @@ class datacache
 	{
 		global $db;
 
-		$query = $db->simple_select("themes", "name, tid, properties, stylesheets", "def='1'", array('limit' => 1));
+		$query = $db->simple_select("themes", "tid, package, name, properties, stylesheets, allowedgroups", "def='1'", array('limit' => 1));
 		$theme = $db->fetch_array($query);
 		$this->update("default_theme", $theme);
 	}

--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -902,9 +902,10 @@ class UserDataHandler extends DataHandler
 
 		if(!empty($user['style']))
 		{
-			$theme = get_theme($user['style']);
+			$repository = \MyBB\app(\MyBB\Database\Repositories\ThemeRepository::class);
+			$theme = $repository->find($user['style']);
 
-			if(empty($theme) || !is_member($theme['allowedgroups'], $user) && $theme['allowedgroups'] != 'all')
+			if(!$theme || !$theme->allowedForUser($user))
 			{
 				$this->set_error('invalid_style');
 				return false;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -5143,7 +5143,7 @@ function build_theme_select($name, $selected = -1, $tid = 0, $depth = "", $userg
 
 	if(!is_array($tcache))
 	{
-		$query = $db->simple_select('themes', 'tid, name, pid, allowedgroups', "pid!='0'");
+		$query = $db->simple_select('themes', 'tid, name, allowedgroups');
 
 		while($theme = $db->fetch_array($query))
 		{

--- a/inc/schemas/mysql_db_tables.php
+++ b/inc/schemas/mysql_db_tables.php
@@ -858,8 +858,8 @@ $tables[] = "CREATE TABLE mybb_templatesets (
 
 $tables[] = "CREATE TABLE mybb_themes (
   tid smallint unsigned NOT NULL auto_increment,
+  package varchar(100) NOT NULL,
   name varchar(100) NOT NULL default '',
-  pid smallint unsigned NOT NULL default '0',
   def tinyint(1) NOT NULL default '0',
   properties text NOT NULL,
   stylesheets text NOT NULL,

--- a/inc/schemas/pgsql_db_tables.php
+++ b/inc/schemas/pgsql_db_tables.php
@@ -888,8 +888,8 @@ $tables[] = "CREATE TABLE mybb_templatesets (
 
 $tables[] = "CREATE TABLE mybb_themes (
   tid serial,
+  package varchar(100) NOT NULL,
   name varchar(100) NOT NULL default '',
-  pid smallint NOT NULL default '0',
   def smallint NOT NULL default '0',
   properties text NOT NULL default '',
   stylesheets text NOT NULL default '',

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -827,8 +827,8 @@ $tables[] = "CREATE TABLE mybb_templatesets (
 
 $tables[] = "CREATE TABLE mybb_themes (
 	tid INTEGER PRIMARY KEY,
+	package varchar(100) NOT NULL,
 	name varchar(100) NOT NULL default '',
-	pid smallint NOT NULL default '0',
 	def tinyint(1) NOT NULL default '0',
 	properties TEXT NOT NULL,
 	stylesheets TEXT NOT NULL,

--- a/inc/seeds/db_inserts.php
+++ b/inc/seeds/db_inserts.php
@@ -1259,6 +1259,16 @@ Four',
             'isdefault' => '1',
         ],
     ],
+    'themes' => [
+        [
+            'package' => 'core.base',
+            'name' => 'Base',
+            'def' => '1',
+            'properties' => 'a:0:{}',
+            'stylesheets' => 'a:0:{}',
+            'allowedgroups' => 'all',
+        ],
+    ],
     'usertitles' => [
         [
             'utid' => '1',

--- a/inc/src/Database/Models/Theme.php
+++ b/inc/src/Database/Models/Theme.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Database\Models;
+
+use MyBB\Extensions\Theme\Theme as ThemeExtension;
+
+/**
+ * A configured instance of a Theme.
+ */
+class Theme
+{
+    public function __construct(
+        public int $id,
+        public ThemeExtension $package,
+        public string $name,
+        public string $properties = 'a:0:{}',
+        public string $stylesheets = 'a:0:{}',
+        public string $allowedgroups = 'all',
+    ) {}
+
+    public function allowedForUser(array|int $user): bool
+    {
+        return (
+            $this->allowedgroups === 'all' ||
+            is_member($this->allowedgroups, $user)
+        );
+    }
+}

--- a/inc/src/Database/Repositories/ThemeRepository.php
+++ b/inc/src/Database/Repositories/ThemeRepository.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Database\Repositories;
+
+use datacache;
+use DB_Base;
+use Exception;
+use InvalidArgumentException;
+use MyBB\Database\Models\Theme;
+use MyBB\Extensions\Theme\Repository as ThemeExtensionRepository;
+
+use const MyBB\View\DEFAULT_THEME_PACKAGE;
+
+readonly class ThemeRepository
+{
+    public const TABLE = 'themes';
+
+    public function __construct(
+        private DB_Base $db,
+        private datacache $datacache,
+        private ThemeExtensionRepository $themeExtensionRepository,
+    ) {}
+
+    /**
+     * Returns a model instance from the given stored representation.
+     */
+    public function fromArray(array $data): Theme
+    {
+        return new Theme(
+            $data['tid'] ?? throw new InvalidArgumentException(),
+            $this->themeExtensionRepository->getExisting(
+                $data['package'] ?? throw new InvalidArgumentException(),
+            ),
+            $data['name'] ?? throw new InvalidArgumentException(),
+            $data['properties'] ?? throw new InvalidArgumentException(),
+            $data['stylesheets'] ?? throw new InvalidArgumentException(),
+            $data['allowedgroups'] ?? throw new InvalidArgumentException(),
+        );
+    }
+
+    public function find(int $id): ?Theme
+    {
+        $row = $this->db->simple_select(
+            self::TABLE,
+            'tid, package, name, properties, stylesheets, allowedgroups',
+            'tid = ' . (int)$id,
+        );
+
+        if ($this->db->num_rows($row) === 0) {
+            return null;
+        } else {
+            $data = $this->db->fetch_array($row);
+
+            return $this->fromArray($data);
+        }
+    }
+
+    public function findDefault(): ?Theme
+    {
+        $array = $this->datacache->read('default_theme');
+
+        if (!$array || !is_array($array)) {
+            $row = $this->db->simple_select(
+                self::TABLE,
+                'tid, package, name, properties, stylesheets, allowedgroups',
+                'def = 1',
+            );
+
+            if ($this->db->num_rows($row) !== 1) {
+                return null;
+            } else {
+                $array = $this->db->fetch_array($row);
+
+                $this->datacache->update(
+                    'default_theme',
+                    $array,
+                );
+            }
+        }
+
+        return $this->fromArray($array);
+    }
+
+    /**
+     * @return array<int, Theme>
+     */
+    public function all(): array
+    {
+        $instances = [];
+
+        $rows = $this->db->simple_select(self::TABLE);
+
+        while ($row = $this->db->fetch_array($rows)) {
+            $instances[$row['tid']] = $this->fromArray($row);
+        }
+
+        return $instances;
+    }
+
+    public function insert(Theme $model): int
+    {
+        $this->db->insert_query(
+            self::TABLE,
+            $this->getArray($model),
+        );
+
+        return $this->db->insert_id();
+    }
+
+    public function update(Theme $model): void
+    {
+        $this->db->update_query(
+            self::TABLE,
+            $this->getArray($model),
+            'tid = ' . (int)$model->id,
+        );
+
+
+        $default = $this->findDefault();
+
+        if ($default && $default->id === $model->id) {
+            $this->datacache->update(
+                'default_theme',
+                $this->getArray($model),
+            );
+        }
+    }
+
+    public function delete(Theme $model): void
+    {
+        $default = $this->findDefault();
+
+        if ($default && $default->id === $model->id) {
+            $this->datacache->update(
+                'default_theme',
+                null,
+            );
+        }
+
+
+        $this->db->delete_query(self::TABLE, 'tid = ' . (int)$model->id);
+    }
+
+    public function setDefault(Theme $model): void
+    {
+        $this->db->update_query(
+            self::TABLE,
+            [
+                'def' => 0,
+            ],
+        );
+
+        $this->db->update_query(
+            self::TABLE,
+            [
+                'def' => 1,
+            ],
+            'tid = ' . (int)$model->id,
+        );
+
+        $this->datacache->update(
+            'default_theme',
+            $this->getArray($model),
+        );
+    }
+
+    public function getFallback(): Theme
+    {
+        return new Theme(
+            0,
+            $this->themeExtensionRepository->get(DEFAULT_THEME_PACKAGE),
+            name: DEFAULT_THEME_PACKAGE,
+        );
+    }
+
+    /**
+     * Returns a stored representation of the given model instance.
+     */
+    public function getArray(Theme $model): array
+    {
+        return [
+            'tid' => $model->id,
+            'package' => $model->package->getPackageName(),
+            'name' => $model->name,
+            'properties' => $model->properties,
+            'stylesheets' => $model->stylesheets,
+            'allowedgroups' => $model->allowedgroups,
+        ];
+    }
+}

--- a/inc/src/Maintenance/functions_data.php
+++ b/inc/src/Maintenance/functions_data.php
@@ -791,6 +791,7 @@ function rebuildDatacache(): void
     $cache->update_groupleaders();
     $cache->update_threadprefixes();
     $cache->update_forumsdisplay();
+    $cache->update_default_theme();
     $cache->update_reportreasons(true);
 }
 

--- a/inc/src/ServiceProvider.php
+++ b/inc/src/ServiceProvider.php
@@ -20,6 +20,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             return $GLOBALS['mybb'];
         });
 
+        $this->app->singleton(\datacache::class, function () {
+            return $GLOBALS['cache'];
+        });
+
         $this->app->singleton(\DB_Base::class, function () {
             return $GLOBALS['db'];
         });

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -36,9 +36,32 @@ function upgrade100_dbchanges()
     }
 
     // Modify columns
-    $db->modify_column("forums", "style", "varchar(30)", "set", "''");
     $db->modify_column("users", "password", "varchar(500)", "set", "''");
-    $db->modify_column("users", "style", "varchar(30)", "set", "''");
+
+    if ($db->field_exists("pid", "themes")) {
+        $db->drop_column("themes", "pid");
+    }
+    if (!$db->field_exists("package", "themes")) {
+        // Delete incompatible data
+        $db->delete_query("themes");
+        $db->delete_query("themestylesheets");
+
+        $db->add_column("themes", "package", "varchar(100) NOT NULL");
+
+        // Insert new default theme entry
+        $db->insert_query("themes", [
+            'package' => 'core.base',
+            'name' => 'Base',
+            'def' => '1',
+            'properties' => 'a:0:{}',
+            'stylesheets' => 'a:0:{}',
+            'allowedgroups' => 'all',
+        ]);
+
+        // Reset incompatible preferences
+        $db->update_query("users", ["style" => 0], "style != 0");
+        $db->update_query("forums", ["style" => 0], "style != 0");
+    }
 
     // Add userfields columns
     foreach (["fid4", "fid5", "fid6"] as $fid) {

--- a/xmlhttp.php
+++ b/xmlhttp.php
@@ -74,52 +74,47 @@ if(!$mybb->user['uid'] && !empty($mybb->cookies['mybbtheme']))
 }
 
 // 2. Load style
+$repository = \MyBB\app(\MyBB\Database\Repositories\ThemeRepository::class);
+$tid = null;
+$theme_model = null;
+
 if(isset($mybb->user['style']) && (int)$mybb->user['style'] != 0)
 {
-	$loadstyle = "tid='".(int)$mybb->user['style']."'";
-}
-else
-{
-	$loadstyle = "def='1'";
+	$tid = (int)$mybb->user['style'];
 }
 
-// Load basic theme information that we could be needing.
-if($loadstyle != "def='1'")
+// Fetch the theme to load
+if($tid != null)
 {
-	$query = $db->simple_select('themes', 'name, tid, properties, allowedgroups', $loadstyle, array('limit' => 1));
-	$theme = $db->fetch_array($query);
+	$theme_model = $repository->find($tid);
 
-	if($theme && !is_member($theme['allowedgroups']) && $theme['allowedgroups'] != 'all')
+	if($theme_model && !$theme_model->allowedForUser($mybb->user))
 	{
 		if(isset($mybb->cookies['mybbtheme']))
 		{
 			my_unsetcookie('mybbtheme');
 		}
 
-		$loadstyle = "def='1'";
+		$tid = null;
 	}
 }
 
-if($loadstyle == "def='1'")
+if($tid == null)
 {
-	if(!$cache->read('default_theme'))
-	{
-		$cache->update_default_theme();
-	}
-
-	$theme = $cache->read('default_theme');
+	$theme_model = $repository->findDefault();
 }
 
-// No theme was found - we attempt to load the master or any other theme
-if(!isset($theme['tid']) || isset($theme['tid']) && !$theme['tid'])
+// No Theme model was found - load fallback values
+if(!$theme_model)
 {
 	// Missing theme was from a user, run a query to set any users using the theme to the default
 	$db->update_query('users', array('style' => 0), "style = '{$mybb->user['style']}'");
 
-	// Attempt to load the master or any other theme if the master is not available
-	$query = $db->simple_select('themes', 'name, tid, properties, stylesheets', '', array('order_by' => 'tid', 'limit' => 1));
-	$theme = $db->fetch_array($query);
+	$theme_model = $repository->getFallback();
 }
+
+$theme = $repository->getArray($theme_model);
+
 $theme = @array_merge($theme, my_unserialize($theme['properties']));
 
 // Set the appropriate image language directory for this theme.
@@ -180,6 +175,15 @@ else
 
 	$theme['imgdir'] = $mybb->get_asset_url($theme['imgdir']);
 	$theme['imglangdir'] = $mybb->get_asset_url($theme['imglangdir']);
+}
+
+if($theme_model->package->exists())
+{
+	// override initial binding
+	\MyBB\app()->instance(
+		\MyBB\Extensions\Theme\Theme::class,
+		$theme_model->package,
+	);
 }
 
 if($lang->settings['charset'])


### PR DESCRIPTION
Resolves #4953

Introduces a basic OOP for entries in the `mybb_themes` table, which in MyBB 1.9 will link database references (`mybb_themes.package`) to Theme Packages.

Theme Packages (represented as `Extensions\Theme\Theme`), have a one-to-many relationship with the entries (represented as `Database\Models\Theme`), containing instance-specific settings and permissions.

Applies preliminary changes in schemas, the 1.9 upgrade, runtime code, and inserts an entry for the default _Base_ theme.