### PR TITLE
Remove raw usage for links and dates in forumdisplay template

### DIFF
--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -877,21 +877,6 @@ if(!empty($threadCache) && is_array($threadCache))
 		}
 
 		$thread['author'] = $thread['uid'];
-		if(!$thread['username'])
-		{
-			if(!$thread['threadusername'])
-			{
-				$thread['username'] = $thread['profilelink'] = $lang->guest;
-			}
-			else
-			{
-				$thread['username'] = $thread['profilelink'] = $thread['threadusername'];
-			}
-		}
-		else
-		{
-			$thread['profilelink'] = build_profile_link($thread['username'], $thread['uid']);
-		}
 
 		// If this thread has a prefix, insert a space between prefix and subject
 		$thread['threadprefix'] = $threadprefix = '';
@@ -939,9 +924,6 @@ if(!empty($threadCache) && is_array($threadCache))
 		{
 			$thread['tid'] = $thread['moved'];
 		}
-
-		$thread['threadlink'] = get_thread_link($thread['tid']);
-		$thread['lastpostlink'] = get_thread_link($thread['tid'], 0, "lastpost");
 
 		// Determine the folder
 		$thread['folder'] = ['value' => '', 'label' => ''];
@@ -1011,15 +993,7 @@ if(!empty($threadCache) && is_array($threadCache))
 			$thread['inlineEditClass'] = "subject_editable";
 		}
 
-		$thread['lastpostdate'] = my_date('relative', $thread['lastpost']);
-
 		$thread['last_poster_name'] = $thread['lastposter'];
-
-		if($thread['lastposteruid'] > 0)
-		{
-			$thread['lastposter'] = build_profile_link($thread['lastposter'], $thread['lastposteruid']);
-		}
-
 		$thread['replies'] = my_number_format($thread['replies']);
 		$thread['views'] = my_number_format($thread['views']);
 
@@ -1030,7 +1004,6 @@ if(!empty($threadCache) && is_array($threadCache))
 
 		$plugins->run_hooks('forumdisplay_thread_end');
 
-		$thread['start_datetime'] = my_date('relative', $thread['dateline']);
 
 		$threadCache[$k] = $thread;
 	}

--- a/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
@@ -13,7 +13,7 @@
 
             {# Thread title #}
             <span class="{{ thread.inlineEditClass }} {{ thread.newclass }}" id="tid_{{ thread.tid }}">
-                <a href="{{ thread.threadlink }}">{{ thread.subject }}</a>
+                <a href="{{ get_thread_link(thread.tid) }}">{{ thread.subject }}</a>
             </span>
 
             {# Deleted thread #}
@@ -83,10 +83,18 @@
                 {% for page in 1..pagesStop %}
                     <a href="{{ get_thread_link(thread.tid, page) }}" class="thread__page-link">{{ page }}</a>
                 {% endfor %}
-                {% if thread.pages > mybb.settings.maxmultipagelinks %}... <a href="{{ thread.threadlink }}" class="thread__page-link">{{ thread.pages }}</a>{% endif %}
+                {% if thread.pages > mybb.settings.maxmultipagelinks %}... <a href="{{ get_thread_link(thread.tid) }}" class="thread__page-link">{{ thread.pages }}</a>{% endif %}
             </span>
         {% endif %}
-        <p class="thread__author">{{ lang.by }} {{ thread.profilelink|raw }} {{ thread.start_datetime|raw }}</p>
+        <p class="thread__author">
+            {{ lang.by }}
+            {% if thread.uid > 0 %}
+                <a href="{{ get_profile_link(thread.uid) }}">{{ thread.uid|format_name }}</a>
+            {% else %}
+                {{ thread.threadusername ?? lang.guest }}
+            {% endif %}
+            {{ thread.dateline|my_date }}
+        </p>
     </div>
     {% if thread.moved %}
         <div class="thread__column thread__column--replies">&nbsp;</div>
@@ -113,12 +121,12 @@
             </a>
             <span class="thread__latest-post__author">
                 {% if thread.lastposteruid > 0 %}
-                    {{ thread.lastposter|raw }}
+                    <a href="{{ get_profile_link(thread.lastposteruid) }}">{{ thread.lastposteruid|format_name }}</a>
                 {% else %}
-                    {{ lang.guest }}
+                    {{ thread.lastposter ?? lang.guest }}
                 {% endif %}
             </span>
-            <a href="{{ thread.lastpostlink }}" class="thread__latest-post__date">{{ thread.lastpostdate|raw }}</a>
+            <a href="{{ get_thread_link(thread.tid, 0, 'lastpost') }}" class="thread__latest-post__date">{{ thread.lastpost|my_date }}</a>
         </p>
     </div>
     {% include 'forumdisplay/thread_modbit.twig' %}


### PR DESCRIPTION
### Changed

- Replaced values computed in `forumdisplay.php` with calls to `my_date`, `format_name`, `get_thread_link` and  `get_profile_link` in templates.