### PR TITLE
Add the ability to suspend a user's private messaging

### DIFF
--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -735,7 +735,7 @@ if($mybb->input['action'] == "edit")
 				}
 			}
 
-			// Moderator "Options" (suspend signature, suspend/moderate posting)
+			// Moderator "Options" (suspend signature, suspend/moderate posting, suspend private messaging)
 			$moderator_options = array(
 				1 => array(
 					"action" => "suspendsignature", // The moderator action we're performing
@@ -757,6 +757,13 @@ if($mybb->input['action'] == "edit")
 					"time" => "suspost_time",
 					"update_field" => "suspendposting",
 					"update_length" => "suspensiontime"
+				),
+				4 => array(
+					"action" => "suspendpm",
+					"period" => "suspm_period",
+					"time" => "suspm_time",
+					"update_field" => "suspendpm",
+					"update_length" => "suspendpmtime"
 				)
 			);
 
@@ -783,8 +790,7 @@ if($mybb->input['action'] == "edit")
 						$string = $option['action']."_error";
 						$errors[] = $lang->$string;
 					}
-
-					if(!is_array($errors))
+					else
 					{
 						$suspend_length = fetch_time_length((int)$mybb->input[$option['time']], $mybb->input[$option['period']]);
 
@@ -1718,6 +1724,44 @@ EOF;
 	$lang->suspend_posts_info = $lang->sprintf($lang->suspend_posts_info, htmlspecialchars_uni($user['username']));
 	$form_container->output_row($form->generate_check_box("suspendposting", 1, $lang->suspend_posts, array("id" => "suspendposting", "onclick" => "toggleBox('suspost');", "checked" => $mybb->get_input('suspendposting'))), $lang->suspend_posts_info, $suspost_div);
 
+	// Suspend private messages
+	// Generate check box
+	$suspm_options = $form->generate_select_box('suspm_period', $periods, $mybb->get_input('suspm_period'), array('id' => 'suspm_period'));
+
+	// Do we have an existing private messaging suspension?
+	if($user['suspendpm'] || ($mybb->get_input('suspendpm') && !empty($errors)))
+	{
+		$mybb->input['suspendpm'] = 1;
+		if($user['suspendpmtime'] == 0 || $mybb->get_input('suspm_period') == "never")
+		{
+			$existing_info = $lang->suspended_perm;
+		}
+		else
+		{
+			$remaining = $user['suspendpmtime'] - TIME_NOW;
+			$suspm_date = nice_time($remaining, array('seconds' => false));
+
+			$color = 'inherit';
+			if($remaining < 3600)
+			{
+				$color = 'red';
+			}
+			elseif($remaining < 86400)
+			{
+				$color = 'maroon';
+			}
+			elseif($remaining < 604800)
+			{
+				$color = 'green';
+			}
+
+			$existing_info = $lang->sprintf($lang->suspend_length, $suspm_date, $color);
+		}
+	}
+
+	$lang->suspend_pm_info = $lang->sprintf($lang->suspend_pm_info, htmlspecialchars_uni($user['username']));
+	$suspm_div = '<div id="suspm">'.$existing_info.''.$lang->suspend_for.' '.$form->generate_numeric_field("suspm_time", $mybb->get_input('suspm_time'), array('style' => 'width: 3em;', 'min' => 0)).' '.$suspm_options.'</div>';
+	$form_container->output_row($form->generate_check_box("suspendpm", 1, $lang->suspend_pm, array("id" => "suspendpm", "onclick" => "toggleBox('suspm');", "checked" => $mybb->get_input('suspendpm'))), $lang->suspend_pm_info, $suspm_div);
 
 	$form_container->end();
 	$plugins->run_hooks("admin_user_users_edit_moderator_options");
@@ -1763,6 +1807,20 @@ function toggleBox(action)
 			$("#suspost").hide();
 		}
 	}
+	else if(action == "suspm")
+	{
+		$("#suspendpm").attr("checked", false);
+		$("#suspm").hide();
+
+		if($("#suspendpm").is(":checked") == true)
+		{
+			$("#suspm").show();
+		}
+		else if($("#suspendpm").is(":checked") == false)
+		{
+			$("#suspm").hide();
+		}
+	}
 }
 
 if($("#moderateposting").is(":checked") == false)
