### PR TITLE
Make header attachments a function helper

### DIFF
--- a/global.php
+++ b/global.php
@@ -534,7 +534,7 @@ if(!(defined('THIS_SCRIPT') && THIS_SCRIPT == 'editpost.php') && ($can_access_mo
 				$modqueue_message = $lang->sprintf($lang->{'unapproved_'.$modqueue_type}, my_number_format(${'unapproved_'.$modqueue_type}));
 			}
 
-			$headerMessage[] = [
+			$headerMessages[] = [
 				'message' => \MyBB\View\template('misc/modqueue_link.twig', [
 					'modqueue_type' => $modqueue_type,
 					'modqueue_message' => $modqueue_message,

--- a/inc/src/Twig/Extensions/ViewExtension.php
+++ b/inc/src/Twig/Extensions/ViewExtension.php
@@ -39,6 +39,7 @@ class ViewExtension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('alt_trow', [$this, 'altTrow']),
             new TwigFunction('attached_assets', [$this, 'getAttachedAssets']),
             new TwigFunction('legacy_styles', [$this, 'getLegacyStyles']),
+            new TwigFunction('header_messages', [$this, 'getHeaderMessages']),
         ];
     }
 
@@ -52,7 +53,6 @@ class ViewExtension extends AbstractExtension implements GlobalsInterface
         return array_merge(
             [
                 'theme' => $this->view->getGlobalThemeArray(),
-                'headerMessages' => isset($GLOBALS['headerMessages']) ? $GLOBALS['headerMessages'] : [],
             ],
         );
     }
@@ -199,5 +199,15 @@ class ViewExtension extends AbstractExtension implements GlobalsInterface
                 }
             }
         }
+    }
+
+    /**
+     * Get the header messages set by the application.
+     *
+     * @return array An array of header messages, if any are set, or an empty array if not.
+     */
+    public function getHeaderMessages(): array
+    {
+        return $GLOBALS['headerMessages'] ?? [];
     }
 }

--- a/inc/themes/core.base/frontend/templates/partials/header.twig
+++ b/inc/themes/core.base/frontend/templates/partials/header.twig
@@ -58,7 +58,7 @@
     <div class="main">
         <div class="wrapper wrapper--main">
             <div id="content">
-                {% for template, options in headerMessages %}
+                {% for template, options in header_messages() %}
                     {% if template matches '/^\\d+$/' %}
                         {% include 'messages/base.twig' %}
                     {% else %}


### PR DESCRIPTION
Updates to the messages array are not propagated properly.

There is also a typo with `$headerMessage` which should be `$headerMessages`.