### PR TITLE
Implement username-based default avatars

### DIFF
--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -534,6 +534,7 @@ class CoreExtension extends AbstractExtension implements GlobalsInterface
      * @param string|null $url The URL to the avatar to render, or null for a default avatar.
      * @param string|null $alt The alternative text to use for the avatar.
      * @param string|null $class An optional CSS class or list of CSS classes to apply to the avatar template.
+     * @param string|null $identifier The string to use when generating the default avatar's initial and color.
      *
      * @return string
      * @throws \Twig\Error\LoaderError
@@ -544,15 +545,23 @@ class CoreExtension extends AbstractExtension implements GlobalsInterface
         Environment $twig,
         ?string $url = '',
         ?string $alt = '',
-        ?string $class = ''
+        ?string $class = '',
+        ?string $identifier = null
     ): string {
         $url = trim($url);
         $alt = trim($alt);
         $class = trim($class);
+        $identifier = trim(strip_tags((string)$identifier));
+
+        if (empty($identifier)) {
+            $identifier = trim(strip_tags((string)$alt));
+        }
 
         if (empty($url)) {
             return $twig->render('partials/default_avatar.twig', [
                 'class' => $class,
+                'default_avatar_initial' => $this->getDefaultAvatarInitial($identifier),
+                'default_avatar_color' => $this->getDefaultAvatarColor($identifier),
             ]);
         }
 
@@ -561,5 +570,43 @@ class CoreExtension extends AbstractExtension implements GlobalsInterface
             'alt' => $alt,
             'class' => $class,
         ]);
+    }
+
+    /**
+     * Returns the initial used for a generated default avatar.
+     *
+     * @param string $identifier Source string for the generated avatar.
+     *
+     * @return string
+     */
+    private function getDefaultAvatarInitial(string $identifier): string
+    {
+        if ($identifier === '') {
+            return '';
+        }
+
+        return my_strtoupper(my_substr($identifier, 0, 1));
+    }
+
+    /**
+     * Returns a background color for a generated default avatar.
+     *
+     * @param string $identifier Source string for the generated avatar.
+     *
+     * @return string
+     */
+    private function getDefaultAvatarColor(string $identifier): string
+    {
+        if ($identifier === '') {
+            return '';
+        }
+
+        $hash = hash('sha256', $identifier);
+
+        $hue = hexdec(substr($hash, 0, 4)) % 360;
+        $saturation = 58 + (hexdec(substr($hash, 4, 2)) / 255) * 24;
+        $lightness = 30 + (hexdec(substr($hash, 6, 2)) / 255) * 14;
+
+        return "hsl({$hue}, {$saturation}%, {$lightness}%)";
     }
 }

--- a/inc/src/Twig/Extensions/CoreExtension.php
+++ b/inc/src/Twig/Extensions/CoreExtension.php
@@ -560,8 +560,8 @@ class CoreExtension extends AbstractExtension implements GlobalsInterface
         if (empty($url)) {
             return $twig->render('partials/default_avatar.twig', [
                 'class' => $class,
-                'default_avatar_initial' => $this->getDefaultAvatarInitial($identifier),
-                'default_avatar_color' => $this->getDefaultAvatarColor($identifier),
+                'initial' => $this->getDefaultAvatarInitial($identifier),
+                'color' => $this->getDefaultAvatarColor($identifier),
             ]);
         }
 

--- a/inc/themes/core.base/frontend/styles/components/_avatars.scss
+++ b/inc/themes/core.base/frontend/styles/components/_avatars.scss
@@ -12,6 +12,12 @@
     .avatar__icon {
         font-size: #{$icon-size}px;
     }
+
+    $initial-size: $size/1.9;
+
+    .avatar__initial {
+        font-size: #{$initial-size}px;
+    }
 }
 
 .avatar-profile-link {
@@ -46,6 +52,32 @@
         align-items: center;
         justify-content: center;
         background: var(--background-3);
+
+        &[data-avatar-color] {
+            background: var(--default-avatar-color, var(--background-3));
+        }
+
+        @supports (background: attr(data-avatar-color type(<color>), #000)) {
+            &[data-avatar-color] {
+                background: attr(data-avatar-color type(<color>), var(--default-avatar-color, var(--background-3)));
+            }
+        }
+    }
+
+    &__initial {
+        display: inline-flex;
+        width: 100%;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        color: var(--invert-font-color);
+        font-weight: 700;
+        line-height: 1;
+        text-transform: uppercase;
+
+        &::before {
+            content: attr(data-avatar-initial);
+        }
     }
 
     &__icon {

--- a/inc/themes/core.base/frontend/styles/utils/_helpers.scss
+++ b/inc/themes/core.base/frontend/styles/utils/_helpers.scss
@@ -46,6 +46,7 @@
     height: #{$size}px;
 
     $icon-size: $size/2;
+    $initial-size: $size/1.9;
 
     .avatar {
         width: #{$size}px;
@@ -53,6 +54,10 @@
 
         &__icon {
             font-size: #{$icon-size}px;
+        }
+
+        &__initial {
+            font-size: #{$initial-size}px;
         }
     }
 }

--- a/inc/themes/core.base/frontend/templates/header/welcomeblock_member.twig
+++ b/inc/themes/core.base/frontend/templates/header/welcomeblock_member.twig
@@ -62,7 +62,7 @@
             </ul>
             <div class="user-bar__avatar">
                 <a href="{{ get_profile_link(mybb.user.uid) }}" class="avatar-profile-link" title="{{ lang.welcome_my_profile }}">
-                    {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar, class='my-avatar avatar--medium')}}
+                    {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar, class='my-avatar avatar--medium', identifier=mybb.user.username) }}
                 </a>
             </div>
         </div>

