### PR TITLE
Fix some additional PHP warnings

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -944,7 +944,7 @@ if(!empty($threadCache) && is_array($threadCache))
 		$thread['lastpostlink'] = get_thread_link($thread['tid'], 0, "lastpost");
 
 		// Determine the folder
-		$thread['folder'] = [];
+		$thread['folder'] = ['value' => '', 'label' => ''];
 		if(isset($thread['doticon']))
 		{
 			$thread['folder']['value'] = "dot_";

--- a/global.php
+++ b/global.php
@@ -647,7 +647,7 @@ if(isset($mybb->user['pmnotice']) && $mybb->user['pmnotice'] == 2 && $mybb->user
 }
 
 // Check if this user has unacknowledged warnings
-$warnings_count = (int)($mybb->user['unacknowledgedwarnings'] ?? 0);
+$warnings_count = $mybb->user['uid'] ? (int)$mybb->user['unacknowledgedwarnings'] : 0;
 if($warnings_count > 0)
 {
 	$headerMessages['warningsnotice']['id'] = 'warning_notice';

--- a/global.php
+++ b/global.php
@@ -647,7 +647,7 @@ if(isset($mybb->user['pmnotice']) && $mybb->user['pmnotice'] == 2 && $mybb->user
 }
 
 // Check if this user has unacknowledged warnings
-$warnings_count = (int)$mybb->user['unacknowledgedwarnings'];
+$warnings_count = (int)($mybb->user['unacknowledgedwarnings'] ?? 0);
 if($warnings_count > 0)
 {
 	$headerMessages['warningsnotice']['id'] = 'warning_notice';

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1582,11 +1582,11 @@ function usergroup_displaygroup($gid)
 	}
 
 	$displaygroup = array();
-	$group = $groupscache[$gid];
+	$group = $groupscache[$gid] ?? [];
 
 	foreach($displaygroupfields as $field)
 	{
-		$displaygroup[$field] = $group[$field];
+		$displaygroup[$field] = $group[$field] ?? null;
 	}
 
 	return $displaygroup;

--- a/newreply.php
+++ b/newreply.php
@@ -857,13 +857,10 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 					$newreply['multiquote_quote'] = $lang->multiquote_external_quote;
 				}
 			}
-
-			if(is_array($newreply['quoted_ids']) && count($newreply['quoted_ids']) > 0)
-			{
-				$newreply['quoted_ids'] = implode("|", $newreply['quoted_ids']);
-			}
 		}
 	}
+
+	$newreply['quoted_ids'] = is_array($newreply['quoted_ids']) ? implode("|", $newreply['quoted_ids']) : '';
 
 	if(isset($mybb->input['quoted_ids']))
 	{
@@ -957,6 +954,7 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 
 	// Preview a post that was written.
 	$newreply['preview'] = false;
+	$postbit = '';
 	if(!empty($mybb->input['previewpost']))
 	{
 		// If this isn't a logged in user, then we need to do some special validation.
@@ -1483,7 +1481,6 @@ if($mybb->input['action'] == "newreply" || $mybb->input['action'] == "editdraft"
 		'attachments' => $attachments,
 		'posts' => $posts,
 		'captcha' => $captcha,
-		'prefixselect' => $prefixselect,
 		'posticons' => $posticons,
         'post_javascript' => $post_javascript,
 	]));

--- a/newthread.php
+++ b/newthread.php
@@ -711,6 +711,7 @@ if($mybb->input['action'] == "newthread" || $mybb->input['action'] == "editdraft
 
 	// If we're previewing a post then generate the preview.
 	$newthread['preview'] = false;
+	$postbit = '';
 	if(!empty($mybb->input['previewpost']))
 	{
 		// If this isn't a logged in user, then we need to do some special validation.

--- a/newthread.php
+++ b/newthread.php
@@ -900,14 +900,14 @@ if($mybb->input['action'] == "newthread" || $mybb->input['action'] == "editdraft
 		}
 
 		$newthread['showcloseoption'] = false;
-		if(is_moderator($thread['fid'], "canopenclosethreads"))
+		if(is_moderator($fid, "canopenclosethreads"))
 		{
 			$newthread['showmodoptions'] = true;
 			$newthread['showcloseoption'] = true;
 		}
 
 		$newthread['showstickoption'] = false;
-		if(is_moderator($thread['fid'], "canstickunstickthreads"))
+		if(is_moderator($fid, "canstickunstickthreads"))
 		{
 			$newthread['showmodoptions'] = true;
 			$newthread['showstickoption'] = true;

--- a/usercp.php
+++ b/usercp.php
@@ -4081,7 +4081,6 @@ if(!$mybb->input['action'])
 	$plugins->run_hooks('usercp_end');
 
 	output_page(\MyBB\View\template('usercp/home.twig', [
-		'useravatar' => $useravatar,
 		'username' => $username,
 		'groupscache' => $groupscache,
 		'reputation_link' => $reputation_link,

--- a/warnings.php
+++ b/warnings.php
@@ -645,6 +645,7 @@ if($mybb->input['action'] == "view")
 		}
 	}
 
+	$revoked_user = '';
 	if(!$warning['daterevoked'])
 	{
 		if(!isset($warn_errors))

--- a/warnings.php
+++ b/warnings.php
@@ -646,14 +646,13 @@ if($mybb->input['action'] == "view")
 	}
 
 	$revoked_user = '';
-	if(!$warning['daterevoked'])
+
+	if(!isset($warn_errors))
 	{
-		if(!isset($warn_errors))
-		{
-			$warn_errors = '';
-		}
+		$warn_errors = '';
 	}
-	else
+
+	if($warning['daterevoked'])
 	{
 		$warning['daterevoked'] = my_date('relative', $warning['daterevoked']);
 		$revoked_user = get_user($warning['revokedby']);


### PR DESCRIPTION
### Fixed

Fixed warnings in `forumdisplay.php`:
- `Undefined array key "label" - Line: 986`
- `Undefined array key "value" - Line: 1007`

Fixed warnings in `global.php`:
- `Undefined array key "unacknowledgedwarnings" - Line: 650 - File: global.php` - Caused by `unacknowledgedwarnings` not being set for guest accounts.

Fixed warnings in `newthread.php`:
- `Undefined variable $thread - Line: 903 - File: newthread.php`
- `Undefined variable $thread - Line: 910 - File: newthread.php`
- `Undefined variable $postbit - Line: 1156 - File: newthread.php`

Fixed warnings in `newreply.php` :
- `Array to string conversion - Line: 359 - File: inc/vendor/twig/twig/src/Template.php` - Caused by empty array for quoted_ids that is not converted to string.

Fixed warnings in `usercp.php`:
- `Undefined variable $useravatar - Line: 4084 - File: usercp.php`. Due to a left-over variable from the `render_avatar()` PR.

Fixed warnings in `warnings.php`:
- `Undefined variable $revoked_user - Line: 671 - File: warnings.php`
- `Undefined variable $warn_errors - Line: 673 - File: warnings.php`

Fixed warnings in `inc/functions.php`:
- `Trying to access array offset on null - Line: 1589 - File: inc/functions.php`