### PR TITLE
Mark the thread rating feature as deprecated using PHPDoc

### DIFF
--- a/admin/modules/tools/recount_rebuild.php
+++ b/admin/modules/tools/recount_rebuild.php
@@ -316,8 +316,9 @@ function acp_recount_referrals()
 
 /**
  * Recount thread ratings
+ *
+ * @deprecated 1.9.0 Thread rating feature is deprecated
  */
-#[\Deprecated(message: "Thread rating feature is deprecated", since: "1.9.0")]
 function acp_recount_thread_ratings()
 {
 	global $db, $mybb, $lang;

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -4599,8 +4599,9 @@ $("#username").select2({
 /**
  * @param int $source_uid
  * @param int $destination_uid
+ *
+ * @deprecated 1.9.0 Thread rating feature is deprecated
  */
-#[\Deprecated(message: "Thread rating feature is deprecated", since: "1.9.0")]
 function merge_thread_ratings($source_uid, $destination_uid)
 {
 	global $db;


### PR DESCRIPTION
### Changed

Mark the thread rating feature as deprecated using PHPDoc instead of the #[Deprecated] attribute