@@ -1781,6 +1839,15 @@ if($("#suspendposting").is(":checked") == false)
 else
 {
 	$("#suspost").show();
+}
+	
+if($("#suspendpm").is(":checked") == false)
+{
+	$("#suspm").hide();
+}
+else
+{
+	$("#suspm").show();
 }
 
 // -->

--- a/inc/datahandlers/pm.php
+++ b/inc/datahandlers/pm.php
@@ -336,7 +336,7 @@ class PMDataHandler extends DataHandler
 				}
 
 				// Can the recipient actually receive private messages based on their permissions or user setting?
-				if(($user['receivepms'] == 0 || $recipient_permissions['canusepms'] == 0) && empty($pm['saveasdraft']))
+				if(($user['receivepms'] == 0 || $recipient_permissions['canusepms'] == 0 || $user['suspendpm']) && empty($pm['saveasdraft']))
 				{
 					$this->set_error("recipient_pms_disabled", array(htmlspecialchars_uni($user['username'])));
 					return false;

--- a/inc/languages/english/admin/user_users.lang.php
+++ b/inc/languages/english/admin/user_users.lang.php
@@ -257,6 +257,9 @@ $l['suspend_for'] = "Suspend for:";
 $l['suspended_perm'] = "<p><small>Suspended permanently.<br />Enter a new time below to change or untick this option to remove this suspension.</small></p>";
 $l['suspend_length'] = "<p><small>Remaining Suspension: <span style=\"color: {2};\">{1}</span>.<br />Enter a new time below to change or untick this option to remove this suspension.</small></p>";
 
+$l['suspend_pm'] = "Suspend private messaging";
+$l['suspend_pm_info'] = "Suspend {1} from sending and receiving new private messages.";
+
 $l['suspendsignature_error'] = "You selected to suspend this user's signature, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['moderateposting_error'] = "You selected to moderate this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendposting_error'] = "You selected to suspend this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";

--- a/inc/languages/english/modcp.lang.php
+++ b/inc/languages/english/modcp.lang.php
@@ -252,18 +252,23 @@ $l['mod_notes'] = "Moderator Notes";
 $l['moderation'] = "Moderator Options";
 $l['moderate_posts'] = "Moderate this user's posts";
 $l['suspend_posts'] = "Suspend this user's posting privileges";
+$l['suspend_pm'] = "Suspend this user's private messaging privileges";
 $l['modpost_length'] = "Moderate for";
 $l['suspost_length'] = "Suspend for";
+$l['suspm_length'] = "Suspend for:";
 
 $l['moderateposts_for'] = "Moderated until {1}.<br />Untick this option to remove, or extend below.";
 $l['suspendposting_for'] = "Suspended until {1}.<br />Untick this option to remove, or extend below.";
+$l['suspendpm_for'] = "Suspended until {1}.<br />Untick this option to remove, or extend below.";
 $l['suspendsignature_for'] = "Suspended until {1}.<br />Untick this option to remove, or extend below.";
 $l['suspendposting_perm'] = "Suspended permanently.<br />Untick this option to remove, or change below.";
+$l['suspendpm_perm'] = "Suspended permanently.<br />Untick this option to remove, or change below.";
 $l['moderateposts_perm'] = "Moderated permanently.<br />Untick this option to remove, or change below.";
 $l['suspendsignature_perm'] = "Suspended permanently.<br />Untick this option to remove, or change below.";
 $l['suspendsignature_error'] = "You selected to suspend this user's signature, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['moderateposting_error'] = "You selected to moderate this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendposting_error'] = "You selected to suspend this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
+$l['suspendpm_error'] = "You selected to suspend this user's private messaging, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendmoderate_error'] = "You've selected to suspend and moderate the user's posts. Please select only one type of moderation.";
 
 $l['expire_hours'] = "hour(s)";

--- a/inc/languages/english/private.lang.php
+++ b/inc/languages/english/private.lang.php
@@ -202,3 +202,8 @@ $l['quickreply_signature'] = "Signature";
 $l['quickreply_disable_smilies'] = "Disable Smilies";
 $l['quickreply_save_copy'] = "Save a Copy";
 $l['quickreply_read_receipt'] = "Request Read Receipt";
+
+$l['error_suspend_pm'] = "Your ability to send and receive private messages is currently suspended {1}.<br />
+Suspension Date: {2}";
+$l['error_suspend_pm_temporal'] = "until {1}";
+$l['error_suspend_pm_permanent'] = "permanently";

--- a/inc/schemas/mysql_db_tables.php
+++ b/inc/schemas/mysql_db_tables.php
@@ -1139,6 +1139,8 @@ $tables[] = "CREATE TABLE mybb_users (
   suspensiontime int unsigned NOT NULL default '0',
   suspendsignature tinyint(1) NOT NULL default '0',
   suspendsigtime int unsigned NOT NULL default '0',
+  suspendpm tinyint(1) NOT NULL default '0',
+  suspendpmtime int unsigned NOT NULL default '0',
   coppauser tinyint(1) NOT NULL default '0',
   classicpostbit tinyint(1) NOT NULL default '0',
   loginattempts smallint(2) unsigned NOT NULL default '0',

--- a/inc/schemas/pgsql_db_tables.php
+++ b/inc/schemas/pgsql_db_tables.php
@@ -1176,6 +1176,8 @@ $tables[] = "CREATE TABLE mybb_users (
   suspensiontime int NOT NULL default '0',
   suspendsignature smallint NOT NULL default '0',
   suspendsigtime int NOT NULL default '0',
+  suspendpm smallint NOT NULL default '0',
+  suspendpmtime int NOT NULL default '0',
   coppauser smallint NOT NULL default '0',
   classicpostbit smallint NOT NULL default '0',
   loginattempts smallint NOT NULL default '0',

--- a/inc/schemas/sqlite_db_tables.php
+++ b/inc/schemas/sqlite_db_tables.php
@@ -1106,6 +1106,8 @@ $tables[] = "CREATE TABLE mybb_users (
 	suspensiontime int NOT NULL default '0',
 	suspendsignature tinyint(1) NOT NULL default '0',
 	suspendsigtime int NOT NULL default '0',
+	suspendpm tinyint(1) NOT NULL default '0',
+	suspendpmtime int NOT NULL default '0',
 	coppauser tinyint(1) NOT NULL default '0',
 	classicpostbit tinyint(1) NOT NULL default '0',
 	loginattempts smallint(2) NOT NULL default '0',

--- a/inc/tasks/usercleanup.php
+++ b/inc/tasks/usercleanup.php
@@ -19,7 +19,7 @@ function task_usercleanup($task)
 	$warningshandler->expire_warnings();
 
 	// Expire any post moderation or suspension limits
-	$query = $db->simple_select("users", "uid, moderationtime, suspensiontime", "(moderationtime!=0 AND moderationtime<".TIME_NOW.") OR (suspensiontime!=0 AND suspensiontime<".TIME_NOW.")");
+	$query = $db->simple_select("users", "uid, moderationtime, suspensiontime, suspendpmtime", "(moderationtime!=0 AND moderationtime<".TIME_NOW.") OR (suspensiontime!=0 AND suspensiontime<".TIME_NOW.") OR (suspendpmtime!=0 AND suspendpmtime<".TIME_NOW.")");
 	while($user = $db->fetch_array($query))
 	{
 		$updated_user = array();
@@ -32,6 +32,11 @@ function task_usercleanup($task)
 		{
 			$updated_user['suspendposting'] = 0;
 			$updated_user['suspensiontime'] = 0;
+		}
+		if($user['suspendpmtime'] != 0 && $user['suspendpmtime'] < TIME_NOW)
+		{
+			$updated_user['suspendpm'] = 0;
+			$updated_user['suspendpmtime'] = 0;
 		}
 		$db->update_query("users", $updated_user, "uid='{$user['uid']}'");
 	}

--- a/inc/themes/core.base/frontend/templates/layouts/messenger.twig
+++ b/inc/themes/core.base/frontend/templates/layouts/messenger.twig
@@ -6,7 +6,7 @@
 
 <nav class="section-menu">
     <ul class="section-menu__links sidebar-navigation">
-        {% if mybb.usergroup.cansendpms %}
+        {% if mybb.usergroup.cansendpms and mybb.user.suspendpm == 0 %}
             <li class="section-menu__item section-menu__item--messenger-compose{% if mybb.input.action == 'send' %} section-menu__item--active{% endif %}">
                 <a href="private.php?action=send" class="section-menu__link">
                     {{ include('partials/icon.twig', {icon: 'edit', class: 'section-menu__icon fa-fw'}, with_context = false) }}

--- a/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
+++ b/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
@@ -274,6 +274,7 @@
         <!--
             var mod_posts = '{% if user.moderateposts or (mybb.input.moderateposting and errors) %}1{% else %}0{% endif %}';
             var susp_posts = '{% if user.suspendposting or (mybb.input.suspendposting and errors) %}1{% else %}0{% endif %}';
+            var susp_pms = '{% if user.suspendpm or (mybb.input.suspendpm and errors) %}1{% else %}0{% endif %}';
             var sig_checked = '{% if user.suspendsignature or (mybb.input.suspendsignature and errors) %}1{% else %}0{% endif %}';
             if(mod_posts == 0)
             {
@@ -283,6 +284,11 @@
             if(susp_posts == 0)
             {
                 $("#susposts_action").hide();
+            }
+
+            if(susp_pms == 0)
+            {
+                $("#suspms_action").hide();
             }
 
             if(sig_checked == 0)
@@ -319,6 +325,18 @@
                     } else {
                         $("#suspost").attr("checked", true);
                         $("#susposts_action").show();
+                    }
+                }
+
+                if(action == "suspms")
+                {
+                    if($("#suspm").prop("checked") == false)
+                    {
+                        $("#suspm").attr("checked", false);
+                        $("#suspms_action").hide();
+                    } else {
+                        $("#suspm").attr("checked", true);
+                        $("#suspms_action").show();
                     }
                 }
             }

