### PR TITLE
Remove raw usage for links and dates in usercp/drafts template

### DIFF
--- a/inc/themes/core.base/frontend/templates/usercp/drafts/row.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/drafts/row.twig
@@ -3,13 +3,13 @@
         <h3 class="draft__subject"><a href="{{ draft.editurl|raw }}">{{ draft.subject }}</a></h3>
         <p class="draft__location">
             {% if draft.type == 'post' %}
-                {{ lang.thread }}: <a href="{{ draft.threadlink|raw }}">{{ draft.threadsubject }}</a>
+                {{ lang.thread }}: <a href="{{ get_thread_link(draft.tid) }}">{{ draft.threadsubject }}</a>
             {% else %}
-                {{ lang.forum }}: <a href="{{ draft.forumlink|raw }}">{{ draft.forumname }}</a>
+                {{ lang.forum }}: <a href="{{ get_forum_link(draft.fid) }}">{{ draft.forumname }}</a>
             {% endif %}
         </p>
         <p class="draft__date">
-            {{ draft.savedate|raw }} {# TODO: Format dates as a Twig function, rather than using |raw for HTML... #}
+            {{ draft.dateline|my_date }}
         </p>
     </div>
     <div class="draft__button">

--- a/usercp.php
+++ b/usercp.php
@@ -2767,7 +2767,6 @@ if($mybb->input['action'] == "drafts")
 		{
 			if($draft['threadvisible'] == 1)
 			{ // We're looking at a draft post
-				$draft['threadlink'] = get_thread_link($draft['tid']);
 				$draft['editurl'] = "newreply.php?action=editdraft&amp;pid={$draft['pid']}";
 				$draft['type'] = 'post';
 			}
@@ -2775,13 +2774,10 @@ if($mybb->input['action'] == "drafts")
 			{
 				if($draft['threadvisible'] == -2)
 				{ // We're looking at a draft thread
-					$draft['forumlink'] = get_forum_link($draft['fid']);
 					$draft['editurl'] = "newthread.php?action=editdraft&amp;tid={$draft['tid']}";
 					$draft['type'] = 'thread';
 				}
 			}
-
-			$draft['savedate'] = my_date('relative', $draft['dateline']);
 
 			$drafts[] = $draft;
 		}


### PR DESCRIPTION
### Removed

- Computed links and values for thread link, forum link and draft date.

### Changed

- Replaced `|raw` filter usage with appropriate Twig filters.

Part of #5171 