### PR TITLE
Remove |raw usage for links, usernames and dates in showthread template

### DIFF
--- a/inc/src/Twig/Extensions/UrlExtension.php
+++ b/inc/src/Twig/Extensions/UrlExtension.php
@@ -10,10 +10,14 @@ class UrlExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('get_profile_link', [$this, 'getProfileLink']),
+            new TwigFunction('get_profile_link', [$this, 'getProfileLink'], [
+                'is_safe' => ['html'],
+            ]),
             new TwigFunction('get_announcement_link', [$this, 'getAnnouncementLink']),
             new TwigFunction('get_forum_link', [$this, 'getForumLink']),
-            new TwigFunction('get_thread_link', [$this, 'getThreadLink']),
+            new TwigFunction('get_thread_link', [$this, 'getThreadLink'], [
+                'is_safe' => ['html'],
+            ]),
             new TwigFunction('get_post_link', [$this, 'getPostLink']),
             new TwigFunction('get_event_link', [$this, 'getEventLink']),
             new TwigFunction('get_calendar_link', [$this, 'getCalendarLink']),

--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -244,13 +244,27 @@
                     {% for post in threadedbits %}
                         {% if post.bitactive %}
                             <div class="threaded-mode__post threaded-mode__post--active" style="margin-left: {{ post.indentsize }}px;">
-                                <span class="threaded-mode__date">{{ post.postdate|raw }}</span>
-                                <span class="threaded-mode__author">{{ lang.by }} {{ post.profilelink|raw }}</span>
+                                <span class="threaded-mode__date">{{ post.postdate }}</span>
+                                <span class="threaded-mode__author">
+                                    {{ lang.by }}
+                                    {% if post.uid > 0 %}
+                                        <a href="{{ get_profile_link(post.uid) }}">{{ post.uid|format_name }}</a>
+                                    {% else %}
+                                        {{ post.username|default(lang.guest) }}
+                                    {% endif %}
+                                </span>
                             </div>
                         {% else %}
                             <div class="threaded-mode__post" style="margin-left: {{ post.indentsize }}px;">
-                                <span class="threaded-mode__date"><a href="showthread.php?tid={{ thread.tid }}&amp;pid={{ post.pid }}&amp;mode=threaded">{{ post.postdate|raw }}</a></span>
-                                <span class="threaded-mode__author">{{ lang.by }} {{ post.profilelink|raw }}</span>
+                                <span class="threaded-mode__date"><a href="showthread.php?tid={{ thread.tid }}&amp;pid={{ post.pid }}&amp;mode=threaded">{{ post.postdate }}</a></span>
+                                <span class="threaded-mode__author">
+                                    {{ lang.by }}
+                                    {% if post.uid > 0 %}
+                                        <a href="{{ get_profile_link(post.uid) }}">{{ post.uid|format_name }}</a>
+                                    {% else %}
+                                        {{ post.username|default(lang.guest) }}
+                                    {% endif %}                                    
+                                </span>
                             </div>
                         {% endif %}
                     {% endfor %}
@@ -395,14 +409,21 @@
                                         {% if similar_thread.threadprefix %}
                                             <span class="tag tag--thread-prefix tag--thread-prefix-{{ similar_thread.prefix }}">{{ similar_thread.threadprefix|raw }}</span>
                                         {% endif %}
-                                        <a href="{{ similar_thread.threadlink|raw }}">{{ similar_thread.subject }}</a>
+                                        <a href="{{ get_thread_link(similar_thread.tid) }}">{{ similar_thread.subject }}</a>
                                         <span class="thread__icons">
                                             {% if similar_thread.hasicon %}
                                                 <img src="{{ similar_thread.icon_path }}" alt="{{ similar_thread.icon_name }}" title="{{ similar_thread.icon_name }}" />
                                             {% endif %}
                                         </span>
                                     </h3>
-                                    <p class="thread__author">{{ lang.by }} {{ similar_thread.profilelink|raw }}</p>
+                                    <p class="thread__author">
+                                        {{ lang.by }}
+                                        {% if similar_thread.uid > 0 %}
+                                            <a href="{{ get_profile_link(similar_thread.uid) }}">{{ similar_thread.uid|format_name }}</a>
+                                        {% else %}
+                                            {{ similar_thread.threadusername|default(lang.guest) }}
+                                        {% endif %}
+                                    </p>
                                 </div>
                                 <div class="thread__column thread__column--replies">
                                     <p class="thread__replies" title="{{ lang.replies }}: {{ thread.replies }} &middot; {{ lang.views }}: {{ thread.views }}">
@@ -414,9 +435,13 @@
                                     <p class="thread__latest-post">
                                         <span class="thread__latest-post__text">{{ lang.lastpost_by }}</span>
                                         <span class="thread__latest-post__author">
