### PR TITLE
Remove incorrect dstcorrection integer output

### DIFF
--- a/inc/themes/core.base/frontend/templates/partials/footer.twig
+++ b/inc/themes/core.base/frontend/templates/partials/footer.twig
@@ -135,8 +135,4 @@
             <img src="{{ task_image }}" width="1" height="1" alt="" />
         {% endif %}
     {# End task image code. #}
-
-    {% if mybb.settings.dstcorrection %}
-        {{ mybb.settings.dstcorrection }}
-    {% endif %}
 </div>

--- a/inc/themes/core.base/frontend/templates/partials/header.twig
+++ b/inc/themes/core.base/frontend/templates/partials/header.twig
@@ -1,7 +1,4 @@
 <div id="container">
-    {% if mybb.settings.dstcorrection %}
-        {{ mybb.settings.dstcorrection }}
-    {% endif %}
     <a name="top" id="top"></a>
 
     <header class="header">


### PR DESCRIPTION
### Removed

- Removed `dstcorrection` output from header and footer causing a `1` to be displayed in both:
<img width="3837" height="396" alt="image" src="https://github.com/user-attachments/assets/0125cb50-a362-4d0a-8909-505b056169be" />
