### PR TITLE
Render forum rules as raw HTML in forumdisplay.twig

### DIFF
--- a/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/forumdisplay.twig
@@ -51,7 +51,7 @@
                     <strong><a href="misc.php?action=rules&amp;fid={{ foruminfo.fid }}">{{ foruminfo.rulestitle|default(trans('forum_rules', foruminfo.name)) }}</a></strong>
                 {% else %}
                     <h4 class="title title--container">{{ foruminfo.rulestitle|default(trans('forum_rules', foruminfo.name)) }}</h4>
-                    {{ foruminfo.rules }}
+                    {{ foruminfo.rules|raw }}
                 {% endif %}
             </section>
         {% endif %}


### PR DESCRIPTION
### Fixed

- HTML is displayed instead of rendered for forum rules in forumdisplay (other locations, such as newthread, already use `|raw`).