### PR TITLE
Adds "Members" to profile, show team breadcrumbs

### DIFF
--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -10,7 +10,7 @@ $l['lastvisit_never'] = "Never";
 $l['lastvisit_hidden'] = "(Hidden)";
 
 $l['search_button'] = 'Search';
-$l['toplinks_memberlist'] = "Member List";
+$l['toplinks_memberlist'] = "Members";
 $l['toplinks_search'] = "Search";
 $l['toplinks_calendar'] = "Calendar";
 $l['toplinks_portal'] = "Portal";
@@ -20,6 +20,8 @@ $l['bottomlinks_returntop'] = "Return to Top";
 $l['bottomlinks_syndication'] = "RSS Syndication";
 $l['bottomlinks_markread'] = "Mark all forums read";
 $l['bottomlinks_help'] = "Help";
+
+$l['nav_memberlist'] = "Members";
 
 $l['welcome_usercp'] = "My Account";
 $l['welcome_modcp'] = "Moderation";

--- a/inc/languages/english/memberlist.lang.php
+++ b/inc/languages/english/memberlist.lang.php
@@ -5,11 +5,9 @@
  *
  */
 
-$l['nav_memberlist'] = "Member List";
-
 $l['memberlist_disabled'] = "The member list functionality has been disabled by the Administrator.";
 
-$l['member_list'] = "Member List";
+$l['member_list'] = "Members";
 $l['avatar']  = "Avatar";
 $l['username'] = "Username";
 $l['joined'] = "Joined";
@@ -17,7 +15,7 @@ $l['lastvisit'] = "Last Visit";
 $l['posts'] = "Post Count";
 $l['threads'] = "Thread Count";
 $l['referrals'] = "Referrals";
-$l['search_members'] = "Search Member List";
+$l['search_members'] = "Search Members";
 $l['website'] = "Website";
 $l['sort_by'] = "Sort by";
 $l['contains'] = "Contains:";
@@ -32,10 +30,10 @@ $l['order_asc'] = "ascending order";
 $l['order_desc'] = "descending order";
 $l['asc'] = "asc";
 $l['desc'] = "desc";
-$l['forumteam'] = "Show Forum Team";
+$l['forumteam'] = "Forum Team";
 $l['advanced_search'] = "Advanced Search";
 $l['nav_memberlist_search'] = "Search";
-$l['search_member_list'] = "Search Member List";
+$l['search_member_list'] = "Search Members";
 $l['search_criteria'] = "Search Criteria";
 $l['begins_with'] = "begins with";
 $l['username_contains'] = "contains";

--- a/member.php
+++ b/member.php
@@ -2013,6 +2013,8 @@ if($mybb->input['action'] == "profile")
 	}
 
 	$lang->nav_profile = $lang->sprintf($lang->nav_profile, $memprofile['username']);
+
+	add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 	add_breadcrumb($lang->nav_profile);
 
 	$memprofile['useravatar'] = format_avatar($memprofile['avatar'], $memprofile['avatardimensions']);

--- a/reputation.php
+++ b/reputation.php
@@ -551,6 +551,7 @@ if(!$mybb->input['action'])
 	}
 
 	// Build navigation menu
+	add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 	add_breadcrumb($lang->nav_profile, get_profile_link($user['uid']));
 	add_breadcrumb($lang->nav_reputation);
 

--- a/showteam.php
+++ b/showteam.php
@@ -21,6 +21,7 @@ if($mybb->settings['enableshowteam'] == 0)
 	error($lang->showteam_disabled);
 }
 
+add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 add_breadcrumb($lang->nav_showteam);
 
 $plugins->run_hooks('showteam_start');

--- a/warnings.php
+++ b/warnings.php
@@ -331,6 +331,7 @@ if($mybb->input['action'] == "warn")
 	}
 
 	$lang->nav_profile = $lang->sprintf($lang->nav_profile, $user['username']);
+	add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 	add_breadcrumb($lang->nav_profile, get_profile_link($user['uid']));
 	add_breadcrumb($lang->nav_add_warning);
 
@@ -580,11 +581,13 @@ if($mybb->input['action'] == "view")
 	$lang->nav_profile = $lang->sprintf($lang->nav_profile, $user['username']);
 	if(!empty($user['uid']))
 	{
+		add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 		add_breadcrumb($lang->nav_profile, get_profile_link($user['uid']));
 		add_breadcrumb($lang->nav_warning_log, "warnings.php?uid={$user['uid']}");
 	}
 	else
 	{
+		add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 		add_breadcrumb($lang->nav_profile);
 		add_breadcrumb($lang->nav_warning_log);
 	}
@@ -692,6 +695,7 @@ if(!$mybb->input['action'])
 
 	$user['username'] = htmlspecialchars_uni($user['username']);
 	$lang->nav_profile = $lang->sprintf($lang->nav_profile, $user['username']);
+	add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 	add_breadcrumb($lang->nav_profile, get_profile_link($user['uid']));
 	add_breadcrumb($lang->nav_warning_log);
 


### PR DESCRIPTION
Adds "Members" breadcrumb above profile and show team pages. This also simplifies "Members List" to "Members."

I moved the `nav_memberlist` language string to `global.lang.php` to avoid duplication across multiple language files.