### PR TITLE
Fix signature suspension not being saved

### DIFF
--- a/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
+++ b/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
@@ -193,12 +193,12 @@
                             <label><input type="checkbox" name="suspendsignature" value="1"{% if user.suspendsignature or (mybb.input.suspendsignature and errors) %} checked{% endif %} class="checkbox" onclick="toggleAction();" /> {{ lang.suspend_signature }}</label>
                         </p>
                         <div class="field__block" id="suspend_action">
-                            {% if user.suspensiontime %}
+                            {% if user.suspendsigtime %}
                                 <p class="field__value">
-                                    {% if user.suspensiontime == 0 %}
+                                    {% if user.suspendsigtime == 0 %}
                                         {{ lang.suspendsignature_perm }}
                                     {% else %}
-                                        {{ trans('suspendsignature_for', user.suspensiontime|my_date) }}
+                                        {{ trans('suspendsignature_for', user.suspendsigtime|my_date) }}
                                     {% endif %}
                                 </p>
                             {% endif %}

--- a/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
+++ b/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
@@ -205,12 +205,12 @@
                             <div class="field__block">
                                 {{ lang.suspost_length }}
                                 &nbsp;
-                                <input type="text" name="suspost_time" value="{{ mybb.input.action_time }}" class="textbox textbox--small" />
+                                <input type="text" name="suspendsignature_time" value="{{ mybb.input.suspendsignature_time }}" class="textbox textbox--small" />
                                 <div class="select-field">
                                     {{ include('partials/icon.twig', {icon: 'sort', class: 'select-field__icon'}, with_context = false) }}
-                                    <select name="suspost_period">
+                                    <select name="suspendsignature_period">
                                         {% for key, value in periods %}
-                                            <option value="{{ key }}"{% if key == mybb.input.action_period %} selected{% endif %}>{{ value }}</option>
+                                            <option value="{{ key }}"{% if key == mybb.input.suspendsignature_period %} selected{% endif %}>{{ value }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>

--- a/modcp.php
+++ b/modcp.php
@@ -2300,8 +2300,8 @@ if($mybb->input['action'] == "do_editprofile")
 		$modoptions = array(
 			1 => array(
 				"action" => "suspendsignature", // The moderator action we're performing
-				"period" => "action_period", // The time period we've selected from the dropdown box
-				"time" => "action_time", // The time we've entered
+				"period" => "suspendsignature_period", // The time period we've selected from the dropdown box
+				"time" => "suspendsignature_time", // The time we've entered
 				"update_field" => "suspendsignature", // The field in the database to update if true
 				"update_length" => "suspendsigtime" // The length of suspension field in the database
 			),


### PR DESCRIPTION
### Fixed

- Signature suspension was not being saved because the input used `suspost_*` instead of `action_*`. 
- Signature suspension time was not being displayed because the conditional referenced `suspensiontime` instead of `suspendsigtime`.

### Changed

Renamed the action and period fields for signature suspension to match other moderation actions (a shorter name might be needed to fully match the others).

Resolves #5196