### PR TITLE
Fix a few additional warnings in misc and modcp

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3390,6 +3390,7 @@ function build_forum_jump($pid = 0, $selitem = 0, $addselect = 1, $depth = "", $
 		}
 	}
 
+	$forum_link = "";
 	if($addselect)
 	{
 		if($showextras != 0)

--- a/misc.php
+++ b/misc.php
@@ -511,9 +511,9 @@ elseif($mybb->input['action'] == "buddypopup")
 
 	// Load Buddies
 	$buddies['showlist'] = false;
+	$buddys = array('online' => [], 'offline' => []);
 	if($mybb->user['buddylist'] != "")
 	{
-		$buddys = array('online' => [], 'offline' => []);
 		$timecut = TIME_NOW - $mybb->settings['wolcutoff'];
 
 		$query = $db->simple_select("users", "*", "uid IN ({$mybb->user['buddylist']})", array('order_by' => 'lastactive'));

--- a/modcp.php
+++ b/modcp.php
@@ -40,7 +40,19 @@ $flist_queue_attach = $wflist_reports = $tflist_reports = $flist_reports = $tfli
 // SQL for fetching items only related to forums this user moderates
 $moderated_forums = array();
 $numannouncements = $nummodqueuethreads = $nummodqueueposts = $nummodqueueattach = $numreportedposts = $nummodlogs = 0;
-$counters = $attachment = $thread = $post = 0;
+$attachment = $thread = $post = 0;
+
+$counters = [
+	'announcements' => 0,
+	'modqueue' => [
+		'threads' => 0,
+		'posts' => 0,
+		'attachments' => 0
+	],
+	'reportedposts' => 0,
+	'modlogs' => 0
+];
+
 if($mybb->usergroup['issupermod'] != 1)
 {
 	$query = $db->simple_select("moderators", "*", "(id='{$mybb->user['uid']}' AND isgroup = '0') OR (id IN ({$mybb->usergroup['all_usergroups']}) AND isgroup = '1')");
@@ -55,16 +67,6 @@ if($mybb->usergroup['issupermod'] != 1)
 	}
 	$moderated_forums = array_unique($moderated_forums);
 
-	$counters = [
-		'announcements' => 0,
-		'modqueue' => [
-			'threads' => 0,
-			'posts' => 0,
-			'attachments' => 0
-		],
-		'reportedposts' => 0,
-		'modlogs' => 0
-	];
 	foreach($moderated_forums as $moderated_forum)
 	{
 		// For Announcements

--- a/modcp.php
+++ b/modcp.php
@@ -3040,6 +3040,7 @@ if($mybb->input['action'] == "ipsearch")
 
 	$ipsearch['results'] = false;
 	$mybb->input['ipaddress'] = $mybb->get_input('ipaddress');
+	$multipage = "";
 	if($mybb->input['ipaddress'])
 	{
 		$ipsearch['results'] = true;

--- a/modcp.php
+++ b/modcp.php
@@ -3041,6 +3041,7 @@ if($mybb->input['action'] == "ipsearch")
 	$ipsearch['results'] = false;
 	$mybb->input['ipaddress'] = $mybb->get_input('ipaddress');
 	$multipage = "";
+	$ipresults = [];
 	if($mybb->input['ipaddress'])
 	{
 		$ipsearch['results'] = true;
@@ -3230,7 +3231,6 @@ if($mybb->input['action'] == "ipsearch")
 		$multipage = multipage($total_results, $perpage, $page, $page_url);
 
 		$post_limit = $perpage;
-		$ipresults = [];
 		if(isset($mybb->input['search_users']) && $user_results && $start <= $user_results)
 		{
 			$query = $db->simple_select('users', 'username, uid, regip, lastip', $user_ip_sql,

--- a/modcp.php
+++ b/modcp.php
@@ -805,6 +805,7 @@ if($mybb->input['action'] == "modlogs")
 		}
 	}
 
+	$multipage = "";
 	if($postcount > $perpage)
 	{
 		$multipage = multipage($postcount, $perpage, $page, $page_url);

--- a/modcp.php
+++ b/modcp.php
@@ -40,6 +40,7 @@ $flist_queue_attach = $wflist_reports = $tflist_reports = $flist_reports = $tfli
 // SQL for fetching items only related to forums this user moderates
 $moderated_forums = array();
 $numannouncements = $nummodqueuethreads = $nummodqueueposts = $nummodqueueattach = $numreportedposts = $nummodlogs = 0;
+$counters = $attachment = $thread = $post = 0;
 if($mybb->usergroup['issupermod'] != 1)
 {
 	$query = $db->simple_select("moderators", "*", "(id='{$mybb->user['uid']}' AND isgroup = '0') OR (id IN ({$mybb->usergroup['all_usergroups']}) AND isgroup = '1')");


### PR DESCRIPTION
### Fixed

- Fixed a few additional warnings:
  - `Undefined variable $buddys - Line: 555 - File: misc.php`
  - `Undefined variable $counters - Line: 4020 - File: modcp.php`
  - `Undefined variable $attachment - Line: 4231 - File: modcp.php`
  - `Undefined variable $post - Line: 4232 - File: modcp.php`
  - `Undefined variable $thread - Line: 4233 - File: modcp.php`
  - `Undefined variable $forum_link - Line: 3411 - File: inc/functions.php`
  - `Undefined variable $multipage - Line: 916 - File: modcp.php`
  - `Undefined variable $multipage - Line: 3375 - File: modcp.php`
  - `Undefined variable $ipresults - Line: 3376 - File: modcp.php`
  - `Trying to access array offset on null - Line: 701 - File: modcp.php`

