### PR TITLE
Use render_avatar() instead of format_avatar() in buddy popup

### DIFF
--- a/inc/themes/core.base/frontend/templates/misc/buddypopup/user.twig
+++ b/inc/themes/core.base/frontend/templates/misc/buddypopup/user.twig
@@ -1,6 +1,6 @@
 <div class="user-list__user">
     <a href="{{ get_profile_link(buddy.uid) }}" class="avatar-profile-link">
-        {{ render_avatar(url=buddy.avatar.image, alt=buddy.username, class='avatar--smallest') }}
+        {{ render_avatar(url=buddy.avatar, alt=buddy.username, class='avatar--smallest') }}
     </a>
     {% if buddy.show_pm %}
         <a href="private.php?action=send&amp;uid={{ buddy.uid }}" target="_blank" onclick="window.opener.location.href=this.href; return false;" class="user-list__shortcut" title="{{ lang.pm_buddy }}">

--- a/misc.php
+++ b/misc.php
@@ -533,8 +533,6 @@ elseif($mybb->input['action'] == "buddypopup")
 				$buddy['last_active'] = my_date('relative', $buddy['lastactive']);
 			}
 
-			$buddy['avatar'] = format_avatar($buddy['avatar'], $buddy['avatardimensions'], '44x44');
-
 			if($buddy['lastactive'] > $timecut && ($buddy['invisible'] == 0 || $mybb->user['usergroup'] == 4) && $buddy['lastvisit'] != $buddy['lastactive'])
 			{
 				$buddys['online'][] = $buddy;


### PR DESCRIPTION
### Changed

- Used `render_avatar()` instead of `format_avatar()`.

Part of #5194