### PR TITLE
Remove default value for userfields TEXT columns in 1.9 upgrade script

### DIFF
--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -67,7 +67,7 @@ function upgrade100_dbchanges()
     // Add userfields columns
     foreach (["fid4", "fid5"] as $fid) {
         if (!$db->field_exists($fid, "userfields")) {
-            $db->add_column("userfields", $fid, "text NOT NULL DEFAULT ''");
+            $db->add_column("userfields", $fid, "text NOT NULL");
         }
     }
 


### PR DESCRIPTION
### Removed

- Removed `DEFAULT ''` in the upgrade script to match the schema definition:
```
  fid4 text NOT NULL,
  fid5 text NOT NULL,
```

