### PR TITLE
Replace remote FA JS with local FA CSS

### DIFF
--- a/inc/themes/core.base/frontend/assets.json
+++ b/inc/themes/core.base/frontend/assets.json
@@ -1,5 +1,12 @@
 {
 	"assets": {
+		"./jscripts/fonts/fontawesome/css/all.min.css": {
+			"attached_to": [
+				{
+					"script": "global"
+				}
+			]
+		},
 		"styles/main.css": {
 			"source": "main.scss",
 			"attached_to": [
@@ -165,18 +172,6 @@
 			"depends_on": [
 				"./jscripts/jquery.js"
 			]
-		},
-		"https://use.fontawesome.com/releases/v5.4.1/js/all.js": {
-			"attached_to": [
-				{
-					"script": "global"
-				}
-			],
-			"attributes": {
-				"defer": "defer",
-				"integrity": "sha384-L469/ELG4Bg9sDQbl0hvjMq8pOcqFgkSpwhwnslzvVVGpDjYJ6wJJyYjvG3u8XW7",
-				"crossorigin": "anonymous"
-			}
 		}
 	}
 }


### PR DESCRIPTION
### Changed

- Replaced the remote Font Awesome JS dependency with the bundled local CSS/webfonts (upgrade from 5.4 to 6.1)

Part of #4839
