### PR TITLE
Add mode parameter to get_post_link

### DIFF
--- a/htaccess-nginx.txt
+++ b/htaccess-nginx.txt
@@ -37,7 +37,11 @@ rewrite ^/thread-([0-9]+)-nextnewest.html$ /showthread.php?tid=$1&action=nextnew
 rewrite ^/thread-([0-9]+)-nextoldest.html$ /showthread.php?tid=$1&action=nextoldest last;
 rewrite ^/thread-([0-9]+)-newpost.html$ /showthread.php?tid=$1&action=newpost last;
 rewrite ^/thread-([0-9]+)-post-([0-9]+).html$ /showthread.php?tid=$1&pid=$2 last;
+rewrite ^/thread-([0-9]+)-post-([0-9]+)-linear.html$ /showthread.php?tid=$1&pid=$2&mode=linear last;
+rewrite ^/thread-([0-9]+)-post-([0-9]+)-threaded.html$ /showthread.php?tid=$1&pid=$2&mode=threaded last;
 rewrite ^/post-([0-9]+).html$ /showthread.php?pid=$1 last;
+rewrite ^/post-([0-9]+)-linear.html$ /showthread.php?pid=$1&mode=linear last;
+rewrite ^/post-([0-9]+)-threaded.html$ /showthread.php?pid=$1&mode=threaded last;
 rewrite ^/announcement-([0-9]+).html$ /announcements.php?aid=$1 last;
 rewrite ^/user-([0-9]+).html$ /member.php?action=profile&uid=$1 last;
 rewrite ^/calendar-([0-9]+).html$ /calendar.php?calendar=$1 last;

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -50,8 +50,12 @@ Options -MultiViews +FollowSymlinks -Indexes
 	RewriteRule ^thread-([0-9]+)-nextoldest\.html$ showthread.php?tid=$1&action=nextoldest [L,QSA]
 	RewriteRule ^thread-([0-9]+)-newpost\.html$ showthread.php?tid=$1&action=newpost [L,QSA]
 	RewriteRule ^thread-([0-9]+)-post-([0-9]+)\.html$ showthread.php?tid=$1&pid=$2 [L,QSA]
+	RewriteRule ^thread-([0-9]+)-post-([0-9]+)-linear\.html$ showthread.php?tid=$1&pid=$2&mode=linear [L,QSA]
+	RewriteRule ^thread-([0-9]+)-post-([0-9]+)-threaded\.html$ showthread.php?tid=$1&pid=$2&mode=threaded [L,QSA]
 
 	RewriteRule ^post-([0-9]+)\.html$ showthread.php?pid=$1 [L,QSA]
+	RewriteRule ^post-([0-9]+)-linear\.html$ showthread.php?pid=$1&mode=linear [L,QSA]
+	RewriteRule ^post-([0-9]+)-threaded\.html$ showthread.php?pid=$1&mode=threaded [L,QSA]
 
 	RewriteRule ^announcement-([0-9]+)\.html$ announcements.php?aid=$1 [L,QSA]
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -6018,21 +6018,23 @@ function get_thread_link($tid, $page = 0, $action = '')
  *
  * @param int $pid The post ID of the post
  * @param int $tid The thread id of the post.
+ * @param string $mode The mode used to display the post.
  * @return string The url to the post.
  */
