### PR TITLE
Fix warnings when adding a new theme stylesheet

### DIFF
--- a/admin/modules/style/themes.php
+++ b/admin/modules/style/themes.php
@@ -2734,7 +2734,7 @@ if($mybb->input['action'] == "add_stylesheet")
 			}
 		}
 
-		if($mybb->input['add_type'] == 1)
+		if(isset($mybb->input['add_type']) && $mybb->input['add_type'] == 1)
 		{
 			$add_checked[1] = "checked=\"checked\"";
 			$add_checked[2] = "";
@@ -2776,7 +2776,7 @@ if($mybb->input['action'] == "add_stylesheet")
 	$stylesheet['colors'] = array();
 	$stylesheet['sid'] = null;
 
-	if($mybb->input['attach'] == 1 && is_array($mybb->input['applied_to']) && (!isset($mybb->input['applied_to']['global']) || $mybb->input['applied_to']['global'][0] != "global"))
+	if(isset($mybb->input['attach']) && $mybb->input['attach'] == 1 && isset($mybb->input['applied_to']) && is_array($mybb->input['applied_to']) && (!isset($mybb->input['applied_to']['global']) || $mybb->input['applied_to']['global'][0] != "global"))
 	{
 		foreach($mybb->input['applied_to'] as $name => $actions)
 		{


### PR DESCRIPTION
### Fixed

- Warnings for `add_type` and `applied_to` when adding a new stylesheet (if you did not select any of the choice  between `Import from another stylesheet in this theme` and `Write my own content`).


Resolves #5118