--- a/inc/themes/core.base/frontend/templates/private/read.twig
+++ b/inc/themes/core.base/frontend/templates/private/read.twig
@@ -22,7 +22,7 @@
         </div>
     </div>
 
-    {% if mybb.settings.pmquickreply and mybb.user.showquickreply and mybb.usergroup.cansendpms and pm.fromid != 0 and pm.folder != 3 %}
+    {% if mybb.settings.pmquickreply and mybb.user.showquickreply and mybb.usergroup.cansendpms and pm.fromid != 0 and pm.folder != 3 and mybb.user.suspendpm == 0 %}
         <div class="post post--reply post--quick-reply compose compose--quick-reply quick-reply" id="post-reply">
             <form action="private.php" method="post" name="input">
                 <input type="hidden" name="my_post_key" value="{{ mybb.post_code }}" />

--- a/inc/upgrades/upgrade100.php
+++ b/inc/upgrades/upgrade100.php
@@ -82,6 +82,15 @@ function upgrade100_dbchanges()
                 $db->add_column("threads", "moved", "int NOT NULL default '0'");
             }
 
+            // Add private messaging suspension columns
+            if (!$db->field_exists("suspendpm", "users")) {
+                $db->add_column("users", "suspendpm", "smallint NOT NULL default '0'");
+            }
+
+            if (!$db->field_exists("suspendpmtime", "users")) {
+                $db->add_column("users", "suspendpmtime", "int NOT NULL default '0'");
+            }
+
             // Update moved threads
             $db->query("
                 UPDATE ".TABLE_PREFIX."threads
@@ -118,6 +127,15 @@ function upgrade100_dbchanges()
                 $db->add_column("threads", "moved", "int NOT NULL default '0'");
             }
 
