### PR TITLE
Introduce Twig UserExtension to style usernames in templates

### DIFF
--- a/inc/src/Twig/Extensions/UserExtension.php
+++ b/inc/src/Twig/Extensions/UserExtension.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace MyBB\Twig\Extensions;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class UserExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('format_name', [$this, 'getFormattedName'], [
+                'is_safe' => ['html'],
+            ]),
+        ];
+    }
+
+    /**
+     * Returns the formatted username for a user.
+     *
+     * @param int|array $user Either a user ID or a user data array.
+     * @return string Formatted username.
+     */
+    public function getFormattedName(int|array $user): string
+    {
+        if (is_int($user)) {
+            $user = get_user($user);
+        }
+
+        if (empty($user['username'])) {
+            return '';
+        }
+
+        return format_name(htmlspecialchars_uni($user['username']), $user['usergroup'] ?? 0, $user['displaygroup'] ?? 0);
+    }
+}

--- a/inc/src/Twig/ServiceProvider.php
+++ b/inc/src/Twig/ServiceProvider.php
@@ -7,6 +7,7 @@ use MyBB;
 use MyBB\Twig\Extensions\CoreExtension;
 use MyBB\Twig\Extensions\LangExtension;
 use MyBB\Twig\Extensions\UrlExtension;
+use MyBB\Twig\Extensions\UserExtension;
 use MyBB\Twig\Extensions\ViewExtension;
 use MyBB\Utilities\BreadcrumbManager;
 use MyBB\View\Optimization;
@@ -47,6 +48,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             return new UrlExtension();
         });
 
+        $this->app->singleton(UserExtension::class, function () {
+            return new UserExtension();
+        });
+
         $this->app->singleton(LoaderInterface::class, function (Container $container) {
             $view = $container->get(Runtime::class);
 
@@ -77,6 +82,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             $env->addExtension($container->make(ViewExtension::class));
             $env->addExtension($container->make(LangExtension::class));
             $env->addExtension($container->make(UrlExtension::class));
+            $env->addExtension($container->make(UserExtension::class));
 
             if ($mybb->dev_mode) {
                 $env->addExtension($container->make(DebugExtension::class));
@@ -100,6 +106,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             CoreExtension::class,
             LangExtension::class,
             UrlExtension::class,
+            UserExtension::class,
             ViewExtension::class,
             LoaderInterface::class,
             Environment::class,

--- a/inc/themes/core.base/frontend/templates/private/read.twig
+++ b/inc/themes/core.base/frontend/templates/private/read.twig
@@ -36,8 +36,7 @@
                     <a href="{{ get_profile_link(mybb.user.uid) }}" class="avatar-profile-link" title="{{ lang.welcome_my_profile }}">
                         {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar) }}
                     </a>
-                    {# TO DO: username styling #}
-                    <h3 class="post__author"><a href="{{ get_profile_link(mybb.user.uid) }}">{{ mybb.user.username }}</a></h3>
+                    <h3 class="post__author"><a href="{{ get_profile_link(mybb.user.uid) }}">{{ mybb.user|format_name }}</a></h3>
                     <span class="post__date">{{ lang.quick_reply }}</span>
                 </div>
                 <div class="post__body">

--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -296,8 +296,7 @@
                         <a href="{{ get_profile_link(mybb.user.uid) }}" class="avatar-profile-link" title="{{ lang.welcome_my_profile }}">
                             {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar) }}
                         </a>
-                        {# TO DO: username styling #}
-                        <h3 class="post__author"><a href="{{ get_profile_link(mybb.user.uid) }}">{{ mybb.user.username }}</a></h3>
+                        <h3 class="post__author"><a href="{{ get_profile_link(mybb.user.uid) }}">{{ mybb.user|format_name }}</a></h3>
                         <span class="post__date">{{ lang.quick_reply }}</span>
                     </div>
                     <div class="post__body">


### PR DESCRIPTION
Introduces a new Twig extension (`UserExtension`) to provide user-related functions and filters in templates.

As a first feature, it adds the `format_name` filter, which formats and styles usernames according to their user/group settings. This complements existing helpers like `get_profile_link()` allowing templates to display usernames safely without using `|raw`.

The filter accepts either a full user array or a user ID, making it flexible for different template contexts (and to avoid looking up the user when not necessary).

As an example, missing username styling in thread and private message quick replies has been updated to use this new filter.

@dvz I’m not sure if this is exactly what you had in mind or the approach you wanted to take, but I thought I’d give it a try. I’m happy to adjust or replace this if it’s not the way you’d prefer to tackle this.