### PR TITLE
Render page layout fragments in legacy templates

### DIFF
--- a/global.php
+++ b/global.php
@@ -868,6 +868,13 @@ if($mybb->settings['awactialert'] == 1 && $mybb->usergroup['cancp'] == 1)
 	}
 }
 
+if($mybb->config['compat_page_render'] ?? true)
+{
+	$headerinclude = '<!-- compat_page_render.headerinclude -->';
+	$header = '<!-- compat_page_render.header -->';
+	$footer = '<!-- compat_page_render.footer -->';
+}
+
 // Check to see if we have any tasks to run
 $task_image = '';
 $task_cache = $cache->read('tasks');

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -21,6 +21,30 @@ function output_page($contents)
 	$stopwatch = \MyBB\app(\MyBB\Utilities\Stopwatch\Stopwatch::class);
 
 
+	if($mybb->config['compat_page_render'] ?? true)
+	{
+		$templates = [
+			'headerinclude',
+			'header',
+			'footer',
+		];
+
+		foreach($templates as $name)
+		{
+			$placeholder = '<!-- compat_page_render.'.$name.' -->';
+
+			if(str_contains($contents, $placeholder))
+			{
+				$contents = str_replace(
+					$placeholder,
+					\MyBB\View\template('partials/'.$name.'.twig'),
+					$contents,
+				);
+			}
+		}
+	}
+
+
 	$contents = $plugins->run_hooks("pre_parse_page", $contents);
 	$contents = parse_page($contents);
 

--- a/inc/themes/core.base/frontend/templates/layouts/master.twig
+++ b/inc/themes/core.base/frontend/templates/layouts/master.twig
@@ -1,79 +1,11 @@
 <!doctype html>
 <html class="no-js"{% if lang.settings.rtl %} dir="rtl"{% endif %}{% if lang.settings.htmllang %} lang="{{ lang.settings.htmllang }}"{% endif %}>
 <head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-
     {% block head %}
         <title>MyBB</title>
     {% endblock head %}
 
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    {% for type in ['style', 'script'] %}
-        {% for asset in attached_assets(type, inserting=true) %}
-            {{ include('partials/' ~ type ~ '.twig', {asset: asset}) }}
-        {% endfor %}
-        <!-- deferred_attached_assets.{{ type }} -->
-    {% endfor %}
-
-    {# TEMPORARY #}
-    {{ asset('https://fonts.googleapis.com/css?family=Asap:400,600,600i|Open+Sans:300,400,700', static=true, type='style') }}
-
-    <link rel="alternate" type="application/rss+xml" title="{{ lang.latest_threads }} (RSS 2.0)" href="{{ mybb.settings.bburl }}/syndication.php" />
-    <link rel="alternate" type="application/atom+xml" title="{{ lang.latest_threads }} (Atom 1.0)" href="{{ mybb.settings.bburl }}/syndication.php?type=atom1.0" />
-
-
-    <script type="text/javascript">
-    <!--
-        lang.unknown_error = "{{ lang.unknown_error }}";
-        lang.confirm_title = "{{ lang.confirm_title }}";
-
-        lang.expcol_collapse = "{{ lang.expcol_collapse }}";
-        lang.expcol_expand = "{{ lang.expcol_expand }}";
-        lang.select2_match = "{{ lang.select2_match }}";
-        lang.select2_matches = "{{ lang.select2_matches }}";
-        lang.select2_nomatches = "{{ lang.select2_nomatches }}";
-        lang.select2_inputtooshort_single = "{{ lang.select2_inputtooshort_single }}";
-        lang.select2_inputtooshort_plural = "{{ lang.select2_inputtooshort_plural }}";
-        lang.select2_inputtoolong_single = "{{ lang.select2_inputtoolong_single }}";
-        lang.select2_inputtoolong_plural = "{{ lang.select2_inputtoolong_plural }}";
-        lang.select2_selectiontoobig_single = "{{ lang.select2_selectiontoobig_single }}";
-        lang.select2_selectiontoobig_plural = "{{ lang.select2_selectiontoobig_plural }}";
-        lang.select2_loadmore = "{{ lang.select2_loadmore }}";
-        lang.select2_searching = "{{ lang.select2_searching }}";
-
-        var templates = {
-            {% for template in ['modal', 'modal_button'] %}
-                {{ template }}: '{{
-                    include('modals/' ~ template ~ '.twig')
-                        |replace({"\n": "\\n", "\r": ""})
-                        |raw
-                }}',
-            {% endfor %}
-        };
-
-        var cookieDomain = "{{ mybb.settings.cookiedomain }}";
-        var cookiePath = "{{ mybb.settings.cookiepath }}";
-        var cookiePrefix = "{{ mybb.settings.cookieprefix }}";
-        var cookieSecureFlag = "{{ mybb.settings.cookiesecureflag }}";
-        var deleteevent_confirm = "{{ lang.deleteevent_confirm }}";
-        var removeattach_confirm = "{{ lang.removeattach_confirm }}";
-        var loading_text = '{{ lang.ajax_loading }}';
-        var saving_changes = '{{ lang.saving_changes }}';
-        var use_xmlhttprequest = "{{ mybb.settings.use_xmlhttprequest }}";
-        var my_post_key = "{{ mybb.post_code }}";
-        var rootpath = "{{ mybb.settings.bburl }}";
-        var imagepath = "{{ theme.imgdir }}";
-        var yes_confirm = "{{ lang.yes }}";
-        var no_confirm = "{{ lang.no }}";
-        var MyBBEditor = null;
-        var spinner_image = "{{ theme.imgdir }}/spinner.gif";
-        var spinner = "<img src='" + spinner_image +"' alt='' />";
-        var modal_zindex = 9999;
-        var modal_close = '{% apply spaceless %}{% include 'modals/close.twig' %}{% endapply %}';
-    // -->
-    </script>
+    {% include 'partials/headerinclude.twig' %}
 
     {% block jscripts %}{% endblock %}
 </head>

