### PR TITLE
Increase max length for PM subjects to match database column

### DIFF
--- a/inc/datahandlers/pm.php
+++ b/inc/datahandlers/pm.php
@@ -63,6 +63,13 @@ class PMDataHandler extends DataHandler
 	public $return_values = array();
 
 	/**
+	 * Maximum length for subjects
+	 *
+	 * @var int
+	 */
+	public $max_subject_length = 120;
+
+	/**
 	 * Verifies a private message subject.
 	 *
 	 * @return boolean True when valid, false when invalid.
@@ -72,7 +79,7 @@ class PMDataHandler extends DataHandler
 		$subject = &$this->data['subject'];
 
 		// Subject is over 85 characters, too long.
-		if(my_strlen($subject) > 85)
+		if(my_strlen($subject) > $this->max_subject_length)
 		{
 			$this->set_error("too_long_subject");
 			return false;

--- a/inc/themes/core.base/frontend/templates/private/send.twig
+++ b/inc/themes/core.base/frontend/templates/private/send.twig
@@ -67,7 +67,7 @@
             </section>
             <section class="section section--form compose__primary-section">
                 <div class="row row--form field">
-                    <input type="text" class="textbox textbox--subject" name="subject" size="40" maxlength="85" value="{{ sendpm.subject }}" placeholder="{{ lang.compose_subject }}" tabindex="1" />
+                    <input type="text" class="textbox textbox--subject" name="subject" size="40" maxlength="120" value="{{ sendpm.subject }}" placeholder="{{ lang.compose_subject }}" tabindex="1" />
                 </div>
                 {% if sendpm.showposticons %}
                     {% set emptyiconcheck = sendpm.emptyiconcheck %}


### PR DESCRIPTION
### Changed

- Moved the subject length to a property and increased value to 120 characters to match the database column (`VARCHAR(120)`).

Related to #4416 