### PR TITLE
Remove unnecessary fid6 from userfields

### DIFF
--- a/inc/schemas/mysql_db_tables.php
+++ b/inc/schemas/mysql_db_tables.php
@@ -964,7 +964,6 @@ $tables[] = "CREATE TABLE mybb_userfields (
   fid3 text NOT NULL,
   fid4 text NOT NULL,
   fid5 text NOT NULL,
-  fid6 text NOT NULL,
   PRIMARY KEY (ufid)
 ) ENGINE=InnoDB;";
 

--- a/inc/schemas/pgsql_db_tables.php
+++ b/inc/schemas/pgsql_db_tables.php
@@ -1000,7 +1000,6 @@ $tables[] = "CREATE TABLE mybb_userfields (
   fid3 text NOT NULL default '',
   fid4 text NOT NULL default '',
   fid5 text NOT NULL default '',
-  fid6 text NOT NULL default '',
   PRIMARY KEY (ufid)
 );";
 $tables[] = "CREATE SEQUENCE mybb_userfields_ufid_seq;";

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -932,8 +932,7 @@ $tables[] = "CREATE TABLE mybb_userfields (
 	fid2 TEXT NOT NULL,
 	fid3 TEXT NOT NULL,
 	fid4 TEXT NOT NULL,
-	fid5 TEXT NOT NULL,
-	fid6 TEXT NOT NULL
+	fid5 TEXT NOT NULL
 );";
 
 $tables[] = "CREATE TABLE mybb_usergroups (

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -41,7 +41,7 @@ function upgrade100_dbchanges()
     $db->modify_column("users", "style", "varchar(30)", "set", "''");
 
     // Add userfields columns
-    foreach (["fid4", "fid5", "fid6"] as $fid) {
+    foreach (["fid4", "fid5"] as $fid) {
         if (!$db->field_exists($fid, "userfields")) {
             $db->add_column("userfields", $fid, "text NOT NULL DEFAULT ''");
         }


### PR DESCRIPTION
### Removed

- `fid6` is not required any more due to the removal of the `skype` profile field in https://github.com/mybb/mybb/commit/7b5f5eb8319c57abb0291189bf261ad2885ce3d7.

Resolves #5113