-function get_post_link($pid, $tid = 0)
+function get_post_link(int $pid, int $tid = 0, string $mode = '') : string
 {
-	if($tid > 0)
+	$link = empty($mode) ? POST_URL : POST_URL_MODE;
+    if($tid > 0)
 	{
-		$link = str_replace("{tid}", $tid, THREAD_URL_POST);
-		$link = str_replace("{pid}", $pid, $link);
-		return htmlspecialchars_uni($link);
-	}
-	else
-	{
-		$link = str_replace("{pid}", $pid, POST_URL);
-		return htmlspecialchars_uni($link);
-	}
+        $link = empty($mode) ? THREAD_URL_POST : THREAD_URL_POST_MODE;
+    }
+
+    $replacements = [
+		'{pid}' => urlencode($pid),
+		'{tid}' => urlencode($tid),
+		'{mode}' => urlencode($mode)
+	];
+    return strtr($link, $replacements);
 }
 
 /**

--- a/inc/init.php
+++ b/inc/init.php
@@ -295,7 +295,9 @@ if($mybb->settings['seourls'] == "yes" || ($mybb->settings['seourls'] == "auto" 
 	define('THREAD_URL_PAGED', "thread-{tid}-page-{page}.html");
 	define('THREAD_URL_ACTION', 'thread-{tid}-{action}.html');
 	define('THREAD_URL_POST', 'thread-{tid}-post-{pid}.html');
+	define('THREAD_URL_POST_MODE', 'thread-{tid}-post-{pid}-{mode}.html');
 	define('POST_URL', "post-{pid}.html");
+	define('POST_URL_MODE', "post-{pid}-{mode}.html");
 	define('PROFILE_URL', "user-{uid}.html");
 	define('ANNOUNCEMENT_URL', "announcement-{aid}.html");
 	define('CALENDAR_URL', "calendar-{calendar}.html");
@@ -312,7 +314,9 @@ else
 	define('THREAD_URL_PAGED', "showthread.php?tid={tid}&page={page}");
 	define('THREAD_URL_ACTION', 'showthread.php?tid={tid}&action={action}');
 	define('THREAD_URL_POST', 'showthread.php?tid={tid}&pid={pid}');
+	define('THREAD_URL_POST_MODE', 'showthread.php?tid={tid}&pid={pid}&mode={mode}');
 	define('POST_URL', "showthread.php?pid={pid}");
+	define('POST_URL_MODE', "showthread.php?pid={pid}&mode={mode}");
 	define('PROFILE_URL', "member.php?action=profile&uid={uid}");
 	define('ANNOUNCEMENT_URL', "announcements.php?aid={aid}");
 	define('CALENDAR_URL', "calendar.php?calendar={calendar}");

--- a/inc/src/Twig/Extensions/UrlExtension.php
+++ b/inc/src/Twig/Extensions/UrlExtension.php
@@ -77,12 +77,13 @@ class UrlExtension extends AbstractExtension
      *
      * @param int $postId The post's ID.
      * @param int $threadId An optional thread ID that the post belongs to.
+     * @param string $mode An optional mode used to display the post.
      *
      * @return string The URL path to the post.
      */
-    public function getPostLink(int $postId, int $threadId = 0): string
+    public function getPostLink(int $postId, int $threadId = 0, string $mode = ''): string
     {
-        return get_post_link($postId, $threadId);
+        return get_post_link($postId, $threadId, $mode);
     }
 
     /**

--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -249,7 +249,7 @@
                             </div>
                         {% else %}
                             <div class="threaded-mode__post" style="margin-left: {{ post.indentsize }}px;">
-                                <span class="threaded-mode__date"><a href="showthread.php?tid={{ thread.tid }}&amp;pid={{ post.pid }}&amp;mode=threaded">{{ post.postdate|raw }}</a></span>
+                                <span class="threaded-mode__date"><a href="{{ get_post_link(post.pid, thread.tid, 'threaded') }}">{{ post.postdate|raw }}</a></span>
                                 <span class="threaded-mode__author">{{ lang.by }} {{ post.profilelink|raw }}</span>
                             </div>
                         {% endif %}


### PR DESCRIPTION
### Added
- Added rewrite rules to support the new `mode` parameter (`linear`, `threaded`) in pretty URLs.

### Changed
- Replaced manually constructed post URL in the `showthread` template with a call to `get_post_link()` as an example.
- Refactored `get_post_link()`:
  - Added parameter and return types.
  - Applied `urlencode()` to individual parameters and used `strtr()` for placeholder substitution.
- Updated the related `get_post_link` Twig function to match the new signature and behavior.

This follows a discussion in https://github.com/mybb/mybb/pull/5129.  
I have not updated the other `get_*_link` functions yet.  
If this approach is accepted, I will submit a separate PR to update the remaining link-generation functions accordingly.
