### PR TITLE
Fix incorrect language key used for submit in ACP help documents

### DIFF
--- a/admin/modules/config/help_documents.php
+++ b/admin/modules/config/help_documents.php
@@ -355,7 +355,7 @@ if($mybb->input['action'] == "edit")
 		$form_container->output_row($lang->enabled." <em>*</em>", "", $form->generate_yes_no_radio('enabled', $mybb->input['enabled']));
 		$form_container->end();
 
-		$buttons[] = $form->generate_submit_button($lang->edit_section);
+		$buttons[] = $form->generate_submit_button($lang->save_section);
 
 		$form->output_submit_wrapper($buttons);
 		$form->end();
@@ -484,7 +484,7 @@ if($mybb->input['action'] == "edit")
 		$form_container->output_row($lang->enabled." <em>*</em>", "", $form->generate_yes_no_radio('enabled', $mybb->input['enabled']));
 		$form_container->end();
 
-		$buttons[] = $form->generate_submit_button($lang->edit_document);
+		$buttons[] = $form->generate_submit_button($lang->save_document);
 
 		$form->output_submit_wrapper($buttons);
 		$form->end();


### PR DESCRIPTION
### Fixed

- Incorrect language key used for the submit button in the ACP help documents management.

Resolves #5110 