### PR TITLE
Use get_thread_link for pagination in thread listing

### DIFF
--- a/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
@@ -81,7 +81,7 @@
                 <span class="thread__page-legend">{{ lang.pages }}</span>
                 {% set pagesStop = (thread.pages > mybb.settings.maxmultipagelinks) ? mybb.settings.maxmultipagelinks : thread.pages %}
                 {% for page in 1..pagesStop %}
-                    <a href="{{ page_link }}" class="thread__page-link">{{ page }}</a>{# TODO: page_link to be replaced when get_thread_link is adapted to Twig #}
+                    <a href="{{ get_thread_link(thread.tid, page) }}" class="thread__page-link">{{ page }}</a>
                 {% endfor %}
                 {% if thread.pages > mybb.settings.maxmultipagelinks %}... <a href="{{ thread.threadlink }}" class="thread__page-link">{{ thread.pages }}</a>{% endif %}
             </span>


### PR DESCRIPTION
### Changed

- Used `get_thread_link()` for pagination in thread listings (pagination was previously non-functional).

Resolves #5116
