### PR TITLE
Fix ACP mail preview by passing empty object to popupWindow options

### DIFF
--- a/admin/modules/tools/mailerrors.php
+++ b/admin/modules/tools/mailerrors.php
@@ -227,7 +227,7 @@ if(!$mybb->input['action'])
 		$log['dateline'] = my_date('relative', $log['dateline']);
 
 		$table->construct_cell($form->generate_check_box("log[{$log['eid']}]", $log['eid'], ''));
-		$table->construct_cell("<a href=\"javascript:MyBB.popupWindow('index.php?module=tools-mailerrors&amp;action=view&amp;eid={$log['eid']}', null, true);\">{$log['subject']}</a>");
+		$table->construct_cell("<a href=\"javascript:MyBB.popupWindow('index.php?module=tools-mailerrors&amp;action=view&amp;eid={$log['eid']}', {}, true);\">{$log['subject']}</a>");
 		$find_from = "<div class=\"float_right\"><a href=\"index.php?module=tools-mailerrors&amp;toaddress={$log['toaddress']}\"><img src=\"styles/{$page->style}/images/icons/find.png\" title=\"{$lang->find_emails_to_addr}\" alt=\"{$lang->find}\" /></a></div>";
 		$table->construct_cell("{$find_from}<div>{$log['toaddress']}</div>");
 		$table->construct_cell($log['error']);

--- a/admin/modules/tools/maillogs.php
+++ b/admin/modules/tools/maillogs.php
@@ -308,7 +308,7 @@ if(!$mybb->input['action'])
 		if($log['type'] == 1)
 		{
 			$table->construct_cell("<img src=\"styles/{$page->style}/images/icons/maillogs_user.png\" title=\"{$lang->email_sent_to_user}\" alt=\"\" />", array("width" => 1));
-			$table->construct_cell("<a href=\"javascript:MyBB.popupWindow('index.php?module=tools-maillogs&amp;action=view&amp;mid={$log['mid']}', null, true);\">{$log['subject']}</a>");
+			$table->construct_cell("<a href=\"javascript:MyBB.popupWindow('index.php?module=tools-maillogs&amp;action=view&amp;mid={$log['mid']}', {}, true);\">{$log['subject']}</a>");
 		}
 		elseif($log['type'] == 2)
 		{
@@ -322,7 +322,7 @@ if(!$mybb->input['action'])
 				$thread_link = $lang->deleted;
 			}
 			$table->construct_cell("<img src=\"styles/{$page->style}/images/icons/maillogs_thread.png\" title=\"{$lang->sent_using_send_thread_feature}\" alt=\"\" />", array("width" => 1));
-			$table->construct_cell("<a href=\"javascript:MyBB.popupWindow('index.php?module=tools-maillogs&amp;action=view&amp;mid={$log['mid']}', null, true);\">{$log['subject']}</a><br /><small>{$lang->thread} {$thread_link}</small>");
+			$table->construct_cell("<a href=\"javascript:MyBB.popupWindow('index.php?module=tools-maillogs&amp;action=view&amp;mid={$log['mid']}', {}, true);\">{$log['subject']}</a><br /><small>{$lang->thread} {$thread_link}</small>");
 		}
 		elseif($log['type'] == 3)
 		{

--- a/admin/modules/user/mass_mail.php
+++ b/admin/modules/user/mass_mail.php
@@ -781,7 +781,7 @@ if($mybb->input['action'] == "send")
 		$format_preview = '';
 		if($email['format'] == 0 || $email['format'] == 2)
 		{
-			$format_preview .= "{$lang->text_based} - <a href=\"#\" onclick=\"javascript:MyBB.popupWindow('index.php?module=user-mass_mail&amp;action=preview&amp;mid={$email['mid']}&amp;format=text', null, true);\">{$lang->preview}</a>";
+			$format_preview .= "{$lang->text_based} - <a href=\"#\" onclick=\"javascript:MyBB.popupWindow('index.php?module=user-mass_mail&amp;action=preview&amp;mid={$email['mid']}&amp;format=text', {}, true);\">{$lang->preview}</a>";
 		}
 		if($email['format'] == 2)
 		{
@@ -789,7 +789,7 @@ if($mybb->input['action'] == "send")
 		}
 		if($email['format'] == 1 || $email['format'] == 2)
 		{
-			$format_preview.= "{$lang->html_based} - <a href=\"#\" onclick=\"javascript:MyBB.popupWindow('index.php?module=user-mass_mail&amp;action=preview&amp;mid={$email['mid']}', null, true);\">{$lang->preview}</a>";
+			$format_preview.= "{$lang->html_based} - <a href=\"#\" onclick=\"javascript:MyBB.popupWindow('index.php?module=user-mass_mail&amp;action=preview&amp;mid={$email['mid']}', {}, true);\">{$lang->preview}</a>";
 		}
 		$table->construct_cell($format_preview);
 		$table->construct_row();


### PR DESCRIPTION
### Fixed

- Passed an empty object (`{}`) to `popupWindow()` instead of `null` to prevent an incorrect reference to `modal_close`.
- This is a temporary workaround and should probably be revisited when the ACP frontend transitions to Twig.

Resolves #5092

