### PR TITLE
Add config flag check for collecting plugins' global variables

### DIFF
--- a/inc/class_plugins.php
+++ b/inc/class_plugins.php
@@ -148,6 +148,8 @@ class pluginSystem
 	 */
 	function run_hooks(string $hook, &$arguments = "")
 	{
+		global $mybb;
+
 		if(!isset($this->hooks[$hook]) || !is_array($this->hooks[$hook]))
 		{
 			return $arguments;
@@ -157,7 +159,10 @@ class pluginSystem
 
 		$this->current_hook_stack[] = $this->current_hook;
 
-		$existing_globals = array_keys($GLOBALS);
+		if($mybb->config['compat_plugin_globals'] ?? true)
+		{
+			$existing_globals = array_keys($GLOBALS);
+		}
 
 		ksort($this->hooks[$hook]);
 
@@ -191,17 +196,20 @@ class pluginSystem
 			}
 		}
 
-		$new_globals = array_diff_key(
-			$GLOBALS,
-			array_flip($existing_globals),
-		);
+		if($mybb->config['compat_plugin_globals'] ?? true)
+		{
+			$new_globals = array_diff_key(
+				$GLOBALS,
+				array_flip($existing_globals),
+			);
 
-		$legacy_template_variables = array_filter(
-			$new_globals,
-			$this->has_scalar_values(...),
-		);
+			$legacy_template_variables = array_filter(
+				$new_globals,
+				$this->has_scalar_values(...),
+			);
 
-		\MyBB\View\set($legacy_template_variables);
+			\MyBB\View\set($legacy_template_variables);
+		}
 
 		array_pop($this->current_hook_stack);
 


### PR DESCRIPTION
Adds a config flag to compatibility feature added in #4863, similarly to #5165

Enabled by default; can be disabled with a [Configuration FIle](https://docs.mybb.com/1.8/administration/configuration-file/) flag:
```php
$config['compat_plugin_globals'] = false;
```