### PR TITLE
Fix undefined index notice in delete_user()

### DIFF
--- a/inc/datahandlers/user.php
+++ b/inc/datahandlers/user.php
@@ -1525,7 +1525,7 @@ class UserDataHandler extends DataHandler
 
 		foreach($this->delete_uids as $key => $uid)
 		{
-			if(!$uid || is_super_admin($uid) || $uid == $mybb->user['uid'])
+			if(!$uid || is_super_admin($uid) || (isset($mybb->user['uid']) && $uid === $mybb->user['uid']))
 			{
 				// Remove super admins
 				unset($this->delete_uids[$key]);


### PR DESCRIPTION
### Fixed

Added an extra check before comparing `$uid` to `$mybb->user['uid']` in `delete_user` method.

Resolves #5141

