### PR TITLE
Add check constraints for disporder columns

### DIFF
--- a/inc/schemas/pgsql_db_tables.php
+++ b/inc/schemas/pgsql_db_tables.php
@@ -179,7 +179,7 @@ $tables[] = "CREATE INDEX mybb_buddyrequests_touid ON mybb_buddyrequests (touid)
 $tables[] = "CREATE TABLE mybb_calendars (
   cid serial,
   name varchar(100) NOT NULL default '',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   startofweek smallint NOT NULL default '0',
   showbirthdays smallint NOT NULL default '0',
   eventlimit smallint NOT NULL default '0',
@@ -289,7 +289,7 @@ $tables[] = "CREATE TABLE mybb_forums (
   type char(1) NOT NULL default '',
   pid smallint NOT NULL default '0',
   parentlist text NOT NULL default '',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   active smallint NOT NULL default '0',
   open smallint NOT NULL default '0',
   threads int NOT NULL default '0',
@@ -362,7 +362,7 @@ $tables[] = "CREATE TABLE mybb_helpdocs (
   document text NOT NULL default '',
   usetranslation smallint NOT NULL default '0',
   enabled smallint NOT NULL default '0',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   PRIMARY KEY (hid)
 );";
 
@@ -372,7 +372,7 @@ $tables[] = "CREATE TABLE mybb_helpsections (
   description text NOT NULL default '',
   usetranslation smallint NOT NULL default '0',
   enabled smallint NOT NULL default '0',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   PRIMARY KEY (sid)
 );";
 
@@ -608,7 +608,7 @@ $tables[] = "CREATE TABLE mybb_profilefields (
   fid serial,
   name varchar(100) NOT NULL default '',
   description text NOT NULL default '',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   contact smallint NOT NULL default '0',
   type text NOT NULL default '',
   regex text NOT NULL default '',
@@ -710,7 +710,7 @@ $tables[] = "CREATE TABLE mybb_reportreasons (
   title varchar(250) NOT NULL default '',
   appliesto varchar(250) NOT NULL default '',
   extra smallint NOT NULL default '0',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   PRIMARY KEY (rid)
 );";
 
@@ -774,7 +774,7 @@ $tables[] = "CREATE TABLE mybb_settinggroups (
   name varchar(100) NOT NULL default '',
   title varchar(220) NOT NULL default '',
   description text NOT NULL default '',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   isdefault smallint NOT NULL default '0',
   PRIMARY KEY (gid)
 );";
@@ -786,7 +786,7 @@ $tables[] = "CREATE TABLE mybb_settings (
   description text NOT NULL default '',
   optionscode text NOT NULL default '',
   value text NOT NULL default '',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   gid smallint NOT NULL default '0',
   isdefault smallint NOT NULL default '0',
   PRIMARY KEY (sid)
@@ -799,7 +799,7 @@ $tables[] = "CREATE TABLE mybb_smilies (
   name varchar(120) NOT NULL default '',
   find text NOT NULL,
   image varchar(220) NOT NULL default '',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   showclickable smallint NOT NULL default '0',
   PRIMARY KEY (sid)
 );";
@@ -1014,7 +1014,7 @@ $tables[] = "CREATE TABLE mybb_usergroups (
   stars smallint NOT NULL default '0',
   starimage varchar(120) NOT NULL default '',
   image varchar(120) NOT NULL default '',
-  disporder smallint NOT NULL default '0',
+  disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
   isbannedgroup smallint NOT NULL default '0',
   canview smallint NOT NULL default '0',
   canviewthreads smallint NOT NULL default '0',

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -164,7 +164,7 @@ $tables[] = "CREATE INDEX mybb_buddyrequests_touid ON mybb_buddyrequests (touid)
 $tables[] = "CREATE TABLE mybb_calendars (
 	cid INTEGER PRIMARY KEY,
 	name varchar(100) NOT NULL default '',
-	disporder smallint NOT NULL default '0',
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
 	startofweek tinyint(1) NOT NULL default '0',
 	showbirthdays tinyint(1) NOT NULL default '0',
 	eventlimit smallint(3) NOT NULL default '0',
@@ -269,7 +269,7 @@ $tables[] = "CREATE TABLE mybb_forums (
 	type char(1) NOT NULL default '',
 	pid smallint NOT NULL default '0',
 	parentlist TEXT NOT NULL,
-	disporder smallint NOT NULL default '0',
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
 	active tinyint(1) NOT NULL default '0',
 	open tinyint(1) NOT NULL default '0',
 	threads int NOT NULL default '0',
@@ -339,7 +339,7 @@ $tables[] = "CREATE TABLE mybb_helpdocs (
 	document TEXT NOT NULL,
 	usetranslation tinyint(1) NOT NULL default '0',
 	enabled tinyint(1) NOT NULL default '0',
-	disporder smallint NOT NULL default '0'
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0)
 );";
 
 $tables[] = "CREATE TABLE mybb_helpsections (