+            // Add private messaging suspension columns
+            if (!$db->field_exists("suspendpm", "users")) {
+                $db->add_column("users", "suspendpm", "tinyint(1) NOT NULL default '0'");
+            }
+
+            if (!$db->field_exists("suspendpmtime", "users")) {
+                $db->add_column("users", "suspendpmtime", "int NOT NULL default '0'");
+            }
+
             // Update moved threads
             $db->query("
                 UPDATE ".TABLE_PREFIX."threads
@@ -150,6 +168,15 @@ function upgrade100_dbchanges()
             }
             if (!$db->field_exists("moved", "threads")) {
                 $db->add_column("threads", "moved", "int unsigned NOT NULL default '0' AFTER closed");
+            }
+
+            // Add private messaging suspension columns
+            if (!$db->field_exists("suspendpm", "users")) {
+                $db->add_column("users", "suspendpm", "tinyint(1) NOT NULL default '0' AFTER suspendsigtime");
+            }
+
+            if (!$db->field_exists("suspendpmtime", "users")) {
+                $db->add_column("users", "suspendpmtime", "int unsigned NOT NULL default '0' AFTER suspendpm");
             }
 
             // Update moved threads

--- a/modcp.php
+++ b/modcp.php
@@ -2296,7 +2296,7 @@ if($mybb->input['action'] == "do_editprofile")
 			remove_avatars($user['uid']);
 		}
 