--- a/inc/themes/core.base/frontend/templates/partials/headerinclude.twig
+++ b/inc/themes/core.base/frontend/templates/partials/headerinclude.twig
@@ -1,0 +1,68 @@
+<meta charset="utf-8">
+<meta http-equiv="x-ua-compatible" content="ie=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+{% for type in ['style', 'script'] %}
+    {% for asset in attached_assets(type, inserting=true) %}
+        {{ include('partials/' ~ type ~ '.twig', {asset: asset}) }}
+    {% endfor %}
+    <!-- deferred_attached_assets.{{ type }} -->
+{% endfor %}
+
+{# TEMPORARY #}
+{{ asset('https://fonts.googleapis.com/css?family=Asap:400,600,600i|Open+Sans:300,400,700', static=true, type='style') }}
+
+<link rel="alternate" type="application/rss+xml" title="{{ lang.latest_threads }} (RSS 2.0)" href="{{ mybb.settings.bburl }}/syndication.php" />
+<link rel="alternate" type="application/atom+xml" title="{{ lang.latest_threads }} (Atom 1.0)" href="{{ mybb.settings.bburl }}/syndication.php?type=atom1.0" />
+
+
+<script type="text/javascript">
+<!--
+    lang.unknown_error = "{{ lang.unknown_error }}";
+    lang.confirm_title = "{{ lang.confirm_title }}";
+
+    lang.expcol_collapse = "{{ lang.expcol_collapse }}";
+    lang.expcol_expand = "{{ lang.expcol_expand }}";
+    lang.select2_match = "{{ lang.select2_match }}";
+    lang.select2_matches = "{{ lang.select2_matches }}";
+    lang.select2_nomatches = "{{ lang.select2_nomatches }}";
+    lang.select2_inputtooshort_single = "{{ lang.select2_inputtooshort_single }}";
+    lang.select2_inputtooshort_plural = "{{ lang.select2_inputtooshort_plural }}";
+    lang.select2_inputtoolong_single = "{{ lang.select2_inputtoolong_single }}";
+    lang.select2_inputtoolong_plural = "{{ lang.select2_inputtoolong_plural }}";
+    lang.select2_selectiontoobig_single = "{{ lang.select2_selectiontoobig_single }}";
+    lang.select2_selectiontoobig_plural = "{{ lang.select2_selectiontoobig_plural }}";
+    lang.select2_loadmore = "{{ lang.select2_loadmore }}";
+    lang.select2_searching = "{{ lang.select2_searching }}";
+
+    var templates = {
+        {% for template in ['modal', 'modal_button'] %}
+            {{ template }}: '{{
+                include('modals/' ~ template ~ '.twig')
+                    |replace({"\n": "\\n", "\r": ""})
+                    |raw
+            }}',
+        {% endfor %}
+    };
+
+    var cookieDomain = "{{ mybb.settings.cookiedomain }}";
+    var cookiePath = "{{ mybb.settings.cookiepath }}";
+    var cookiePrefix = "{{ mybb.settings.cookieprefix }}";
+    var cookieSecureFlag = "{{ mybb.settings.cookiesecureflag }}";
+    var deleteevent_confirm = "{{ lang.deleteevent_confirm }}";
+    var removeattach_confirm = "{{ lang.removeattach_confirm }}";
+    var loading_text = '{{ lang.ajax_loading }}';
+    var saving_changes = '{{ lang.saving_changes }}';
+    var use_xmlhttprequest = "{{ mybb.settings.use_xmlhttprequest }}";
+    var my_post_key = "{{ mybb.post_code }}";
+    var rootpath = "{{ mybb.settings.bburl }}";
+    var imagepath = "{{ theme.imgdir }}";
+    var yes_confirm = "{{ lang.yes }}";
+    var no_confirm = "{{ lang.no }}";
+    var MyBBEditor = null;
+    var spinner_image = "{{ theme.imgdir }}/spinner.gif";
+    var spinner = "<img src='" + spinner_image +"' alt='' />";
+    var modal_zindex = 9999;
+    var modal_close = '{% apply spaceless %}{% include 'modals/close.twig' %}{% endapply %}';
+// -->
+</script>


### PR DESCRIPTION
Resolves #5137

Reintroduces MyBB ≤ 1.8's separate `headerinclude` template to render the corresponding legacy fragment.

Enabled by default; can be disabled with a [Configuration FIle](https://docs.mybb.com/1.8/administration/configuration-file/) flag:
```php
$config['compat_page_render'] = false;
```