### PR TITLE
Hide remaining canratethreads elements from the ACP

### DIFF
--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -737,7 +737,6 @@ $(function() {
 			'canpostreplys' => 'posting',
 			'canonlyreplyownthreads' => 'posting',
 			'canpostattachments' => 'posting',
-			'canratethreads' => 'posting',
 
 			'caneditposts' => 'editing',
 			'candeleteposts' => 'editing',
@@ -756,11 +755,12 @@ $(function() {
 		);
 
 		$hidefields = array();
-			if($usergroup['gid'] == 1)
-			{
-				$hidefields = array('canonlyviewownthreads', 'canonlyreplyownthreads', 'caneditposts', 'candeleteposts', 'candeletethreads', 'caneditattachments', 'canviewdeletetionnotice');
-			}
-
+		if($usergroup['gid'] == 1)
+		{
+			$hidefields = array('canonlyviewownthreads', 'canonlyreplyownthreads', 'caneditposts', 'candeleteposts', 'candeletethreads', 'caneditattachments', 'canviewdeletetionnotice');
+		}
+		$hidefields[] = 'canratethreads'; // deprecated: Thread rating feature is deprecated since 1.9.0
+		
 		$groups = $plugins->run_hooks("admin_forum_management_permission_groups", $groups);
 
 		foreach($hidefields as $field)

--- a/admin/modules/user/groups.php
+++ b/admin/modules/user/groups.php
@@ -1120,7 +1120,6 @@ if($mybb->input['action'] == "edit")
 	$posting_options = array(
 		$form->generate_check_box("canpostthreads", 1, $lang->can_post_threads, array("checked" => $mybb->get_input('canpostthreads', MyBB::INPUT_INT))),
 		$form->generate_check_box("canpostreplys", 1, $lang->can_post_replies, array("checked" => $mybb->get_input('canpostreplys', MyBB::INPUT_INT))),
-		$form->generate_check_box("canratethreads", 1, $lang->can_rate_threads, array("checked" => $mybb->get_input('canratethreads', MyBB::INPUT_INT))),
 		"{$lang->max_posts_per_day}<br /><small class=\"input\">{$lang->max_posts_per_day_desc}</small><br />".$form->generate_numeric_field('maxposts', $mybb->input['maxposts'], array('id' => 'maxposts', 'class' => 'field50', 'min' => 0))
 	);
 	$form_container->output_row($lang->posting_options, "", "<div class=\"group_settings_bit\">".implode("</div><div class=\"group_settings_bit\">", $posting_options)."</div>");

--- a/inc/languages/english/admin/user_groups.lang.php
+++ b/inc/languages/english/admin/user_groups.lang.php
@@ -102,7 +102,6 @@ $l['can_view_board_closed'] = "Can view board when closed?";
 $l['posting_options'] = "Posting Options";
 $l['can_post_threads'] = "Can post new threads?";
 $l['can_post_replies'] = "Can post replies to threads?";
-$l['can_rate_threads'] = "Can rate threads?";
 $l['moderation_options'] = "Moderation Options";
 $l['mod_new_posts'] = "Moderate new posts?";
 $l['mod_new_threads'] = "Moderate new threads?";


### PR DESCRIPTION
### Changed

- Forum management: added an extra deprecation message for the `canratethreads` permission and included it in the `hidefields` array to prevent displaying a checkbox without text (since the corresponding language keys have already been removed).
- Groups management: removed the `canratethread` permission checkbox (same issue, no text).

Fixes #3498 