### PR TITLE
Allow overriding task titles and descriptions via language keys

### DIFF
--- a/admin/modules/tools/system_health.php
+++ b/admin/modules/tools/system_health.php
@@ -754,10 +754,20 @@ if(!$mybb->input['action'])
 	$task_cache = $cache->read("tasks");
 	$nextrun = $task_cache['nextrun'];
 
+	$lang->load('tools_tasks');
 	$query = $db->simple_select("tasks", "*", "nextrun >= '{$nextrun}' AND enabled='1'", array("order_by" => "nextrun", "order_dir" => "asc", 'limit' => 3));
 	while($task = $db->fetch_array($query))
 	{
 		$task['title'] = htmlspecialchars_uni($task['title']);
+		if(!empty($task['file']))
+		{
+			$lang_var = "task_{$task['file']}_title";
+			if(isset($lang->$lang_var))
+			{
+				$task['title'] = $lang->$lang_var;
+			}
+		}
+
 		$next_run = my_date('normal', $task['nextrun'], "", 2);
 		$table->construct_cell("<strong>{$task['title']}</strong>");
 		$table->construct_cell($next_run, array("class" => "align_center"));

--- a/admin/modules/tools/tasks.php
+++ b/admin/modules/tools/tasks.php
@@ -739,6 +739,19 @@ if(!$mybb->input['action'])
 	{
 		$task['title'] = htmlspecialchars_uni($task['title']);
 		$task['description'] = htmlspecialchars_uni($task['description']);
+
+		if(!empty($task['file']))
+		{
+			foreach(['title', 'description'] as $field)
+			{
+				$lang_var = "task_{$task['file']}_{$field}";
+				if(isset($lang->$lang_var))
+				{
+					$task[$field] = $lang->$lang_var;
+				}
+			}
+		}
+
 		$next_run = my_date('normal', $task['nextrun'], "", 2);
 		if($task['enabled'] == 1)
 		{

--- a/admin/modules/tools/tasks.php
+++ b/admin/modules/tools/tasks.php
@@ -675,7 +675,7 @@ if($mybb->input['action'] == "logs")
 	$pagination = draw_admin_pagination($current_page, $per_page, $log_count, "index.php?module=tools-tasks&amp;action=logs&amp;page={page}");
 
 	$query = $db->query("
-		SELECT l.*, t.title
+		SELECT l.*, t.title, t.file
 		FROM ".TABLE_PREFIX."tasklog l
 		LEFT JOIN ".TABLE_PREFIX."tasks t ON (t.tid=l.tid)
 		ORDER BY l.dateline DESC
@@ -685,6 +685,15 @@ if($mybb->input['action'] == "logs")
 	{
 		$log_entry['title'] = htmlspecialchars_uni($log_entry['title']);
 		$log_entry['data'] = htmlspecialchars_uni($log_entry['data']);
+
+		if(!empty($log_entry['file']))
+		{
+			$lang_var = "task_{$log_entry['file']}_title";
+			if(isset($lang->$lang_var))
+			{
+				$log_entry['title'] = $lang->$lang_var;
+			}
+		}
 
 		$date = my_date('relative', $log_entry['dateline']);
 		$table->construct_cell("<a href=\"index.php?module=tools-tasks&amp;action=edit&amp;tid={$log_entry['tid']}\">{$log_entry['title']}</a>");

--- a/inc/functions_task.php
+++ b/inc/functions_task.php
@@ -18,6 +18,8 @@ function run_task($tid=0)
 {
 	global $db, $mybb, $cache, $plugins, $task, $lang;
 
+	$lang->load('tools_tasks');
+
 	// Run a specific task
 	if($tid > 0)
 	{
@@ -67,6 +69,15 @@ function run_task($tid=0)
 			"locked" => 0
 		);
 		$db->update_query("tasks", $updated_task, "tid='{$task['tid']}'");
+
+		if(!empty($task['file']))
+		{
+			$lang_var = "task_{$task['file']}_title";
+			if(isset($lang->$lang_var))
+			{
+				$task['title'] = $lang->$lang_var;
+			}
+		}
 
 		$subject = $lang->sprintf($lang->email_broken_task_subject, $mybb->settings['bbname']);
 		$message = $lang->sprintf($lang->email_broken_task, $mybb->settings['bbname'], $mybb->settings['bburl'], $task['title']);

--- a/inc/functions_task.php
+++ b/inc/functions_task.php
@@ -18,7 +18,7 @@ function run_task($tid=0)
 {
 	global $db, $mybb, $cache, $plugins, $task, $lang;
 
-	$lang->load('tools_tasks');
+	$lang->load('admin/tools_tasks', true);
 
 	// Run a specific task
 	if($tid > 0)


### PR DESCRIPTION
### Added

Added the ability to override titles and descriptions for planned tasks using language keys/files. This would eliminate the need to maintain `tasks.xml` in language packs. There may be a few additional places where this should be applied, but I wanted to check first if this is something people would be interested in.