@@ -348,7 +348,7 @@ $tables[] = "CREATE TABLE mybb_helpsections (
 	description TEXT NOT NULL,
 	usetranslation tinyint(1) NOT NULL default '0',
 	enabled tinyint(1) NOT NULL default '0',
-	disporder smallint NOT NULL default '0'
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0)
 );";
 
 $tables[] = "CREATE TABLE mybb_icons (
@@ -569,7 +569,7 @@ $tables[] = "CREATE TABLE mybb_profilefields (
 	fid INTEGER PRIMARY KEY,
 	name varchar(100) NOT NULL default '',
 	description TEXT NOT NULL,
-	disporder smallint NOT NULL default '0',
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
 	contact tinyint(1) NOT NULL default '0',
 	type TEXT NOT NULL,
 	regex TEXT NOT NULL,
@@ -665,7 +665,7 @@ $tables[] = "CREATE TABLE mybb_reportreasons (
 	title varchar(250) NOT NULL default '',
 	appliesto varchar(250) NOT NULL default '',
 	extra tinyint(1) NOT NULL default '0',
-	disporder smallint NOT NULL default '0'
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0)
 );";
 
 $tables[] = "CREATE TABLE mybb_reputation (
@@ -724,7 +724,7 @@ $tables[] = "CREATE TABLE mybb_settinggroups (
 	name varchar(100) NOT NULL default '',
 	title varchar(220) NOT NULL default '',
 	description TEXT NOT NULL,
-	disporder smallint NOT NULL default '0',
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
 	isdefault tinyint(1) NOT NULL default '0'
 );";
 
@@ -735,7 +735,7 @@ $tables[] = "CREATE TABLE mybb_settings (
 	description TEXT NOT NULL,
 	optionscode TEXT NOT NULL,
 	value TEXT NOT NULL,
-	disporder smallint NOT NULL default '0',
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
 	gid smallint NOT NULL default '0',
 	isdefault tinyint(1) NOT NULL default '0'
 );";
@@ -747,7 +747,7 @@ $tables[] = "CREATE TABLE mybb_smilies (
 	name varchar(120) NOT NULL default '',
 	find TEXT NOT NULL,
 	image varchar(220) NOT NULL default '',
-	disporder smallint NOT NULL default '0',
+	disporder smallint NOT NULL default '0' CHECK (disporder >= 0),
 	showclickable tinyint(1) NOT NULL default '0'
 );";
 
@@ -945,7 +945,7 @@ $tables[] = "CREATE TABLE mybb_usergroups (
 	stars smallint(4) NOT NULL default '0',
 	starimage varchar(120) NOT NULL default '',
 	image varchar(120) NOT NULL default '',
-	disporder smallint(6) NOT NULL default '0',
+	disporder smallint(6) NOT NULL default '0' CHECK (disporder >= 0),
 	isbannedgroup tinyint(1) NOT NULL default '0',
 	canview tinyint(1) NOT NULL default '0',
 	canviewthreads tinyint(1) NOT NULL default '0',

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -370,3 +370,45 @@ function upgrade100_smilies()
         $db->insert_query_multiple('smilies', $insert);
     }
 }
+
+function upgrade100_check_constraints()
+{
+    global $db;
+
+    $constraints = [
+        ['table' => 'calendars', 'column' => 'disporder'],
+        ['table' => 'forums', 'column' => 'disporder'],
+        ['table' => 'helpdocs', 'column' => 'disporder'],
+        ['table' => 'helpsections', 'column' => 'disporder'],
+        ['table' => 'profilefields', 'column' => 'disporder'],
+        ['table' => 'reportreasons', 'column' => 'disporder'],
+        ['table' => 'settinggroups', 'column' => 'disporder'],
+        ['table' => 'settings', 'column' => 'disporder'],
+        ['table' => 'smilies', 'column' => 'disporder'],
+        ['table' => 'usergroups', 'column' => 'disporder'],
+    ];
+
+    if ($db->type === "pgsql") {
+        foreach ($constraints as $constraint) {
+            $table_name = TABLE_PREFIX . $constraint['table'];
+            $column_name = $constraint['column'];
+            $constraint_name = $table_name . '_' . $column_name ."_check";
+            $query = $db->query("
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = '" . $table_name . "'::regclass
+                    AND contype = 'c' AND conname = '" . $constraint_name . "'
+            ");
+
+            if ($db->num_rows($query) == 0) {
+                // Reset values that are negative
+                $db->update_query($constraint['table'], array($column_name => 0), $column_name . ' < 0');
+                // Create constraint
+                $db->write_query("
+                    ALTER TABLE " . $table_name . "
+                    ADD CONSTRAINT " . $constraint_name . " CHECK (" . $column_name  . " >= 0)
+                ");
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
### Added

- Added `CHECK` constraints for disporder columns in SQLite and PostgreSQL.

Part of #4918