### PR TITLE
Add url() and path() Twig functions

### DIFF
--- a/inc/src/Twig/Extensions/UrlExtension.php
+++ b/inc/src/Twig/Extensions/UrlExtension.php
@@ -10,6 +10,8 @@ class UrlExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
+            new TwigFunction('path', [$this, 'path']),
+            new TwigFunction('url', [$this, 'url']),
             new TwigFunction('get_profile_link', [$this, 'getProfileLink']),
             new TwigFunction('get_announcement_link', [$this, 'getAnnouncementLink']),
             new TwigFunction('get_forum_link', [$this, 'getForumLink']),
@@ -19,6 +21,91 @@ class UrlExtension extends AbstractExtension
             new TwigFunction('get_calendar_link', [$this, 'getCalendarLink']),
             new TwigFunction('get_calendar_week_link', [$this, 'getCalendarWeekLink']),
         ];
+    }
+
+    /**
+     * Build a relative path by appending query parameters to a script or URL.
+     *
+     *
+     * @param string $script Base script or URL.
+     * @param array $params Query parameters to append or override.
+     * @param string|null $fragment Optional fragment identifier.
+     *
+     * @return string The resulting relative path.
+     */
+    public function path(string $script, array $params = [], ?string $fragment = null): string
+    {
+        return $this->build($script, $params, $fragment, false);
+    }
+
+    /**
+     * Build an absolute URL by appending query parameters to a script or URL.
+     *
+     *
+     * @param string $script Base script or URL.
+     * @param array $params Query parameters to append or override.
+     * @param string|null $fragment Optional fragment identifier.
+     *
+     * @return string The resulting absolute URL.
+     */
+    public function url(string $script, array $params = [], ?string $fragment = null): string
+    {
+        return $this->build($script, $params, $fragment, true);
+    }
+
+    /**
+     * Internal URL builder.
+     *
+     *
+     * @param string $script Base script or URL.
+     * @param array $params Query parameters to append or override.
+     * @param string|null $fragment Optional fragment identifier.
+     * @param bool $absolute Whether to return an absolute URL.
+     *
+     * @return string The resulting URL or path.
+     */
+    private function build(string $script, array $params, ?string $fragment, bool $absolute): string
+    {
+        if ($absolute) {
+            $hasScheme = (bool) parse_url($script, PHP_URL_SCHEME);
+            $isProtocolRelative = str_starts_with($script, '//');
+
+            if (!$hasScheme && !$isProtocolRelative) {
+                global $mybb;
+                $script = rtrim($mybb->settings['bburl'], '/') . '/' . ltrim($script, '/');
+            }
+        }
+
+        $existingFragment = null;
+        if (str_contains($script, '#')) {
+            [$script, $existingFragment] = explode('#', $script, 2);
+        }
+
+        $base = $script;
+        $existingQuery = '';
+        if (str_contains($script, '?')) {
+            [$base, $existingQuery] = explode('?', $script, 2);
+        }
+
+        $existingParams = [];
+        if ($existingQuery !== '') {
+            parse_str(str_replace('&amp;', '&', $existingQuery), $existingParams);
+        }
+
+        $merged = array_merge($existingParams, $params);
+        $query = $merged !== [] ? http_build_query($merged, '', '&') : '';
+
+        $out = $base;
+        if ($query !== '') {
+            $out .= '?' . $query;
+        }
+
+        $finalFragment = $fragment ?? $existingFragment;
+        if ($finalFragment !== null && $finalFragment !== '') {
+            $out .= '#' . $finalFragment;
+        }
+
+        return $out;
     }
 
     /**

--- a/inc/src/Twig/Extensions/UrlExtension.php
+++ b/inc/src/Twig/Extensions/UrlExtension.php
@@ -12,6 +12,7 @@ class UrlExtension extends AbstractExtension
         return [
             new TwigFunction('path', [$this, 'path']),
             new TwigFunction('url', [$this, 'url']),
+            new TwigFunction('url_from', [$this, 'urlFrom']),
             new TwigFunction('get_profile_link', [$this, 'getProfileLink']),
             new TwigFunction('get_announcement_link', [$this, 'getAnnouncementLink']),
             new TwigFunction('get_forum_link', [$this, 'getForumLink']),
@@ -25,7 +26,6 @@ class UrlExtension extends AbstractExtension
 
     /**
      * Build a relative path by appending query parameters to a script or URL.
-     *
      *
      * @param string $script Base script or URL.
      * @param array $params Query parameters to append or override.
@@ -41,7 +41,6 @@ class UrlExtension extends AbstractExtension
     /**
      * Build an absolute URL by appending query parameters to a script or URL.
      *
-     *
      * @param string $script Base script or URL.
      * @param array $params Query parameters to append or override.
      * @param string|null $fragment Optional fragment identifier.
@@ -50,21 +49,36 @@ class UrlExtension extends AbstractExtension
      */
     public function url(string $script, array $params = [], ?string $fragment = null): string
     {
-        return $this->build($script, $params, $fragment, true);
+        return $this->build($script, $params, $fragment, true, 'bburl');
+    }
+
+    /**
+     * Build an absolute URL by appending query parameters to a script or URL using a configured base setting.
+     *
+     * @param string $baseSetting Setting name to use as URL base.
+     * @param string $script Base script or URL.
+     * @param array $params Query parameters to append or override.
+     * @param string|null $fragment Optional fragment identifier.
+     *
+     * @return string The resulting absolute URL.
+     */
+    public function urlFrom(string $baseSetting, string $script, array $params = [], ?string $fragment = null): string
+    {
+        return $this->build($script, $params, $fragment, true, $baseSetting);
     }
 
     /**
      * Internal URL builder.
      *
-     *
      * @param string $script Base script or URL.
      * @param array $params Query parameters to append or override.
      * @param string|null $fragment Optional fragment identifier.
      * @param bool $absolute Whether to return an absolute URL.
+     * @param string $baseSetting Setting name to use as URL base when $absolute is true.
      *
      * @return string The resulting URL or path.
      */
