### PR TITLE
Update renderAvatar to return full URL

### DIFF
--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -556,6 +556,10 @@ class CoreExtension extends AbstractExtension implements GlobalsInterface
             ]);
         }
 
+        if (!my_validate_url($url)) {
+            $url = $this->mybb->get_asset_url($url);
+        }
+
         return $twig->render('partials/avatar.twig', [
             'url' => $url,
             'alt' => $alt,


### PR DESCRIPTION
### Changed

- Ensure `renderAvatar` returns an absolute URL when given a relative avatar path.

Resolves #5265