### PR TITLE
Add `datahandler_get_friendly_errors` plugin hook to `DataHandler::get_friendly_errors`

### DIFF
--- a/inc/datahandler.php
+++ b/inc/datahandler.php
@@ -119,13 +119,16 @@ class DataHandler
 	 */
 	function get_friendly_errors()
 	{
-		global $lang;
+		global $lang, $plugins;
 
 		// Load the language pack we need
 		if($this->language_file)
 		{
 			$lang->load($this->language_file, true);
 		}
+
+		$plugins->run_hooks('datahandler_get_friendly_errors', $this);
+
 		// Prefix all the error codes with the language prefix.
 		$errors = array();
 		foreach($this->errors as $error)


### PR DESCRIPTION
Validation hooks are lacking to intercept data handler errors, see:
https://github.com/mybb/mybb/blob/6d293d9b02f4c2f0726b16a1bfde70cb4a040709/newthread.php#L763-L784

This new hook is a more global hook in `datahandler_get_friendly_errors` that will allow plugins to catch any validation errors in more scenarios.

Plugins will be able to catch, set, or modify errors. They will also be able to invalidate the handler data process by forcing `$DataHandler->is_validated = false;`

Part of #5313 

<details>
<summary>Generative AI Summary (Le Chat)</summary>
This change introduces a new plugin hook, `datahandler_get_friendly_errors`, in the `DataHandler->get_friendly_errors()` method, allowing plugins to intercept or alter error messages before they are translated and returned to users. The hook addresses the lack of a standardized way for plugins to modify error information, reducing the need for brittle workarounds. It is invoked after language packs are loaded and before error codes are converted to localized messages. Plugins can inspect and modify the `$this->errors` array within the DataHandler instance. Examples include adding custom error codes, suppressing specific errors, and enriching error message data. The change is backward compatible and has minimal performance impact. Testing involves verifying unchanged behavior without plugins, confirming error modifications by plugins, and ensuring performance is unaffected. Documentation will be updated to include details about the hook and its usage patterns.
</details>