-                                            {{ similar_thread.lastposterlink|raw }}
+                                        {% if similar_thread.lastposteruid > 0 %}
+                                            <a href="{{ get_profile_link(similar_thread.lastposteruid) }}">{{ similar_thread.lastposteruid|format_name }}</a>
+                                        {% else %}
+                                            {{ similar_thread.lastposter|default(lang.guest) }}
+                                        {% endif %}
                                         </span>
-                                        <a href="{{ similar_thread.lastpostlink|raw }}" class="thread__latest-post__date">{{ similar_thread.lastpostdate|raw }}</a>
+                                        <a href="{{ get_thread_link(similar_thread.tid, 0, 'lastpost') }}" class="thread__latest-post__date">{{ similar_thread.lastpost|my_date }}</a>
                                     </p>
                                 </div>
                             </div>
@@ -461,7 +486,7 @@
                 <div class="container container--small container--users-browsing">
                     {{ lang.users_browsing_thread }}
                     {% for user in onlinemembers %}
-                        <a href="{{ user.profilelink|raw }}" title="{{ lang.users_browsing_thread_reading }} ({{ user.reading }})">{{ user.username|raw }}</a>{{ user.invisiblemark }}{% if not loop.last %}{{ lang.comma }}{% endif %}
+                        <a href="{{ get_profile_link(user.uid) }}" title="{{ lang.users_browsing_thread_reading }} ({{ user.reading }})">{{ user|format_name }}</a>{{ user.invisiblemark }}{% if not loop.last %}{{ lang.comma }}{% endif %}
                     {% endfor %}
                     {% if thread.inviscount and thread.onlinemembers %}
                         {{ lang.comma }}

--- a/showthread.php
+++ b/showthread.php
@@ -1059,15 +1059,6 @@ if($mybb->input['action'] == "thread")
 				$similar_thread['icon_name'] = $icon['name'];
 			}
 
-			if(!$similar_thread['username'])
-			{
-				$similar_thread['username'] = $similar_thread['profilelink'] = $similar_thread['threadusername'];
-			}
-			else
-			{
-				$similar_thread['profilelink'] = build_profile_link($similar_thread['username'], $similar_thread['uid']);
-			}
-
 			// If this thread has a prefix, insert a space between prefix and subject
 			if($similar_thread['prefix'] != 0)
 			{
@@ -1083,23 +1074,6 @@ if($mybb->input['action'] == "thread")
 			}
 
 			$similar_thread['subject'] = $parser->parse_badwords($similar_thread['subject']);
-			$similar_thread['threadlink'] = get_thread_link($similar_thread['tid']);
-			$similar_thread['lastpostlink'] = get_thread_link($similar_thread['tid'], 0, "lastpost");
-
-			$similar_thread['lastpostdate'] = my_date('relative', $similar_thread['lastpost']);
-			$lastposter = $similar_thread['lastposter'];
-			$lastposteruid = $similar_thread['lastposteruid'];
-
-			// Don't link to guest's profiles (they have no profile).
-			if($lastposteruid == 0)
-			{
-				$similar_thread['lastposterlink'] = $lastposter;
-			}
-			else
-			{
-				$similar_thread['lastposterlink'] = build_profile_link($lastposter, $lastposteruid);
-			}
-
 			$similar_thread['replies'] = my_number_format($similar_thread['replies']);
 			$similar_thread['views'] = my_number_format($similar_thread['views']);
 
@@ -1360,10 +1334,7 @@ if($mybb->input['action'] == "thread")
 
 				if($user['invisible'] != 1 || $mybb->usergroup['canviewwolinvis'] == 1 || $user['uid'] == $mybb->user['uid'])
 				{
-					$user['profilelink'] = get_profile_link($user['uid']);
-					$user['username'] = format_name($user['username'], $user['usergroup'], $user['displaygroup']);
 					$user['reading'] = my_date($mybb->settings['timeformat'], $user['time']);
-
 					++$thread['onlinemembers'];
 					$onlinemembers[] = $user;
 				}
@@ -1435,8 +1406,6 @@ function buildtree($replyto = 0, $indent = 0)
 				$post['subject'] = "[".$lang->no_subject."]";
 			}
 
-			$post['profilelink'] = build_profile_link($post['username'], $post['uid']);
-
 			$post['bitactive'] = false;
 			if($mybb->input['pid'] == $post['pid'])
 			{
@@ -1451,7 +1420,6 @@ function buildtree($replyto = 0, $indent = 0)
 				$posts = buildtree($post['pid'], $indent);
 				$posttree = array_merge($posttree, $posts);
 			}
-
 		}
 		--$indent;
 	}


### PR DESCRIPTION
### Removed

- Computed links and values server-side for threads, posts, and users.

### Changed

- Replaced all `|raw` filter usage with appropriate Twig filters depending on the scenario:
  - `my_date` for dates
  - `format_name` for usernames
  - `get_profile_link` for user profile links
  - `get_thread_link` for thread links

This is a test with the showthread template only to check if this is the way you guys would like to go.