### PR TITLE
Fix postdate display in threaded mode

### DIFF
--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -244,7 +244,7 @@
                     {% for post in threadedbits %}
                         {% if post.bitactive %}
                             <div class="threaded-mode__post threaded-mode__post--active" style="margin-left: {{ post.indentsize }}px;">
-                                <span class="threaded-mode__date">{{ post.postdate }}</span>
+                                <span class="threaded-mode__date">{{ post.dateline|my_date }}</span>
                                 <span class="threaded-mode__author">
                                     {{ lang.by }}
                                     {% if post.uid > 0 %}
@@ -256,14 +256,16 @@
                             </div>
                         {% else %}
                             <div class="threaded-mode__post" style="margin-left: {{ post.indentsize }}px;">
-                                <span class="threaded-mode__date"><a href="showthread.php?tid={{ thread.tid }}&amp;pid={{ post.pid }}&amp;mode=threaded">{{ post.postdate }}</a></span>
+                                <span class="threaded-mode__date">
+                                    <a href="showthread.php?tid={{ thread.tid }}&amp;pid={{ post.pid }}&amp;mode=threaded">{{ post.dateline|my_date }}</a>
+                                </span>
                                 <span class="threaded-mode__author">
                                     {{ lang.by }}
                                     {% if post.uid > 0 %}
                                         <a href="{{ get_profile_link(post.uid) }}">{{ post.uid|format_name }}</a>
                                     {% else %}
                                         {{ post.username|default(lang.guest) }}
-                                    {% endif %}                                    
+                                    {% endif %}
                                 </span>
                             </div>
                         {% endif %}

--- a/showthread.php
+++ b/showthread.php
@@ -1405,7 +1405,6 @@ function buildtree($replyto = 0, $indent = 0)
 	{
 		foreach($tree[$replyto] as $key => $post)
 		{
-			$post['postdate'] = my_date('relative', $post['dateline']);
 			$post['subject'] = $parser->parse_badwords($post['subject']);
 
 			if(!$post['subject'])


### PR DESCRIPTION
### Changed

- Used `my_date` filter instead of computing it beforehand.

Issue:
<img width="2494" height="300" alt="image" src="https://github.com/user-attachments/assets/4f43a53c-28fd-47fd-89d3-912cde9e7fd8" />

After fix:
<img width="2497" height="312" alt="image" src="https://github.com/user-attachments/assets/e7402968-df32-4869-ab6a-6b24f11799fd" />
