### PR TITLE
Fix moderators display in forumdisplay template

### DIFF
--- a/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
@@ -36,7 +36,7 @@
                     {% for moderator in moderators.users %}
                         <a href="{{ moderator.profilelink|raw }}">{{ moderator.username|raw }}</a>{% if loop.last == false %}{{ lang.comma }} {% endif %}
                     {% endfor %}
-                    {% if moderators.groups %}{{ lang.comma }} {% endif %}
+                    {% if moderators.users and moderators.groups %}{{ lang.comma }} {% endif %}
                     {% for moderator in moderators.groups %}
                         {{ moderator.title }}{% if loop.last == false %}{{ lang.comma }} {% endif %}
                     {% endfor %}


### PR DESCRIPTION
### Fixed

- Incorrect moderators display when there are no users and only group(s).
