### PR TITLE
Fix additional PHP 8 warnings

### DIFF
--- a/admin/modules/forum/management.php
+++ b/admin/modules/forum/management.php
@@ -572,7 +572,7 @@ if($mybb->input['action'] == "permissions")
 		}
 	}
 
-	if($mybb->input['ajax'] != 1)
+	if($mybb->get_input('ajax', MyBB::INPUT_INT) !== 1)
 	{
 		$sub_tabs = array();
 
@@ -760,14 +760,14 @@ $(function() {
 			$hidefields = array('canonlyviewownthreads', 'canonlyreplyownthreads', 'caneditposts', 'candeleteposts', 'candeletethreads', 'caneditattachments', 'canviewdeletetionnotice');
 		}
 		$hidefields[] = 'canratethreads'; // deprecated: Thread rating feature is deprecated since 1.9.0
-		
+
 		$groups = $plugins->run_hooks("admin_forum_management_permission_groups", $groups);
 
 		foreach($hidefields as $field)
 		{
 			unset($groups[$field]);
 		}
-		
+
 		$tabs = array();
 		foreach(array_unique(array_values($groups)) as $group)
 		{
@@ -775,7 +775,7 @@ $(function() {
 			$tabs[$group] = $lang->$lang_group;
 		}
 
-		if($mybb->input['ajax'] == 1)
+		if($mybb->get_input('ajax', MyBB::INPUT_INT) == 1)
 		{
 			$page->output_tab_control($tabs, false, "tabs2");
 		}
@@ -817,7 +817,7 @@ $(function() {
 			echo "</div>";
 		}
 
-		if($mybb->input['ajax'] == 1)
+		if($mybb->get_input('ajax', MyBB::INPUT_INT) == 1)
 		{
 			$buttons[] = $form->generate_submit_button($lang->cancel, array('onclick' => '$.modal.close(); return false;'));
 			$buttons[] = $form->generate_submit_button($lang->save_permissions, array('id' => 'savePermissions'));
@@ -835,7 +835,7 @@ $(function() {
 		}
 	}
 
-	if($mybb->input['ajax'] != 1)
+	if($mybb->get_input('ajax', MyBB::INPUT_INT) != 1)
 	{
 		$page->output_footer();
 	}

--- a/admin/modules/user/admin_permissions.php
+++ b/admin/modules/user/admin_permissions.php
@@ -466,7 +466,7 @@ if(!$mybb->input['action'])
 				foreach($groups as $group)
 				{
 					if($group == "") continue;
-					if($group_permissions[$group] != "")
+					if(!empty($group_permissions[$group]))
 					{
 						$perm_type = "group";
 						break;

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -373,7 +373,8 @@ if($mybb->input['action'] == "add")
 	$query = $db->simple_select("profilefields", "*", "required=1", array('order_by' => 'disporder'));
 
 	$profile_fields = array(
-        'contact_required'  => array(),
+		'contact_required' => array(),
+		'contact_optional' => array(),
 		'required' => array(),
 		'optional' => array(),
 	);
@@ -950,6 +951,8 @@ if($mybb->input['action'] == "edit")
 	$query = $db->simple_select("profilefields", "*", "", array('order_by' => 'disporder'));
 
 	$profile_fields = array(
+		'contact_required' => array(),
+		'contact_optional' => array(),
 		'required' => array(),
 		'optional' => array(),
 	);
@@ -4508,6 +4511,7 @@ function user_search_conditions($input, &$form)
 
 	$profile_fields = array(
 		'contact_required' => array(),
+		'contact_optional' => array(),
 		'required' => array(),
 		'optional' => array(),
 	);

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -373,6 +373,7 @@ if($mybb->input['action'] == "add")
 	$query = $db->simple_select("profilefields", "*", "required=1", array('order_by' => 'disporder'));
 
 	$profile_fields = array(
+        'contact_required'  => array(),
 		'required' => array(),
 		'optional' => array(),
 	);
@@ -1782,7 +1783,7 @@ EOF;
 
 	// Suspend avatar
 	// Generate check box
-	$suspendavatar_options = $form->generate_select_box('suspendavatar_period', $periods, $mybb->input['suspendavatar_period'], array('id' => 'suspendavatar_period'));
+	$suspendavatar_options = $form->generate_select_box('suspendavatar_period', $periods, $mybb->get_input('suspendavatar_period'), array('id' => 'suspendavatar_period'));
 
 	// Do we have any existing suspensions here?
 	$existing_info = '';

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -4506,6 +4506,7 @@ function user_search_conditions($input, &$form)
 	$query = $db->simple_select("profilefields", "*", "", array('order_by' => 'disporder'));
 
 	$profile_fields = array(
+		'contact_required' => array(),
 		'required' => array(),
 		'optional' => array(),
 	);

--- a/forumdisplay.php
+++ b/forumdisplay.php
@@ -1065,6 +1065,8 @@ if($mybb->user['uid'])
 	}
 }
 
+$prefixselect = '';
+
 // Is this a real forum with threads?
 if($foruminfo['type'] != "c")
 {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1667,7 +1667,7 @@ function forum_permissions($fid = 0, $uid = 0, $gid = 0)
 				$cached_forum_permissions[$gid][$forum['fid']] = fetch_forum_permissions($forum['fid'], $gid, $groupperms);
 			}
 		}
-		return $cached_forum_permissions[$gid];
+		return $cached_forum_permissions[$gid] ?? [];
 	}
 }
 

--- a/inc/functions_modcp.php
+++ b/inc/functions_modcp.php
@@ -65,7 +65,7 @@ function fetch_forum_announcements($pid = 0, $depth = 1)
 		}
 	}
 
-	if(!is_array($forums_by_parent[$pid]))
+	if(!isset($forums_by_parent[$pid]) || !is_array($forums_by_parent[$pid]))
 	{
 		return;
 	}
@@ -234,7 +234,7 @@ function send_report($report, $report_type = 'post')
 	$emailsubject = $lang->sprintf($lang->$lang_string_subject, $mybb->settings['bbname']);
 	$emailmessage = $lang->sprintf($lang->$lang_string_message, $mybb->user['username'], $mybb->settings['bbname'], $send_report_subject, $mybb->settings['bburl'], $send_report_url, $report_reason);
 	$pm_recipients = array();
-	
+
 	while($mod = $db->fetch_array($query))
 	{
 		if($mybb->settings['reportmethod'] == "pms" && $mod['receivepms'] != 0 && $mybb->settings['enablepms'] != 0)

--- a/index.php
+++ b/index.php
@@ -386,7 +386,7 @@ if($mybb->settings['subforumsindex'] != 0)
 }
 
 $forum_list = build_forumbits();
-$forums = $forum_list['forum_list'];
+$forums = $forum_list['forum_list'] ?? '';
 
 $plugins->run_hooks('index_end');
 

--- a/warnings.php
+++ b/warnings.php
@@ -193,6 +193,9 @@ if($mybb->input['action'] == "warn")
 		error($lang->error_cant_warn_user);
 	}
 
