### PR TITLE
Enhance tryGet method to support global variables fallback

### DIFF
--- a/inc/src/View/Runtime/SharedData.php
+++ b/inc/src/View/Runtime/SharedData.php
@@ -37,7 +37,7 @@ class SharedData
      */
     public function tryGet(string $key): array|null|int|float|string|bool
     {
-        return $this->data[$key] ?? null;
+        return $GLOBALS[$key] ?? $this->data[$key] ?? null;
     }
 
     /**


### PR DESCRIPTION
There is an issue with plugins that set global variables in a hook and modify them in another.