### PR TITLE
Add missing forumjump to showthread and forumdisplay

### DIFF
--- a/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
@@ -288,6 +288,9 @@
                         {% endif %}
                     </div>
                 {% endif %}
+
+                {# Forum jump menu #}
+                {{ forumjump|raw }}
             </footer>
         {% endif %}
     </div>

--- a/inc/themes/core.base/frontend/templates/misc/forumjump.twig
+++ b/inc/themes/core.base/frontend/templates/misc/forumjump.twig
@@ -1,10 +1,3 @@
-{# NOT USED
-
-   Can be shown on forum display or show thread by adding
-       {{ forumjump|raw }}
-   to forumdisplay.twig or showthread.twig
-
-#}
 {% if showextras %}
     <section class="container">
         <form action="forumdisplay.php" method="get">

--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -478,6 +478,9 @@
                     {% endif %}
                 </div>
             {% endif %}
+
+            {# Forum jump menu #}
+            {{ forumjump|raw }}
         </footer>
 	<script type="text/javascript">
 		var thread_deleted = "{{ thread_deleted }}";


### PR DESCRIPTION
### Added

- Added missing `forumjump` contents to `showthread` and `forumdisplay`. `forumdisplay.twig` is already called in `build_forum_jump` to produce `$forumjump`.

Fixes #5111 

