### PR TITLE
Use urlencode() in get_*_link functions

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -5892,10 +5892,14 @@ function get_event_date($event)
  * @param int $uid The user id of the profile.
  * @return string The url to the profile.
  */
-function get_profile_link($uid = 0)
+function get_profile_link(int $uid = 0) : string
 {
-	$link = str_replace("{uid}", $uid, PROFILE_URL);
-	return htmlspecialchars_uni($link);
+	$link = PROFILE_URL;
+	$replacements = [
+		'{uid}' => urlencode($uid),
+	];
+
+	return strtr($link, $replacements);
 }
 
 /**
@@ -5904,10 +5908,14 @@ function get_profile_link($uid = 0)
  * @param int $aid The announement id of the announcement.
  * @return string The url to the announcement.
  */
-function get_announcement_link($aid = 0)
+function get_announcement_link(int $aid = 0) : string
 {
-	$link = str_replace("{aid}", $aid, ANNOUNCEMENT_URL);
-	return htmlspecialchars_uni($link);
+	$link = ANNOUNCEMENT_URL;
+	$replacements = [
+		'{aid}' => urlencode($aid),
+	];
+
+	return strtr($link, $replacements);
 }
 
 /**
@@ -5957,19 +5965,20 @@ function build_profile_link($username = "", $uid = 0, $target = "", $onclick = "
  * @param int $page (Optional) The page number of the forum.
  * @return string The url to the forum.
  */
-function get_forum_link($fid, $page = 0)
+function get_forum_link(int $fid, int $page = 0) : string
 {
-	if($page > 0)
+	$link = FORUM_URL;
+	$replacements = [
+		'{fid}' => urlencode($fid),
+	];
+
+    if($page > 0)
 	{
-		$link = str_replace("{fid}", $fid, FORUM_URL_PAGED);
-		$link = str_replace("{page}", $page, $link);
-		return htmlspecialchars_uni($link);
-	}
-	else
-	{
-		$link = str_replace("{fid}", $fid, FORUM_URL);
-		return htmlspecialchars_uni($link);
-	}
+        $link = FORUM_URL_PAGED;
+        $replacements['{page}'] = urlencode($page);
+    }
+
+	return strtr($link, $replacements);
 }
 
 /**
@@ -5980,37 +5989,26 @@ function get_forum_link($fid, $page = 0)
  * @param string $action (Optional) The action we're performing (ex, lastpost, newpost, etc)
  * @return string The url to the thread.
  */
-function get_thread_link($tid, $page = 0, $action = '')
+function get_thread_link(int $tid, int $page = 0, string $action = '') : string
 {
-	if($page > 1)
+	$link = THREAD_URL;
+	$replacements = [
+		'{tid}' => urlencode($tid),
+	];
+
+	if($action)
 	{
-		if($action)
-		{
-			$link = THREAD_URL_ACTION;
-			$link = str_replace("{action}", $action, $link);
-		}
-		else
-		{
-			$link = THREAD_URL_PAGED;
-		}
-		$link = str_replace("{tid}", $tid, $link);
-		$link = str_replace("{page}", $page, $link);
-		return htmlspecialchars_uni($link);
+		$link = THREAD_URL_ACTION;
+		$replacements['{action}'] = urlencode($action);
 	}
-	else
+
+	if($page > 1 && empty($action))
 	{
-		if($action)
-		{
-			$link = THREAD_URL_ACTION;
-			$link = str_replace("{action}", $action, $link);
-		}
-		else
-		{
-			$link = THREAD_URL;
-		}
-		$link = str_replace("{tid}", $tid, $link);
-		return htmlspecialchars_uni($link);
+		$link = THREAD_URL_PAGED;
+		$replacements['{page}'] = urlencode($page);
 	}
+
+	return strtr($link, $replacements);
 }
 
 /**
@@ -6020,19 +6018,20 @@ function get_thread_link($tid, $page = 0, $action = '')
  * @param int $tid The thread id of the post.
  * @return string The url to the post.
  */