-		// Moderator "Options" (suspend signature, suspend/moderate posting)
+		// Moderator "Options" (suspend signature, suspend/moderate posting, suspend private messaging)
 		$modoptions = array(
 			1 => array(
 				"action" => "suspendsignature", // The moderator action we're performing
@@ -2318,6 +2318,13 @@ if($mybb->input['action'] == "do_editprofile")
 				"time" => "suspost_time",
 				"update_field" => "suspendposting",
 				"update_length" => "suspensiontime"
+			),
+			4 => array(
+				"action" => "suspendpm",
+				"period" => "suspm_period",
+				"time" => "suspm_time",
+				"update_field" => "suspendpm",
+				"update_length" => "suspendpmtime"
 			)
 		);
 
@@ -2594,6 +2601,17 @@ if($mybb->input['action'] == "editprofile")
 			"select_option" => "suspost",
 			"lang" => [
 				"title" => "suspend_posts",
+				"length" => "suspend_length"
+			]
+		),
+		array(
+			"action" => "suspendpm",
+			"option" => "suspendpm",
+			"time" => "suspm_time",
+			"length" => "suspendpmtime",
+			"select_option" => "suspm",
+			"lang" => [
+				"title" => "suspend_pm",
 				"length" => "suspend_length"
 			]
 		)

--- a/private.php
+++ b/private.php
@@ -555,6 +555,17 @@ if($mybb->input['action'] == "do_send" && $mybb->request_method == "post")
 		error_no_permission();
 	}
 
+	if((int)$mybb->user['suspendpm'] === 1)
+	{
+		$suspendpmtype = $lang->error_suspend_pm_permanent;
+		if($mybb->user['suspendpmtime'])
+		{
+			$suspendpmtype = $lang->sprintf($lang->error_suspend_pm_temporal, my_date($mybb->settings['dateformat'], $mybb->user['suspendpmtime']));
+		}
+		$lang->error_suspend_pm = $lang->sprintf($lang->error_suspend_pm, $suspendpmtype, my_date($mybb->settings['timeformat'], $mybb->user['suspendpmtime']));
+		error($lang->error_suspend_pm);
+	}
+
 	// Verify incoming POST request
 	verify_post_check($mybb->get_input('my_post_key'));
 
@@ -665,6 +676,17 @@ if($mybb->input['action'] == "send")
 	if($mybb->usergroup['cansendpms'] == 0)
 	{
 		error_no_permission();
+	}
+
+	if((int)$mybb->user['suspendpm'] === 1)
+	{
+		$suspendpmtype = $lang->error_suspend_pm_permanent;
+		if($mybb->user['suspendpmtime'])
+		{
+			$suspendpmtype = $lang->sprintf($lang->error_suspend_pm_temporal, my_date($mybb->settings['dateformat'], $mybb->user['suspendpmtime']));
+		}
+		$lang->error_suspend_pm = $lang->sprintf($lang->error_suspend_pm, $suspendpmtype, my_date($mybb->settings['timeformat'], $mybb->user['suspendpmtime']));
+		error($lang->error_suspend_pm);
 	}
 
 	$plugins->run_hooks("private_send_start");


### PR DESCRIPTION
Based on https://github.com/mybb/mybb/pull/4376.

### Added

- Added the ability to suspend a user's private messaging. Based on Xazin's work, the main difference is that users can still access their inbox and message folders, but they cannot compose new messages or reply to existing ones.

### Fixed

- Fixed an issue where moderator options in the ACP were not saved because of an incorrect conditional.

Resolves #5134

