### PR TITLE
Switch data type for smtperror column in mailerrors

### DIFF
--- a/inc/schemas/mysql_db_tables.php
+++ b/inc/schemas/mysql_db_tables.php
@@ -402,7 +402,7 @@ $tables[] = "CREATE TABLE mybb_mailerrors (
   fromaddress varchar(150) NOT NULL default '',
   dateline int unsigned NOT NULL default '0',
   error text NOT NULL,
-  smtperror varchar(200) NOT NULL default '',
+  smtperror text NOT NULL,
   smtpcode smallint(5) unsigned NOT NULL default '0',
   PRIMARY KEY (eid)
 ) ENGINE=InnoDB;";

--- a/inc/schemas/pgsql_db_tables.php
+++ b/inc/schemas/pgsql_db_tables.php
@@ -419,7 +419,7 @@ $tables[] = "CREATE TABLE mybb_mailerrors (
   fromaddress varchar(150) NOT NULL default '',
   dateline int NOT NULL default '0',
   error text NOT NULL default '',
-  smtperror varchar(200) NOT NULL default '',
+  smtperror text NOT NULL,
   smtpcode smallint NOT NULL default '0',
   PRIMARY KEY(eid)
 );";

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -391,7 +391,7 @@ $tables[] = "CREATE TABLE mybb_mailerrors (
 	fromaddress varchar(150) NOT NULL default '',
 	dateline int NOT NULL default '0',
 	error TEXT NOT NULL,
-	smtperror varchar(200) NOT NULL default '',
+	smtperror text NOT NULL,
 	smtpcode smallint(5) NOT NULL default '0'
 );";
 

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -37,6 +37,7 @@ function upgrade100_dbchanges()
 
     // Modify columns
     $db->modify_column("users", "password", "varchar(500)", "set", "''");
+    $db->modify_column("mailerrors", "smtperror", "text", "set", false);
 
     if ($db->field_exists("pid", "themes")) {
         $db->drop_column("themes", "pid");


### PR DESCRIPTION
### Changed

- Changed the type for `smtperror` to TEXT. From what I’ve found, errors can easily exceed 300 characters—which was the suggestion in the issue—and nowadays, storing TEXT objects adds little to no overhead for a table like this.

Resolves #5061 

