### PR TITLE
Truncate spamlog usernames to avoid column length errors

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -8437,7 +8437,7 @@ function log_spam_block($username = '', $email = '', $ip_address = '', $data = a
 	$ip_address = my_inet_pton($ip_address);
 
 	$insert_array = array(
-		'username' => $db->escape_string($username),
+		'username' => $db->escape_string(my_substr($username, 0, 120)),
 		'email' => $db->escape_string($email),
 		'ipaddress' => $db->escape_binary($ip_address),
 		'dateline' => (int)TIME_NOW,


### PR DESCRIPTION
### Changed

- Cherry-picked change from 1.8, truncating spamlog username.

Resolves #5060 

