### PR TITLE
Update moderation suspension options

### DIFF
--- a/inc/languages/english/modcp.lang.php
+++ b/inc/languages/english/modcp.lang.php
@@ -271,6 +271,7 @@ $l['suspendposting_error'] = "You selected to suspend this user's posts, but did
 $l['suspendpm_error'] = "You selected to suspend this user's private messaging, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendmoderate_error'] = "You've selected to suspend and moderate the user's posts. Please select only one type of moderation.";
 
+$l['no_change'] = "No change";
 $l['expire_hours'] = "hour(s)";
 $l['expire_days'] = "day(s)";
 $l['expire_weeks'] = "week(s)";

--- a/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
+++ b/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
@@ -196,7 +196,7 @@
                             {% if user.suspendsigtime %}
                                 <p class="field__value">
                                     {% if user.suspendsigtime == 0 %}
-                                        {{ lang.suspendsignature_perm }}
+                                        {{ lang.suspendsignature_perm|raw }}
                                     {% else %}
                                         {{ trans('suspendsignature_for', user.suspendsigtime|my_date) }}
                                     {% endif %}
@@ -239,7 +239,7 @@
                                 {% if user[opt.option] %}
                                     <p class="field__value">
                                         {% if user[opt.length] == 0 %}
-                                            {{ attribute(lang, opt.option ~ '_perm') }}
+                                            {{ attribute(lang, opt.option ~ '_perm')|raw }}
                                         {% else %}
                                             {{ trans(opt.option ~ '_for', user[opt.length]|my_date) }}
                                         {% endif %}

--- a/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
+++ b/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
@@ -193,7 +193,7 @@
                             <label><input type="checkbox" name="suspendsignature" value="1"{% if user.suspendsignature or (mybb.input.suspendsignature and errors) %} checked{% endif %} class="checkbox" onclick="toggleAction();" /> {{ lang.suspend_signature }}</label>
                         </p>
                         <div class="field__block" id="suspend_action">
-                            {% if user.suspendsigtime %}
+                            {% if user.suspendsignature %}
                                 <p class="field__value">
                                     {% if user.suspendsigtime == 0 %}
                                         {{ lang.suspendsignature_perm|raw }}

--- a/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
+++ b/inc/themes/core.base/frontend/templates/modcp/editprofile.twig
@@ -210,7 +210,13 @@
                                     {{ include('partials/icon.twig', {icon: 'sort', class: 'select-field__icon'}, with_context = false) }}
                                     <select name="suspendsignature_period">
                                         {% for key, value in periods %}
-                                            <option value="{{ key }}"{% if key == mybb.input.suspendsignature_period %} selected{% endif %}>{{ value }}</option>
+                                            <option value="{{ key }}"
+                                                {% if key == mybb.input.suspendsignature_period ?? (user.suspendsignature ? '' : 'never') %}
+                                                    selected
+                                                {% endif %}
+                                            >
+                                                {{ value }}
+                                            </option>
                                         {% endfor %}
                                     </select>
                                 </div>
@@ -246,7 +252,13 @@
                                         {{ include('partials/icon.twig', {icon: 'sort', class: 'select-field__icon'}, with_context = false) }}
                                         <select name="{{ opt.select_option }}_period">
                                             {% for key, value in periods %}
-                                                <option value="{{ key }}"{% if key == mybb.input[opt.select_option ~ '_period'] %} selected{% endif %}>{{ value }}</option>
+                                                <option value="{{ key }}"
+                                                    {% if key == mybb.input[opt.select_option ~ '_period'] ?? (user[opt.option] ? '' : 'never') %}
+                                                        selected
+                                                    {% endif %}
+                                                >
+                                                    {{ value }}
+                                                </option>
                                             {% endfor %}
                                         </select>
                                     </div>

--- a/modcp.php
+++ b/modcp.php
@@ -2618,6 +2618,7 @@ if($mybb->input['action'] == "editprofile")
 	);
 
 	$periods = array(
+		"" => $lang->no_change,
 		"hours" => $lang->expire_hours,
 		"days" => $lang->expire_days,
 		"weeks" => $lang->expire_weeks,


### PR DESCRIPTION
### Added

- Added `No change` option (set to `""`) to avoid overriding existing suspensions when existing.

### Changed

- If no existing suspension, `Permanent` is the default option in the list.

### Fixed

- Incorrect conditional for signature suspension message: `suspendsigtime` should be `suspendsignature` because time is set to 0 for permanent suspension.
- Missing `|raw` for permanent suspension messages that contain HTML tags.

Resolves #4422