+	$warnings = [];
+	$post = null;
+
 	// Giving a warning for a specific post
 	if($mybb->get_input('pid', MyBB::INPUT_INT))
 	{
@@ -217,8 +220,6 @@ if($mybb->input['action'] == "warn")
 		$post['subject'] = $parser->parse_badwords($post['subject']);
 		$post['subject'] = htmlspecialchars_uni($post['subject']);
 		$post['link'] = get_post_link($post['pid']);
-
-		$warnings = [];
 
 		// Fetch any existing warnings issued for this post
 		$query = $db->query("


### PR DESCRIPTION
### Fixed

- Fixed a warning when forums list is empty  (`Trying to access array offset on null - Line: 389 - File: index.php`).
- Fixed a warning for a key in `$profile_fields` array in the ACP users module (`Undefined array key "contact_required" - Line: 430 - File: admin/modules/user/users.php`).
- Fixed a warning when cached forums permissions is not set (` Trying to access array offset on null - Line: 1670 - File: inc/functions.php`).
- Fixed a warning due to using `$mybb->input[]` instead of `$mybb->get_input()` for `suspendavatar_period` select generation (`Undefined array key "suspendavatar_period" - Line: 1788 - File: admin/modules/user/users.php`).
- Fixed a warning due to unitialized `$prefixselect` in forumdisplay (`Undefined variable $prefixselect - Line: 1092 - File: forumdisplay.php`).
- Fixed a warning in `fetch_forum_announcements` when there are no forums.
- Fixed a warning in admin_permissions (`Undefined array key 8 - Line: 469 - File: admin/modules/user/admin_permissions.php`).
- Fixed a warning in forums management (`Undefined array key "ajax" - Line: 778 - File: admin/modules/forum/management.php`).
- Fixed two warnings in `warnings.php` (`Undefined variable $post - Line: 479 - File: warnings.php`, `Undefined variable $warnings - Line: 479 - File: warnings.php`)/