### PR TITLE
Fix a few PHP 8.1+ warnings

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3753,6 +3753,8 @@ function build_mycode_inserter($bind = "message", $smilies = true)
 
 					$i = 0;
 
+					$emoticons = ['hidden' => '', 'dropdown' => '', 'more' => ''];
+
 					foreach($smiliecache as $smilie)
 					{
 						$finds = explode("\n", $smilie['find']);

--- a/private.php
+++ b/private.php
@@ -51,7 +51,7 @@ foreach($foldersexploded as $key => $fid_and_name)
 		$folder['defaultname'] = get_pm_folder_name($folder['id']);
 	}
 
-	if($mybb->input['action'] == "empty")
+	if($mybb->get_input('action') === "empty")
 	{
 		$unread_cond2 = '';
 		if($folderinfo[0] == 1)

--- a/private.php
+++ b/private.php
@@ -743,6 +743,7 @@ if($mybb->input['action'] == "send")
 
 	// Preview
 	$sendpm['preview'] = false;
+	$postbit = '';
 	if(!empty($mybb->input['preview']))
 	{
 		$sendpm['preview'] = true;

--- a/usercp.php
+++ b/usercp.php
@@ -951,6 +951,7 @@ if($mybb->input['action'] == "subscriptions")
 		}
 	}
 
+	$threads = [];
 	if(!empty($subscriptions))
 	{
 		$tids = implode(",", array_keys($subscriptions));
@@ -998,9 +999,6 @@ if($mybb->input['action'] == "subscriptions")
 		}
 
 		$threadprefixes = build_prefixes();
-
-		$threads = [];
-
 		$forums_cache = cache_forums();
 
 		// Now we can build our subscription list


### PR DESCRIPTION
### Fixed

Fixed the following warnings:
- `Undefined variable $postbit - Line: 991 - File: private.php PHP 8.5.0 (Linux)`
- `Undefined array key "dropdown" - Line: 3774 - File: inc/functions.php PHP 8.5.0 (Linux)`
- `Undefined array key "more" - Line: 3779 - File: inc/functions.php PHP 8.5.0 (Linux)`
- `Undefined array key "action" - Line: 54 - File: private.php PHP 8.5.0 (Linux)`
- `Undefined variable $threads - Line: 1185 - File: usercp.php PHP 8.5.0 (Linux)`