### PR TITLE
Use render_avatar instead of format_avatar in templates

### DIFF
--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -287,7 +287,6 @@ function build_postbit($post, $post_type=0)
 	if((isset($mybb->user['showavatars']) && $mybb->user['showavatars'] != 0) || $mybb->user['uid'] == 0)
 	{
 		$post['showavatar'] = true;
-		$post['useravatar'] = format_avatar($post['avatar'], $post['avatardimensions'], $mybb->settings['postmaxavatarsize']);
 	}
 	
 	if($post['userusername'])

--- a/inc/themes/core.base/frontend/templates/member/profile.twig
+++ b/inc/themes/core.base/frontend/templates/member/profile.twig
@@ -7,9 +7,7 @@
 {% block body %}
     <div class="profile">
         <header class="page-header profile__header">
-            {% if memprofile.useravatar %}
-                <img src="{{ memprofile.avatar_image }}" alt="" {{ memprofile.avatar_width_height }} class="avatar" />
-            {% endif %}
+            {{ render_avatar(url=memprofile.avatar, alt=memprofile.username, class='avatar--large') }}
             <h1 class="profile__username">{{ memprofile.formattedname|raw }}</h1>
             <p class="profile__usertitle">{{ memprofile.user_title }}</p>
             {% if memprofile.groupimage %}

--- a/inc/themes/core.base/frontend/templates/portal/portal_announcement.twig
+++ b/inc/themes/core.base/frontend/templates/portal/portal_announcement.twig
@@ -4,12 +4,9 @@
     </h1>
     <div class="post">
         <div class="post__meta">
-            {% if announcement.useravatar %}
-                <a href="{{ get_profile_link(announcement.uid )}}" class="avatar-profile-link">
-                    {# TO DO: fix default avatar #}
-                    {{ render_avatar(url=announcement.avatar_image, alt=announcement.username) }}
-                </a>
-            {% endif %}
+            <a href="{{ get_profile_link(announcement.uid )}}" class="avatar-profile-link">
+                {{ render_avatar(url=announcement.avatar, alt=announcement.username) }}
+            </a>
             <h3 class="post__author">
                 {{ announcement.profilelink|raw }}
             </h3>

--- a/inc/themes/core.base/frontend/templates/postbit/postbit.twig
+++ b/inc/themes/core.base/frontend/templates/postbit/postbit.twig
@@ -51,11 +51,7 @@
         {# Author avatar #}
         {% if post.showavatar %}
             <a href="{{ post.profilelink_plain|raw }}" class="avatar-profile-link">
-                {% if post.avatar %}
-                    <img src="{{ post.useravatar.image }}" alt="" {{ post.useravatar.width_height|raw }} class="avatar" />
-                {% else %}
-                    {% include 'partials/default_avatar.twig' %}
-                {% endif %}
+                {{ render_avatar(url=post.avatar, alt=post.username, class='avatar--large') }}
             </a>
         {% endif %}
 

--- a/inc/themes/core.base/frontend/templates/usercp/home.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/home.twig
@@ -12,7 +12,9 @@
 
 {% block accountBody %}
     <section class="block block--container account-dashboard">
-        <a href="{{ get_profile_link(mybb.user.uid) }}" class="avatar-profile-link"><img src="{{ useravatar.image }}" alt="{{ mybb.user.username }}" title="{{ mybb.user.username }}" {{ useravatar.width_height }} class="avatar" /></a>
+        <a href="{{ get_profile_link(mybb.user.uid) }}" class="avatar-profile-link">
+            {{ render_avatar(url=mybb.user.avatar, alt=mybb.user.username, class='avatar--large') }}
+        </a>
         <ul class="list list--divided list--stats">
             <li class="list__item title">{{ username|raw }}</li>
             <li class="list__item">

--- a/member.php
+++ b/member.php
@@ -2017,10 +2017,6 @@ if($mybb->input['action'] == "profile")
 	add_breadcrumb($lang->nav_memberlist, "memberlist.php");
 	add_breadcrumb($lang->nav_profile);
 
-	$memprofile['useravatar'] = format_avatar($memprofile['avatar'], $memprofile['avatardimensions']);
-	$memprofile['avatar_image'] = $memprofile['useravatar']['image'];
-	$memprofile['avatar_width_height'] = $memprofile['useravatar']['width_height'];
-
 	$memprofile['hascontacts'] = false;
 	$memprofile['showwebsite'] = false;
 	if(my_validate_url($memprofile['website']) && !is_member($mybb->settings['hidewebsite']) && $memperms['canchangewebsite'] == 1)

--- a/memberlist.php
+++ b/memberlist.php
@@ -416,11 +416,6 @@ else
 			$user['starimage'] = str_replace("{theme}", $theme['imgdir'], $user['starimage']);
 		}
 
-		// Show avatar
-		$useravatar = format_avatar($user['avatar'], $user['avatardimensions'], my_strtolower($mybb->settings['memberlistmaxavatarsize']));
-		$user['avatar_image'] = $useravatar['image'];
-		$user['avatar_width_height'] = $useravatar['width_height'];
-
 		$last_seen = max(array($user['lastactive'], $user['lastvisit']));
 		if(empty($last_seen))
 		{

--- a/portal.php
+++ b/portal.php
@@ -592,10 +592,6 @@ if(!empty($mybb->settings['portal_announcementsfid']))
 				$announcement['icon_name'] = $icon['name'];
 			}
 
-			$announcement['useravatar'] = format_avatar($announcement['avatar'], $announcement['avatardimensions']);
-			$announcement['avatar_image'] = $announcement['useravatar']['image'];
-			$announcement['avatar_width_height'] = $announcement['useravatar']['width_height'];
-
 			$announcement['date'] = my_date('relative', $announcement['dateline']);
 
 			$plugins->run_hooks("portal_announcement");

--- a/usercp.php
+++ b/usercp.php
@@ -2028,8 +2028,6 @@ if($mybb->input['action'] == "avatar")
 		$avatarurl = htmlspecialchars_uni($mybb->user['avatar']);
 	}
 
-	$useravatar = format_avatar($mybb->user['avatar'], $mybb->user['avatardimensions'], '100x100');
-
 	if($mybb->settings['maxavatardims'] != "")
 	{
 		list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
@@ -2046,7 +2044,6 @@ if($mybb->input['action'] == "avatar")
 
 	output_page(\MyBB\View\template('usercp/avatar.twig', [
 		'error' => $error,
-		'useravatar' => $useravatar,
 		'extranotes' => $extranotes
 	]));
 }
@@ -3492,8 +3489,6 @@ if(!$mybb->input['action'])
 
 	$lang->posts_day = $lang->sprintf($lang->posts_day, my_number_format($perday), $percent);
 	$mybb->user['regdate'] = my_date('relative', $mybb->user['regdate']);
-
-	$useravatar = format_avatar($mybb->user['avatar'], $mybb->user['avatardimensions'], '100x100');
 
 	// Make reputations row
 	$reputation_link = '';


### PR DESCRIPTION
### Removed

- Removed unnecessary calls to `format_avatar()`.
- Removed unnecessary include for `partials/default_avatar.twig` since `render_avatar()` already uses it as the fallback.

### Changed 

- Used `render_avatar()` in `member`, `usercp`, `postbit` and `portal` templates.

Part of #5194 

