### PR TITLE
Use tooltip for posts edit information in postbit

### DIFF
--- a/inc/themes/core.base/frontend/styles/pages/_posts.scss
+++ b/inc/themes/core.base/frontend/styles/pages/_posts.scss
@@ -56,20 +56,62 @@ $post-spacing: 25px;
     &__edit-log {
         margin-#{$left}: 4px;
         font-size: 0.8em;
+        display: inline-block;
+        color: $alt-font-color-2;
 
-        &:link,
-        &:visited {
-            color: $alt-font-color-2;
+        &-button {
+            background: none;
+            border: none;
+            color: inherit;
+            cursor: pointer;
+            font-size: 1em;
+            padding: 0;
+
+            &:hover,
+            &:focus {
+                color: $link-hover;
+            }
         }
 
-        &:hover {
-            color: $link-hover;
+        &-popover {
+            background-color: $dark-background-1;
+            border: 1px solid $dark-border-1;
+            border-radius: $radius;
+            box-shadow: 0 2px 10px $dark-border-1;
+            color: $invert-font-color;
+            font-size: 1em;
+            line-height: 1.3;
+            opacity: 0;
+            padding: 10px;
+            transition: opacity 0.15s ease, visibility 0.15s ease;
+
+            inset: auto auto anchor(top) anchor(right);
+            position-try: bottom right;
+            
+            a {
+                color: $alt-font-color-2;
+
+                &:link,
+                &:visited {
+                    color: $alt-font-color-2;
+                }
+
+                &:focus,
+                &:hover {
+                    color: $link-hover;
+                }
+            }
+        }
+
+        &-popover:popover-open {
+            opacity: 1;
         }
     }
 
     &__edit-reason {
         color: $alt-font-color-1;
         margin-#{$left}: 4px;
+        margin-top: 2px;
         font-size: 0.8em;
     }
 

--- a/inc/themes/core.base/frontend/templates/postbit/postbit.twig
+++ b/inc/themes/core.base/frontend/templates/postbit/postbit.twig
@@ -95,9 +95,27 @@
             <input type="checkbox" class="checkbox post__inline-mod" name="inlinemod_{{ post.pid }}" id="inlinemod_{{ post.pid }}" value="1" {% if post.inlinechecked %}checked="checked"{% endif %}/>
         {% endif %}
 
+        {# Post edit information #}
         {% if post.editedmsg %}
-            <a href="#" class="post__edit-log" title="" id="edited_by_{{ post.pid }}">{{ include('partials/icon.twig', {icon: 'pencil-alt', class: ''}, with_context = false) }}</a>
-            <span class="post__edit-reason">({{ post.editnote|raw }} {{ post.editedprofilelink|raw }}.{% if post.editreason %} <em>{{ lang.postbit_editreason }}: {{ post.editreason }}</em>{% endif %})</span>
+            <span class="post__edit-log">
+                <button popovertarget="editlog-{{ post.pid }}" popovertargetaction="toggle" class="post__edit-log-button" aria-label="{{ lang.postbit_editreason }}" style="anchor-name: editlog-button-{{ post.pid }};">
+                    {{ include('partials/icon.twig', { icon: 'pencil-alt', class: '' }, with_context = false) }}
+                </button>
+                <div
+                    id="editlog-{{ post.pid }}"
+                    popover="auto"
+                    class="post__edit-log-popover"
+                    style="position-anchor: editlog-button-{{ post.pid }};"
+                    role="dialog"
+                >
+                    {{ post.editnote|raw }} {{ post.editedprofilelink|raw }}
+                    {% if post.editreason %}
+                        <div class="edit-reason">
+                            {{ lang.postbit_editreason }}: <em>{{ post.editreason }}</em>
+                        </div>
+                    {% endif %}
+                </div>
+            </span>
         {% endif %}
 
         {# IP address #}


### PR DESCRIPTION
### Changed

- Updated the postbit template to use a tooltip for post edit information (as originally mentioned in [#5013](https://github.com/mybb/mybb/pull/5013)). I’m not a CSS expert, so this might still need some tweaks or improvements.

### Example
Before:
<img width="2596" height="765" alt="image" src="https://github.com/user-attachments/assets/b0f53874-2ad6-47f5-a3e5-a4e7cdd19f39" />

After:
<img width="2596" height="765" alt="image" src="https://github.com/user-attachments/assets/a52c897a-a49c-4bd6-8f0a-1713f7763bf3" />

Resolves #5112
