### PR TITLE
Fix uninitialized string offset in query functions for binary fields

### DIFF
--- a/inc/db_mysql_pdo.php
+++ b/inc/db_mysql_pdo.php
@@ -237,7 +237,7 @@ class MysqlPdoDbDriver extends AbstractPdoDbDriver
 
 		foreach ($array as $field => $value) {
 			if (isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field]) {
-				if($value[0] != 'X') { // Not escaped?
+				if($value !== '' && $value[0] != 'X') { // Not escaped?
 					$value = $this->escape_binary($value);
 				}
 

--- a/inc/db_mysqli.php
+++ b/inc/db_mysqli.php
@@ -752,7 +752,7 @@ class DB_MySQLi implements DB_Base
 		{
 			if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
 			{
-				if($value[0] != 'X') // Not escaped?
+				if($value !== '' && $value[0] != 'X') // Not escaped?
 				{
 					$value = $this->escape_binary($value);
 				}
@@ -858,7 +858,7 @@ class DB_MySQLi implements DB_Base
 		{
 			if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
 			{
-				if($value[0] != 'X') // Not escaped?
+				if($value !== '' && $value[0] != 'X') // Not escaped?
 				{
 					$value = $this->escape_binary($value);
 				}
@@ -1247,7 +1247,7 @@ class DB_MySQLi implements DB_Base
 		{
 			if(isset($mybb->binary_fields[$table][$column]) && $mybb->binary_fields[$table][$column])
 			{
-				if($value[0] != 'X') // Not escaped?
+				if($value !== '' && $value[0] != 'X') // Not escaped?
 				{
 					$value = $this->escape_binary($value);
 				}

--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -662,7 +662,7 @@ class DB_SQLite implements DB_Base
 		{
 			if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
 			{
-				if($value[0] != 'X') // Not escaped?
+				if($value !== '' && $value[0] != 'X') // Not escaped?
 				{
 					$value = $this->escape_binary($value);
 				}
@@ -770,7 +770,7 @@ class DB_SQLite implements DB_Base
 		{
 			if(isset($mybb->binary_fields[$table][$field]) && $mybb->binary_fields[$table][$field])
 			{
-				if($value[0] != 'X') // Not escaped?
+				if($value !== '' && $value[0] != 'X') // Not escaped?
 				{
 					$value = $this->escape_binary($value);
 				}
@@ -1124,7 +1124,7 @@ class DB_SQLite implements DB_Base
 			$columns .= $comma.$column;
 			if(isset($mybb->binary_fields[$table][$column]) && $mybb->binary_fields[$table][$column])
 			{
-				if($value[0] != 'X') // Not escaped?
+				if($value !== '' && $value[0] != 'X') // Not escaped?
 				{
 					$value = $this->escape_binary($value);
 				}


### PR DESCRIPTION
### Fixed

- Fixed binary field escaping in query functions to avoid uninitialized string offset notices for empty values.

Resolves #4849