--- a/inc/themes/core.base/frontend/templates/partials/default_avatar.twig
+++ b/inc/themes/core.base/frontend/templates/partials/default_avatar.twig
@@ -1,3 +1,7 @@
-<span class="avatar avatar--default{% if class %} {{ class }}{% endif %}">
-    {{ include('partials/icon.twig', {icon: 'user', class: 'avatar__icon'}, with_context = false) }}
+<span class="avatar avatar--default{% if class %} {{ class }}{% endif %}"{% if default_avatar_color %} data-avatar-color="{{ default_avatar_color }}" style="--default-avatar-color: {{ default_avatar_color }};"{% endif %}>
+    {% if default_avatar_initial %}
+        <span class="avatar__initial" data-avatar-initial="{{ default_avatar_initial }}" aria-hidden="true"></span>
+    {% else %}
+        {{ include('partials/icon.twig', {icon: 'user', class: 'avatar__icon'}, with_context = false) }}
+    {% endif %}
 </span>

--- a/inc/themes/core.base/frontend/templates/partials/default_avatar.twig
+++ b/inc/themes/core.base/frontend/templates/partials/default_avatar.twig
@@ -1,6 +1,6 @@
-<span class="avatar avatar--default{% if class %} {{ class }}{% endif %}"{% if default_avatar_color %} data-avatar-color="{{ default_avatar_color }}" style="--default-avatar-color: {{ default_avatar_color }};"{% endif %}>
-    {% if default_avatar_initial %}
-        <span class="avatar__initial" data-avatar-initial="{{ default_avatar_initial }}" aria-hidden="true"></span>
+<span class="avatar avatar--default{% if class %} {{ class }}{% endif %}"{% if color %} data-avatar-color="{{ color }}" style="--default-avatar-color: {{ color }};"{% endif %}>
+    {% if initial %}
+        <span class="avatar__initial" data-avatar-initial="{{ initial }}" aria-hidden="true"></span>
     {% else %}
         {{ include('partials/icon.twig', {icon: 'user', class: 'avatar__icon'}, with_context = false) }}
     {% endif %}

--- a/inc/themes/core.base/frontend/templates/private/read.twig
+++ b/inc/themes/core.base/frontend/templates/private/read.twig
@@ -34,7 +34,7 @@
                 <input type="hidden" name="do" value="reply" />
                 <div class="post__meta">
                     <a href="{{ get_profile_link(mybb.user.uid) }}" class="avatar-profile-link" title="{{ lang.welcome_my_profile }}">
-                        {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar) }}
+                        {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar, identifier=mybb.user.username) }}
                     </a>
                     <h3 class="post__author"><a href="{{ get_profile_link(mybb.user.uid) }}">{{ mybb.user|format_name }}</a></h3>
                     <span class="post__date">{{ lang.quick_reply }}</span>

--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -318,7 +318,7 @@
                     <input type="hidden" name="method" value="quickreply" />
                     <div class="post__meta">
                         <a href="{{ get_profile_link(mybb.user.uid) }}" class="avatar-profile-link" title="{{ lang.welcome_my_profile }}">
-                            {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar) }}
+                            {{ render_avatar(url=mybb.user.avatar, alt=lang.welcome_my_avatar, identifier=mybb.user.username) }}
                         </a>
                         <h3 class="post__author"><a href="{{ get_profile_link(mybb.user.uid) }}">{{ mybb.user|format_name }}</a></h3>
                         <span class="post__date">{{ lang.quick_reply }}</span>


### PR DESCRIPTION
# Added

Implements username-based default avatars for users without a custom avatar. Default avatars now display:
- a generated initial based on username/identifier
- a generated background color in a visually acceptable range

# Example

<img width="2909" height="1911" alt="image" src="https://github.com/user-attachments/assets/b782dec0-ba04-4b11-aefc-2e9794bebf83" />

Resolves #5190