-function get_post_link($pid, $tid = 0)
+function get_post_link(int $pid, int $tid = 0) : string
 {
-	if($tid > 0)
+	$link = POST_URL;
+	$replacements = [
+		'{pid}' => urlencode($pid),
+	];
+
+    if($tid > 0)
 	{
-		$link = str_replace("{tid}", $tid, THREAD_URL_POST);
-		$link = str_replace("{pid}", $pid, $link);
-		return htmlspecialchars_uni($link);
-	}
-	else
-	{
-		$link = str_replace("{pid}", $pid, POST_URL);
-		return htmlspecialchars_uni($link);
-	}
+        $link = THREAD_URL_POST;
+        $replacements['{tid}'] = urlencode($tid);
+    }
+
+	return strtr($link, $replacements);
 }
 
 /**
@@ -6041,10 +6040,14 @@ function get_post_link($pid, $tid = 0)
  * @param int $eid The event ID of the event
  * @return string The URL of the event
  */
-function get_event_link($eid)
+function get_event_link(int $eid) : string
 {
-	$link = str_replace("{eid}", $eid, EVENT_URL);
-	return htmlspecialchars_uni($link);
+	$link = EVENT_URL;
+	$replacements = [
+		'{eid}' => urlencode($eid),
+	];
+
+	return strtr($link, $replacements);
 }
 
 /**
@@ -6056,31 +6059,28 @@ function get_event_link($eid)
  * @param int $day The day (optional)
  * @return string The URL of the calendar
  */
-function get_calendar_link($calendar, $year = 0, $month = 0, $day = 0)
+function get_calendar_link(int $calendar, int $year = 0, int $month = 0, int $day = 0)
 {
+	$link = CALENDAR_URL;
+	$replacements = [
+		'{calendar}' => urlencode($calendar),
+	];
+
 	if($day > 0)
 	{
-		$link = str_replace("{month}", $month, CALENDAR_URL_DAY);
-		$link = str_replace("{year}", $year, $link);
-		$link = str_replace("{day}", $day, $link);
-		$link = str_replace("{calendar}", $calendar, $link);
-		return htmlspecialchars_uni($link);
+		$link = CALENDAR_URL_DAY;
+		$replacements['{month}'] = urlencode($month);
+		$replacements['{day}'] = urlencode($day);
+		$replacements['{year}'] = urlencode($year);
 	}
 	elseif($month > 0)
 	{
-		$link = str_replace("{month}", $month, CALENDAR_URL_MONTH);
-		$link = str_replace("{year}", $year, $link);
-		$link = str_replace("{calendar}", $calendar, $link);
-		return htmlspecialchars_uni($link);
+		$link = CALENDAR_URL_MONTH;
+		$replacements['{month}'] = urlencode($month);
+		$replacements['{year}'] = urlencode($year);
 	}
-	/* Not implemented
-    elseif ($year > 0) {
-    }*/
-	else
-	{
-		$link = str_replace("{calendar}", $calendar, CALENDAR_URL);
-		return htmlspecialchars_uni($link);
-	}
+
+	return strtr($link, $replacements);
 }
 
 /**
@@ -6090,15 +6090,16 @@ function get_calendar_link($calendar, $year = 0, $month = 0, $day = 0)
  * @param int $week The week
  * @return string The URL of the calendar
  */
-function get_calendar_week_link($calendar, $week)
+function get_calendar_week_link(int $calendar, int $week) : string
 {
-	if($week < 0)
-	{
-		$week = str_replace('-', "n", $week);
-	}
-	$link = str_replace("{week}", $week, CALENDAR_URL_WEEK);
-	$link = str_replace("{calendar}", $calendar, $link);
-	return htmlspecialchars_uni($link);
+    $week = $week < 0 ? 'n' . abs($week) : (string)$week;
+	$link = CALENDAR_URL_WEEK;
+    $replacements = [
+        '{calendar}' => urlencode($calendar),
+        '{week}' => urlencode($week),
+    ];
+
+    return strtr($link, $replacements);
 }
 
 /**


### PR DESCRIPTION
### Changed

- Refactored the `get_*_link` functions to use `urlencode()` instead of `htmlspecialchars_uni()`. This removes the need to mark the related Twig functions as HTML-safe or to use `|raw`.

Resolves #4793
Part of #5171
Partially discussed in #5129

