### PR TITLE
Fix 4139 Update hardcoded image file formats

### DIFF
--- a/admin/modules/config/post_icons.php
+++ b/admin/modules/config/post_icons.php
@@ -141,7 +141,24 @@ if($mybb->input['action'] == "add_multiple")
 					if($file != ".." && $file != ".")
 					{
 						$ext = get_extension($file);
-						if($ext == "gif" || $ext == "jpg" || $ext == "jpeg" || $ext == "png" || $ext == "bmp")
+						if(in_array($ext, array(
+							'apng',
+							'png',
+							'avif',
+							'gif',
+							'jpg',
+							'jpeg',
+							'jfif',
+							'pjpeg',
+							'pjp',
+							'svg',
+							'webp',
+							'bmp',
+							'ico',
+							'cur',
+							'tif',
+							'tiff',
+						)))
 						{
 							if(!isset($aicons[$path.$file]))
 							{

--- a/admin/modules/config/smilies.php
+++ b/admin/modules/config/smilies.php
@@ -352,7 +352,24 @@ if($mybb->input['action'] == "add_multiple")
 					if($file != ".." && $file != ".")
 					{
 						$ext = get_extension($file);
-						if($ext == "gif" || $ext == "jpg" || $ext == "jpeg" || $ext == "png" || $ext == "bmp")
+						if(in_array($ext, array(
+							'apng',
+							'png',
+							'avif',
+							'gif',
+							'jpg',
+							'jpeg',
+							'jfif',
+							'pjpeg',
+							'pjp',
+							'svg',
+							'webp',
+							'bmp',
+							'ico',
+							'cur',
+							'tif',
+							'tiff',
+						)))
 						{
 							if(!$asmilies[$path.$file])
 							{

--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -370,7 +370,15 @@ function acp_rebuild_attachment_thumbnails()
 	while($attachment = $db->fetch_array($query))
 	{
 		$ext = my_strtolower(my_substr(strrchr($attachment['filename'], "."), 1));
-		if($ext == "gif" || $ext == "png" || $ext == "jpg" || $ext == "jpeg" || $ext == "jpe")
+		if(in_array($ext, array(
+			'png',
+			'avif',
+			'gif',
+			'jpg',
+			'jpeg',
+			'webp',
+			'bmp',
+		)))
 		{
 			$thumbname = str_replace(".attach", "_thumb.$ext", $attachment['attachname']);
 			$thumbnail = generate_thumbnail($uploadspath_abs."/".$attachment['attachname'], $uploadspath_abs, $thumbname, $mybb->settings['attachthumbh'], $mybb->settings['attachthumbw']);

--- a/attachment.php
+++ b/attachment.php
@@ -132,31 +132,43 @@ $plugins->run_hooks("attachment_end");
 
 if(isset($mybb->input['thumbnail']))
 {
-	if(!file_exists($uploadspath_abs."/".$attachment['thumbnail']))
+	$ext = get_extension($attachment['thumbnail']);
+
+	$type = $attachment['filetype'];
+
+	if(!in_array($ext, array(
+			'apng',
+			'png',
+			'avif',
+			'gif',
+			'jpg',
+			'jpeg',
+			'jfif',
+			'pjpeg',
+			'pjp',
+			'svg',
+			'webp',
+			'bmp',
+			'ico',
+			'cur',
+			'tif',
+			'tiff',
+		)) ||
+		!in_array($type, array(
+			'image/apng',
+			'image/png',
+			'image/avif',
+			'image/gif',
+			'image/jpeg',
+			'image/svg+xml',
+			'image/webp',
+			'image/bmp',
+			'image/x-icon',
+			'image/tiff',
+		)) ||
+		!file_exists($uploadspath_abs."/".$attachment['thumbnail']))
 	{
 		error($lang->error_invalidattachment);
-	}
-
-	$ext = get_extension($attachment['thumbnail']);
-	switch($ext)
-	{
-		case "gif":
-			$type = "image/gif";
-			break;
-		case "bmp":
-			$type = "image/bmp";
-			break;
-		case "png":
-			$type = "image/png";
-			break;
-		case "jpg":
-		case "jpeg":
-		case "jpe":
-			$type = "image/jpeg";
-			break;
-		default:
-			$type = "image/unknown";
-			break;
 	}
 
 	header("Content-disposition: filename=\"{$attachment['filename']}\"");
@@ -181,13 +193,18 @@ else
 
 	switch($attachment['filetype'])
 	{
-		case "application/pdf":
-		case "image/bmp":
-		case "image/gif":
-		case "image/jpeg":
-		case "image/pjpeg":
-		case "image/png":
-		case "text/plain":
+		case 'application/pdf':
+		case 'image/apng':
+		case 'image/png':
+		case 'image/avif':
+		case 'image/gif':
+		case 'image/jpeg':
+		case 'image/svg+xml':
+		case 'image/webp':
+		case 'image/bmp':
+		case 'image/x-icon':
+		case 'image/tiff':
+		case 'text/plain':
 			header("Content-type: {$attachment['filetype']}");
 			if(!empty($attachtypes[$ext]['forcedownload']))
 			{

--- a/inc/functions_image.php
+++ b/inc/functions_image.php
@@ -66,7 +66,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 			$im = @imagecreatefromwebp($file);
 		}
 		// imagecreatefromavif() is only available in PHP >= 8.1
-		elseif(defined('IMG_AVIF') && $imgtype === IMG_AVIF && function_exists('imagecreatefromavif'))
+		elseif($imgtype === IMG_AVIF && function_exists('imagecreatefromavif'))
 		{
 			$im = @imagecreatefromavif($file);
 		}

--- a/inc/functions_image.php
+++ b/inc/functions_image.php
@@ -45,23 +45,23 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 	{
 		check_thumbnail_memory($imgwidth, $imgheight, $imgtype, $imgbits, $imgchan);
 
-		if($imgtype === IMAGETYPE_PNG && function_exists('imagecreatefrompng'))
+		if($imgtype === IMG_PNG && function_exists('imagecreatefrompng'))
 		{
 			$im = @imagecreatefrompng($file);
 		}
-		elseif($imgtype === IMAGETYPE_JPEG && function_exists('imagecreatefromjpeg'))
+		elseif($imgtype === IMG_JPEG && function_exists('imagecreatefromjpeg'))
 		{
 			$im = @imagecreatefromjpeg($file);
 		}
-		elseif($imgtype === IMAGETYPE_GIF && function_exists('imagecreatefromgif'))
+		elseif($imgtype === IMG_GIF && function_exists('imagecreatefromgif'))
 		{
 			$im = @imagecreatefromgif($file);
 		}
-		elseif($imgtype === IMAGETYPE_BMP && function_exists('imagecreatefrombmp'))
+		elseif($imgtype === IMG_BMP && function_exists('imagecreatefrombmp'))
 		{
 			$im = @imagecreatefrombmp($file);
 		}
-		elseif($imgtype === IMAGETYPE_WEBP && function_exists('imagecreatefromwebp'))
+		elseif($imgtype === IMG_WEBP && function_exists('imagecreatefromwebp'))
 		{
 			$im = @imagecreatefromwebp($file);
 		}
@@ -92,7 +92,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 		}
 
 		// Attempt to preserve the transparency if there is any
-		if($imgtype === IMAGETYPE_PNG)
+		if($imgtype === IMG_PNG)
 		{
 			// A PNG!
 			imagealphablending($thumbim, false);
@@ -101,7 +101,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 			// Save Alpha...
 			imagesavealpha($thumbim, true);
 		}
-		elseif($imgtype === IMAGETYPE_GIF)
+		elseif($imgtype === IMG_GIF)
 		{
 			// Transparent GIF?
 			$trans_color = imagecolortransparent($im);
@@ -123,12 +123,12 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 			@imagecopyresized($thumbim, $im, 0, 0, 0, 0, $thumbwidth, $thumbheight, $imgwidth, $imgheight);
 		}
 		@imagedestroy($im);
-		if(!function_exists('imagegif') && $imgtype === IMAGETYPE_GIF)
+		if(!function_exists('imagegif') && $imgtype === IMG_GIF)
 		{
 			$filename = str_replace('.gif', '.jpg', $filename);
 		}
 
-		if(!function_exists('imagebmp') && $imgtype === IMAGETYPE_BMP)
+		if(!function_exists('imagebmp') && $imgtype === IMG_BMP)
 		{
 			$filename = str_replace('.bmp', '.jpg', $filename);
 		}
@@ -140,7 +140,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 
 		switch($imgtype)
 		{
-			case IMAGETYPE_GIF:
+			case IMG_GIF:
 				if(function_exists('imagegif'))
 				{
 					@imagegif($thumbim, $path. '/' .$filename);
@@ -150,13 +150,13 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 					@imagejpeg($thumbim, $path. '/' .$filename);
 				}
 				break;
-			case IMAGETYPE_JPEG:
+			case IMG_JPEG:
 				@imagejpeg($thumbim, $path. '/' .$filename);
 				break;
-			case IMAGETYPE_PNG:
+			case IMG_PNG:
 				@imagepng($thumbim, $path. '/' .$filename);
 				break;
-			case IMAGETYPE_BMP:
+			case IMG_BMP:
 				if(function_exists('imagebmp'))
 				{
 					@imagebmp($thumbim, $path. '/' .$filename);
@@ -166,7 +166,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 					@imagejpeg($thumbim, $path. '/' .$filename);
 				}
 				break;
-			case IMAGETYPE_WEBP:
+			case IMG_WEBP:
 				@imagewebp($thumbim, $path. '/' .$filename);
 				break;
 			case IMG_AVIF:

--- a/inc/functions_image.php
+++ b/inc/functions_image.php
@@ -9,7 +9,7 @@
  */
 
 /**
- * Generates a thumbnail based on specified dimensions (supports png, jpg, and gif)
+ * Generates a thumbnail based on specified dimensions (supports png, jpg, gif, bmp, webp, and avif)
  *
  * @param string $file the full path to the original image
  * @param string $path the directory path to where to save the new image
@@ -31,7 +31,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 	$imgdesc = getimagesize($file);
 	$imgwidth = $imgdesc[0];
 	$imgheight = $imgdesc[1];
-	$imgtype = $imgdesc[2];
+	$imgtype = (int)$imgdesc[2];
 	$imgattr = $imgdesc[3];
 	$imgbits = isset($imgdesc['bits']) ? $imgdesc['bits'] : null;
 	$imgchan = isset($imgdesc['channels']) ? $imgdesc['channels'] : null;
@@ -45,26 +45,30 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 	{
 		check_thumbnail_memory($imgwidth, $imgheight, $imgtype, $imgbits, $imgchan);
 
-		if($imgtype == 3)
+		if($imgtype === IMAGETYPE_PNG && function_exists('imagecreatefrompng'))
 		{
-			if(@function_exists("imagecreatefrompng"))
-			{
-				$im = @imagecreatefrompng($file);
-			}
+			$im = @imagecreatefrompng($file);
 		}
-		elseif($imgtype == 2)
+		elseif($imgtype === IMAGETYPE_JPEG && function_exists('imagecreatefromjpeg'))
 		{
-			if(@function_exists("imagecreatefromjpeg"))
-			{
-				$im = @imagecreatefromjpeg($file);
-			}
+			$im = @imagecreatefromjpeg($file);
 		}
-		elseif($imgtype == 1)
+		elseif($imgtype === IMAGETYPE_GIF && function_exists('imagecreatefromgif'))
 		{
-			if(@function_exists("imagecreatefromgif"))
-			{
-				$im = @imagecreatefromgif($file);
-			}
+			$im = @imagecreatefromgif($file);
+		}
+		elseif($imgtype === IMAGETYPE_BMP && function_exists('imagecreatefrombmp'))
+		{
+			$im = @imagecreatefrombmp($file);
+		}
+		elseif($imgtype === IMAGETYPE_WEBP && function_exists('imagecreatefromwebp'))
+		{
+			$im = @imagecreatefromwebp($file);
+		}
+		// imagecreatefromavif() is only available in PHP >= 8.1
+		elseif(defined('IMG_AVIF') && $imgtype === IMG_AVIF && function_exists('imagecreatefromavif'))
+		{
+			$im = @imagecreatefromavif($file);
 		}
 		else
 		{
@@ -88,7 +92,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 		}
 
 		// Attempt to preserve the transparency if there is any
-		if($imgtype == 3)
+		if($imgtype === IMAGETYPE_PNG)
 		{
 			// A PNG!
 			imagealphablending($thumbim, false);
@@ -97,7 +101,7 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 			// Save Alpha...
 			imagesavealpha($thumbim, true);
 		}
-		elseif($imgtype == 1)
+		elseif($imgtype === IMAGETYPE_GIF)
 		{
 			// Transparent GIF?
 			$trans_color = imagecolortransparent($im);
@@ -119,27 +123,61 @@ function generate_thumbnail($file, $path, $filename, $maxheight, $maxwidth)
 			@imagecopyresized($thumbim, $im, 0, 0, 0, 0, $thumbwidth, $thumbheight, $imgwidth, $imgheight);
 		}
 		@imagedestroy($im);
-		if(!function_exists("imagegif") && $imgtype == 1)
+		if(!function_exists('imagegif') && $imgtype === IMAGETYPE_GIF)
 		{
-			$filename = str_replace(".gif", ".jpg", $filename);
+			$filename = str_replace('.gif', '.jpg', $filename);
 		}
+
+		if(!function_exists('imagebmp') && $imgtype === IMAGETYPE_BMP)
+		{
+			$filename = str_replace('.bmp', '.jpg', $filename);
+		}
+
+		if(!function_exists('imageavif') && $imgtype === IMG_AVIF)
+		{
+			$filename = str_replace('.avif', '.jpg', $filename);
+		}
+
 		switch($imgtype)
 		{
-			case 1:
-				if(function_exists("imagegif"))
+			case IMAGETYPE_GIF:
+				if(function_exists('imagegif'))
 				{
-					@imagegif($thumbim, $path."/".$filename);
+					@imagegif($thumbim, $path. '/' .$filename);
 				}
 				else
 				{
-					@imagejpeg($thumbim, $path."/".$filename);
+					@imagejpeg($thumbim, $path. '/' .$filename);
 				}
 				break;
-			case 2:
-				@imagejpeg($thumbim, $path."/".$filename);
+			case IMAGETYPE_JPEG:
+				@imagejpeg($thumbim, $path. '/' .$filename);
 				break;
-			case 3:
-				@imagepng($thumbim, $path."/".$filename);
+			case IMAGETYPE_PNG:
+				@imagepng($thumbim, $path. '/' .$filename);
+				break;
+			case IMAGETYPE_BMP:
+				if(function_exists('imagebmp'))
+				{
+					@imagebmp($thumbim, $path. '/' .$filename);
+				}
+				else
+				{
+					@imagejpeg($thumbim, $path. '/' .$filename);
+				}
+				break;
+			case IMAGETYPE_WEBP:
+				@imagewebp($thumbim, $path. '/' .$filename);
+				break;
+			case IMG_AVIF:
+				if(function_exists('imageavif'))
+				{
+					@imageavif($thumbim, $path. '/' .$filename);
+				}
+				else
+				{
+					@imagejpeg($thumbim, $path. '/' .$filename);
+				}
 				break;
 		}
 		@my_chmod($path."/".$filename, '0644');

--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -1004,7 +1004,36 @@ function get_post_attachments($id, &$post)
 				$attachment['filename'] = htmlspecialchars_uni($attachment['filename']);
 				$attachment['filesize'] = get_friendly_size($attachment['filesize']);
 				$ext = get_extension($attachment['filename']);
-				if($ext == "jpeg" || $ext == "gif" || $ext == "bmp" || $ext == "png" || $ext == "jpg")
+
+				if(in_array($ext, array(
+						'apng',
+						'png',
+						'avif',
+						'gif',
+						'jpg',
+						'jpeg',
+						'jfif',
+						'pjpeg',
+						'pjp',
+						'svg',
+						'webp',
+						'bmp',
+						'ico',
+						'cur',
+						'tif',
+						'tiff',
+					)) && in_array($attachment['filetype'], array(
+						'image/apng',
+						'image/png',
+						'image/avif',
+						'image/gif',
+						'image/jpeg',
+						'image/svg+xml',
+						'image/webp',
+						'image/bmp',
+						'image/x-icon',
+						'image/tiff',
+					)))
 				{
 					$isimage = true;
 				}

--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -229,12 +229,20 @@ function upload_avatar($avatar=array(), $uid=0)
 	}
 
 	// Check we have a valid extension
-    	$ext = get_extension(my_strtolower($avatar['name']));
-    	if(!preg_match("#^(gif|jpg|jpeg|jpe|bmp|png)$#i", $ext))
-    	{
-        	$ret['error'] = $lang->error_avatartype;
-        	return $ret;
-    	}
+	$ext = get_extension(my_strtolower($avatar['name']));
+	if(!in_array($ext, array(
+		'png',
+		'avif',
+		'gif',
+		'jpg',
+		'jpeg',
+		'webp',
+		'bmp',
+	)))
+	{
+		$ret['error'] = $lang->error_avatartype;
+		return $ret;
+	}
 
 	if(defined('IN_ADMINCP'))
 	{
@@ -329,24 +337,26 @@ function upload_avatar($avatar=array(), $uid=0)
 
 	switch($avatar['type'])
 	{
-		case "image/gif":
-			$img_type =  1;
+		case 'image/png':
+			$img_type = IMAGETYPE_PNG;
 			break;
-		case "image/jpeg":
-		case "image/x-jpg":
-		case "image/x-jpeg":
-		case "image/pjpeg":
-		case "image/jpg":
-			$img_type = 2;
+		case 'image/avif':
+			$img_type =  IMG_AVIF;
 			break;
-		case "image/png":
-		case "image/x-png":
-			$img_type = 3;
+		case 'image/gif':
+			$img_type =  IMAGETYPE_GIF;
 			break;
-		case "image/bmp":
-		case "image/x-bmp":
-		case "image/x-windows-bmp":
-			$img_type = 6;
+		case 'image/jpeg':
+			$img_type = IMAGETYPE_JPEG;
+			break;
+		case 'image/webp':
+			$img_type = IMAGETYPE_WEBP;
+			break;
+		case 'image/bmp':
+			$img_type = IMAGETYPE_BMP;
+			break;
+		case 'image/x-icon':
+			$img_type = IMAGETYPE_ICO;
 			break;
 		default:
 			$img_type = 0;
@@ -563,24 +573,39 @@ function upload_attachment($attachment, $update_attachment=false)
 	);
 
 	// If we're uploading an image, check the MIME type compared to the image type and attempt to generate a thumbnail
-	if($ext == "gif" || $ext == "png" || $ext == "jpg" || $ext == "jpeg" || $ext == "jpe")
+	if(in_array($ext, array(
+		'png',
+		'avif',
+		'gif',
+		'jpg',
+		'jpeg',
+		'webp',
+		'bmp',
+	)))
 	{
 		// Check a list of known MIME types to establish what kind of image we're uploading
 		switch(my_strtolower($file['type']))
 		{
-			case "image/gif":
-				$img_type =  1;
+			case 'image/png':
+				$img_type = IMAGETYPE_PNG;
 				break;
-			case "image/jpeg":
-			case "image/x-jpg":
-			case "image/x-jpeg":
-			case "image/pjpeg":
-			case "image/jpg":
-				$img_type = 2;
+			case 'image/avif':
+				$img_type =  IMG_AVIF;
 				break;
-			case "image/png":
-			case "image/x-png":
-				$img_type = 3;
+			case 'image/gif':
+				$img_type =  IMAGETYPE_GIF;
+				break;
+			case 'image/jpeg':
+				$img_type = IMAGETYPE_JPEG;
+				break;
+			case 'image/webp':
+				$img_type = IMAGETYPE_WEBP;
+				break;
+			case 'image/bmp':
+				$img_type = IMAGETYPE_BMP;
+				break;
+			case 'image/x-icon':
+				$img_type = IMAGETYPE_ICO;
 				break;
 			default:
 				$img_type = 0;

--- a/inc/functions_upload.php
+++ b/inc/functions_upload.php
@@ -338,25 +338,22 @@ function upload_avatar($avatar=array(), $uid=0)
 	switch($avatar['type'])
 	{
 		case 'image/png':
-			$img_type = IMAGETYPE_PNG;
+			$img_type = IMG_PNG;
 			break;
 		case 'image/avif':
 			$img_type =  IMG_AVIF;
 			break;
 		case 'image/gif':
-			$img_type =  IMAGETYPE_GIF;
+			$img_type =  IMG_GIF;
 			break;
 		case 'image/jpeg':
-			$img_type = IMAGETYPE_JPEG;
+			$img_type = IMG_JPEG;
 			break;
 		case 'image/webp':
-			$img_type = IMAGETYPE_WEBP;
+			$img_type = IMG_WEBP;
 			break;
 		case 'image/bmp':
-			$img_type = IMAGETYPE_BMP;
-			break;
-		case 'image/x-icon':
-			$img_type = IMAGETYPE_ICO;
+			$img_type = IMG_BMP;
 			break;
 		default:
 			$img_type = 0;
@@ -587,25 +584,22 @@ function upload_attachment($attachment, $update_attachment=false)
 		switch(my_strtolower($file['type']))
 		{
 			case 'image/png':
-				$img_type = IMAGETYPE_PNG;
+				$img_type = IMG_PNG;
 				break;
 			case 'image/avif':
 				$img_type =  IMG_AVIF;
 				break;
 			case 'image/gif':
-				$img_type =  IMAGETYPE_GIF;
+				$img_type =  IMG_GIF;
 				break;
 			case 'image/jpeg':
-				$img_type = IMAGETYPE_JPEG;
+				$img_type = IMG_JPEG;
 				break;
 			case 'image/webp':
-				$img_type = IMAGETYPE_WEBP;
+				$img_type = IMG_WEBP;
 				break;
 			case 'image/bmp':
-				$img_type = IMAGETYPE_BMP;
-				break;
-			case 'image/x-icon':
-				$img_type = IMAGETYPE_ICO;
+				$img_type = IMG_BMP;
 				break;
 			default:
 				$img_type = 0;

--- a/inc/init.php
+++ b/inc/init.php
@@ -327,3 +327,6 @@ $time_formats = array(
 	3 => "H:i"
 );
 
+defined('IMAGETYPE_WEBP') || define('IMAGETYPE_WEBP', 18);
+
+defined('IMG_AVIF') || define('IMG_AVIF', 256);

--- a/inc/init.php
+++ b/inc/init.php
@@ -327,6 +327,8 @@ $time_formats = array(
 	3 => "H:i"
 );
 
-defined('IMAGETYPE_WEBP') || define('IMAGETYPE_WEBP', 18);
+defined('IMG_WEBP') || define('IMG_WEBP', 18);
+
+defined('IMG_BMP') || define('IMG_BMP', 64);
 
 defined('IMG_AVIF') || define('IMG_AVIF', 256);


### PR DESCRIPTION
This attempts to fix the following issues:

Resolves #3847
Resolves #4139

Notes:

- `.jpe` file format was removed.

Feedback is welcome.