-    private function build(string $script, array $params, ?string $fragment, bool $absolute): string
+    private function build(string $script, array $params, ?string $fragment, bool $absolute, string $baseSetting = 'bburl'): string
     {
         if ($absolute) {
             $hasScheme = (bool) parse_url($script, PHP_URL_SCHEME);
@@ -72,7 +86,13 @@ class UrlExtension extends AbstractExtension
 
             if (!$hasScheme && !$isProtocolRelative) {
                 global $mybb;
-                $script = rtrim($mybb->settings['bburl'], '/') . '/' . ltrim($script, '/');
+
+                $baseUrl = $mybb->settings[$baseSetting] ?? '';
+                if (!is_string($baseUrl) || $baseUrl === '' || !my_validate_url($baseUrl, false, true)) {
+                    $baseUrl = $mybb->settings['bburl'] ?? '';
+                }
+
+                $script = rtrim($baseUrl, '/') . '/' . ltrim($script, '/');
             }
         }
 

--- a/inc/themes/core.base/frontend/templates/calendar/event.twig
+++ b/inc/themes/core.base/frontend/templates/calendar/event.twig
@@ -12,11 +12,11 @@
         <div class="page-controls page-controls--compact">
             <div class="page-buttons">
                 {% if calendar_permissions.canaddevents %}
-                    <a href="calendar.php?action=addevent&amp;calendar={{ calendar.cid }}" class="button button--half-width">
+                    <a href="{{ path('calendar.php', {action: 'addevent', calendar: calendar.cid}) }}" class="button button--half-width">
                         {{ include('partials/icon.twig', {icon: 'calendar-plus', class: 'button__icon'}, with_context = false) }}
                         <span class="button__text">{{ lang.add_public_event }}</span>
                     </a>
-                    <a href="calendar.php?action=addevent&amp;calendar={{ calendar.cid }}&amp;private=1" class="button button--half-width">
+                    <a href="{{ path('calendar.php', {action: 'addevent', calendar: calendar.cid, private: 1}) }}" class="button button--half-width">
                         {{ include('partials/icon.twig', {icon: 'calendar-plus', class: 'button__icon'}, with_context = false) }}
                         <span class="button__text">{{ lang.add_private_event }}</span>
                     </a>

--- a/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
@@ -96,7 +96,7 @@
             {% endfor %}
         </div>
     {% endif %}
-    
+
     <div class="thread__replies thread__count thread__count--replies">
         <a href="{{ mybb.settings.bburl }}/misc.php?action=whoposted&amp;tid={{ thread.tid }}" onclick="MyBB.whoPosted({{ thread.tid }}); return false;" class="thread__reply-count">{{ thread.replies }}</a>
         <span class="thread__legend">{% if thread.replies == 1 %}{{ lang.reply }}{% else %}{{ lang.replies }}{% endif %}</span>

--- a/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
@@ -98,7 +98,7 @@
     {% endif %}
 
     <div class="thread__replies thread__count thread__count--replies">
-        <a href="{{ mybb.settings.bburl }}/misc.php?action=whoposted&amp;tid={{ thread.tid }}" onclick="MyBB.whoPosted({{ thread.tid }}); return false;" class="thread__reply-count">{{ thread.replies }}</a>
+        <a href="{{ url('misc.php', {action: 'whoposted', tid: thread.tid}) }}" onclick="MyBB.whoPosted({{ thread.tid }}); return false;" class="thread__reply-count">{{ thread.replies }}</a>
         <span class="thread__legend">{% if thread.replies == 1 %}{{ lang.reply }}{% else %}{{ lang.replies }}{% endif %}</span>
         {% if thread.unapprovedposts and modpermissions.canviewunapprove %}
             <span class="thread__unapproved-replies" title="{{ (thread.unapprovedposts == 1) ? trans('thread_unapproved_post_count', 1) : trans('thread_unapproved_posts_count', thread.unapprovedposts) }}">


### PR DESCRIPTION
### Added

- Added `url()`, `path()` and internal `build()` methods to `UrlExtension`.

### Changed

- Updated `event.twig` and `thread.twig` to demonstrate usage of `url()` and `path()`.

Resolves #5225
