### PR TITLE
Strip illegal XML control characters from parsed posts in syndication

### DIFF
--- a/syndication.php
+++ b/syndication.php
@@ -225,7 +225,7 @@ if(!empty($firstposts))
 			}
 		}
 
-		$items[$post['tid']]['description'] = $parsed_message;
+		$items[$post['tid']]['description'] = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $parsed_message);
 		$items[$post['tid']]['updated'] = $post['edittime'];
 		$items[$post['tid']]['author'] = array("uid" => $post['uid'], "name" => $post['username']);
 		$feedgenerator->add_item($items[$post['tid']]);


### PR DESCRIPTION
### Changed

- Stripped illegal control characters from posts in syndication.

### Example error
```
XML Parsing Error: not well-formed
Location: https://mybb.localtest.me:8443/syndication.php?limit=20
Line Number 24, Column 38:
```

Resolves #4975

