### PR TITLE
Fix/absolute attachment urls

### DIFF
--- a/inc/functions_online.php
+++ b/inc/functions_online.php
@@ -748,7 +748,7 @@ function build_friendly_wol_location($user_activity)
 			$tid = $posts[$pid];
 			if(!empty($threads[$tid]))
 			{
-				$location_name = $lang->sprintf($lang->viewing_attachment2, $user_activity['aid'], $threads[$tid], get_thread_link($tid));
+				$location_name = $lang->sprintf($lang->viewing_attachment2, $mybb->settings['bburl'], $user_activity['aid'], $threads[$tid], get_thread_link($tid));
 			}
 			else
 			{

--- a/inc/languages/english/online.lang.php
+++ b/inc/languages/english/online.lang.php
@@ -11,7 +11,7 @@ $l['nav_onlinetoday'] = "Who Was Online Today";
 $l['viewing_announcements'] = "Viewing Announcement <a href=\"{1}\">{2}</a>";
 $l['viewing_announcements2'] = "Viewing Announcement";
 $l['viewing_attachment'] = "Viewing Attachment";
-$l['viewing_attachment2'] = "Viewing <a href=\"attachment.php?aid={1}\" target=\"_blank\">Attachment</a> in Thread <a href=\"{3}\">{2}</a>";
+$l['viewing_attachment2'] = "Viewing <a href=\"{1}/attachment.php?aid={2}\" target=\"_blank\">Attachment</a> in Thread <a href=\"{1}/{4}\">{3}</a>";
 $l['viewing_calendar'] = "Viewing <a href=\"calendar.php\">Calendar</a>";
 $l['viewing_event'] = "Viewing Event";
 $l['viewing_event2'] = "Viewing Event <a href=\"{1}\">{2}</a>";

--- a/inc/themes/core.base/frontend/templates/misc/attachments_attachment.twig
+++ b/inc/themes/core.base/frontend/templates/misc/attachments_attachment.twig
@@ -5,7 +5,7 @@
             {% if attachment.visible %}
                 {{ attachment.filename }}
             {% else %}
-                <a href="attachment.php?aid={{ attachment.aid }}" target="_blank">{{ attachment.filename }}</a>
+                <a href="{{ url('attachment.php', { 'aid': attachment.aid }) }}" target="_blank">{{ attachment.filename }}</a>
             {% endif %}
         </span>
         <span class="uploaded-attachment__file-size">({{ attachment.size }})</span>

--- a/inc/themes/core.base/frontend/templates/modcp/modqueue/attachment.twig
+++ b/inc/themes/core.base/frontend/templates/modcp/modqueue/attachment.twig
@@ -1,7 +1,7 @@
 <div class="row mod-queue">
     <div class="mod-queue__header">
         <div class="mod-queue__info">
-            <h2 class="mod-queue__subject"><a href="attachment.php?aid={{ attachment.aid }}" target="_blank">{{ attachment.filename }}</a> ({{ attachment.filesize }})</h2>
+            <h2 class="mod-queue__subject"><a href="{{ url('attachment.php', { 'aid': attachment.aid }) }}" target="_blank">{{ attachment.filename }}</a> ({{ attachment.filesize }})</h2>
             <div class="mod-queue__author">{{ lang.by }} {{ attachment.profile_link|raw }}</div>
             <div class="mod-queue__date">{{ attachment.attachdate|raw }}</div>
             <div class="mod-queue__post">{{ lang.post }}: <a href="{{ attachment.link }}">{{ attachment.postsubject }}</a></div>

--- a/inc/themes/core.base/frontend/templates/postbit/postbit_attached_image.twig
+++ b/inc/themes/core.base/frontend/templates/postbit/postbit_attached_image.twig
@@ -1,5 +1,5 @@
 <img
-        src="attachment.php?aid={{ image.aid }}"
+        src="{{ url('attachment.php', { 'aid': image.aid }) }}"
         class="attachments__attachment attachment attachment--image"
         alt=""
         title="{{ lang.postbit_attachment_filename }} {{ image.filename }} {{ lang.postbit_attachment_size }} {{ image.filesize }} {{ image.date }}"

--- a/inc/themes/core.base/frontend/templates/postbit/postbit_attached_thumbnail.twig
+++ b/inc/themes/core.base/frontend/templates/postbit/postbit_attached_thumbnail.twig
@@ -1,6 +1,6 @@
-<a href="attachment.php?aid={{ thumb.aid }}" target="_blank">
+<a href="{{ url('attachment.php', { 'aid': thumb.aid }) }}" target="_blank">
     <img
-            src="attachment.php?thumbnail={{ thumb.aid }}"
+            src="{{ url('attachment.php', { 'thumbnail': thumb.aid }) }}"
             class="attachments__attachment attachment attachment--image"
             alt=""
             title="{{ lang.postbit_attachment_filename }} {{ thumb.filename }} {{ lang.postbit_attachment_size }} {{ thumb.filesize }} {{ thumb.date }}"

--- a/inc/themes/core.base/frontend/templates/postbit/postbit_attachment.twig
+++ b/inc/themes/core.base/frontend/templates/postbit/postbit_attachment.twig
@@ -1,5 +1,5 @@
 <div class="attachments__attachment attachment">
     <span class="attachment__icon">{{ attachment.icon|raw }}</span>
-    <a href="attachment.php?aid={{ attachment.aid }}" target="_blank" title="{{ attachment.date }}" class="attachment__link">{{ attachment.filename }}</a>
+    <a href="{{ url('attachment.php', { 'aid': attachment.aid }) }}" target="_blank" title="{{ attachment.date }}" class="attachment__link">{{ attachment.filename }}</a>
     <span class="attachment__data">({{ lang.postbit_attachment_size }} {{ attachment.filesize }} / {{ lang.postbit_attachment_downloads }} {{ attachment.downloads }})</span>
 </div>

--- a/inc/themes/core.base/frontend/templates/usercp/attachments/row.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/attachments/row.twig
@@ -1,7 +1,7 @@
 <div class="row row--simple-columns attachment">
     <div class="attachment__icon">{{ attachment.icon|raw }}</div>
     <div class="row__primary attachment__file">
-        <h3 class="attachment__file-name"><a href="attachment.php?aid={{ attachment.aid }}" target="_blank">{{ attachment.filename }}</a></h3>
+        <h3 class="attachment__file-name"><a href="{{ url('attachment.php', { 'aid': attachment.aid }) }}" target="_blank">{{ attachment.filename }}</a></h3>
         <div class="attachment__size-downloads">{{ trans('attachment_size_downloads', attachment.size, attachment.downloads) }}</div>
         <div class="attachment__date">{{ attachment.date|raw }}</div>
     </div>


### PR DESCRIPTION
This is a fix for when rending/linking attachments in the portal; because the portal can be placed outside the scope of the forum, it is necessary to make attachment links absolute.

I just made all links absolute for consistency across the theme.