### PR TITLE
Enhance draft thread handling with poll integration

### DIFF
--- a/inc/languages/english/polls.lang.php
+++ b/inc/languages/english/polls.lang.php
@@ -40,6 +40,7 @@ $l['you_voted'] = "You voted for this item.";
 
 $l['redirect_pollposted'] = "Your poll has been posted.<br />You will now be returned to the thread.";
 $l['redirect_pollpostedmoderated'] = "Your poll has been posted, but your thread is still pending moderation.<br />You will be returned to the forum.";
+$l['redirect_pollposted_draft'] = "Your poll has been posted, but your thread is a draft.<br />You will now be taken to your draft listing.";
 $l['redirect_pollupdated'] = "The poll has been updated.<br />You will now be returned to the thread.";
 $l['redirect_votethanks'] = "Thank you for voting.<br />You will now be returned to the thread.";
 $l['redirect_unvoted'] = "Your vote(s) in this thread have been removed.<br />You will now be returned to the thread.";

--- a/inc/languages/english/usercp.lang.php
+++ b/inc/languages/english/usercp.lang.php
@@ -236,6 +236,7 @@ $l['no_drafts'] = "You do not currently have any draft threads or posts.<p>To sa
 $l['drafts'] = "Saved Drafts";
 $l['drafts_count'] = "Saved Drafts ({1})";
 $l['draft_saved'] = "Saved";
+$l['draft_has_poll'] = "Has poll";
 $l['edit_draft'] = "Edit Draft";
 $l['draft_title'] = "Draft Title";
 $l['delete_drafts'] = "Delete Selected Drafts";

--- a/inc/themes/core.base/frontend/templates/misc/postpoll.twig
+++ b/inc/themes/core.base/frontend/templates/misc/postpoll.twig
@@ -3,9 +3,13 @@
     <div class="section__container">
         <div class="row row--form field">
             <div class="option-field">
-                <input type="checkbox" class="checkbox" name="postpoll" id="postpoll" value="1" {% if editpost.postpollchecked %} checked="checked"{% endif %} />
+                <input type="checkbox" class="checkbox" name="postpoll" id="postpoll"
+                       value="1" {% if newthread.postpollchecked or editpost.postpollchecked %} checked="checked"{% endif %} />
                 <h3 class="option-field__name"><label for="postpoll">{{ lang.poll_check }}</label></h3>
-                {{ lang.num_options }} <input type="text" class="textbox textbox--small" name="numpolloptions" value="{{ composepost.numpolloptions }}" size="10" /> {{ trans('max_options', mybb.settings.maxpolloptions) }}
+                {{ lang.num_options }} <input type="text" class="textbox textbox--small" name="numpolloptions"
+                                              value="{{ composepost.numpolloptions }}"
+                                              size="10"/> {{ trans('max_options', mybb.settings.maxpolloptions) }}
+            </div>
         </div>
     </div>
 </section>

--- a/inc/themes/core.base/frontend/templates/usercp/drafts/row.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/drafts/row.twig
@@ -1,6 +1,16 @@
 <div class="row row--simple-columns draft">
     <div class="row__primary">
-        <h3 class="draft__subject"><a href="{{ draft.editurl|raw }}">{{ draft.subject }}</a></h3>
+        <h3 class="draft__subject">
+            <a href="{{ draft.editurl|raw }}">{{ draft.subject }}</a>
+            {# Poll #}
+            {% if draft.poll and draft.canmanagepolls %}
+                <a href="{{ url('polls.php', { 'action': 'editpoll', 'pid': draft.poll}) }}">
+                    {{ include('partials/icon.twig', {icon: 'check-square', class: 'thread__icon thread__icon--poll fa-fw', title: lang.draft_has_poll}, with_context = false) }}
+                </a>
+            {% elseif draft.poll %}
+                    {{ include('partials/icon.twig', {icon: 'check-square', class: 'thread__icon thread__icon--poll fa-fw', title: lang.draft_has_poll}, with_context = false) }}
+            {% endif %}
+        </h3>
         <p class="draft__location">
             {% if draft.type == 'post' %}
                 {{ lang.thread }}: <a href="{{ get_thread_link(draft.tid) }}">{{ draft.threadsubject }}</a>
@@ -19,6 +29,7 @@
         </a>
     </div>
     <div class="row__checkbox">
-        <input type="checkbox" class="checkbox checkbox--select-row" name="deletedraft[{{ draft.id }}]" value="{{ draft.type }}" />
+        <input type="checkbox" class="checkbox checkbox--select-row" name="deletedraft[{{ draft.id }}]"
+               value="{{ draft.type }}"/>
     </div>
 </div>

--- a/newthread.php
+++ b/newthread.php
@@ -144,10 +144,10 @@ if((empty($_POST) && empty($_FILES)) && $mybb->get_input('processed', MyBB::INPU
 $errors = array();
 
 // Handle attachments if we've got any.
-if($mybb->settings['enableattachments'] == 1 && 
-	($mybb->get_input('newattachment') || $mybb->get_input('updateattachment') || 
-	((($mybb->input['action'] == "do_newthread" && $mybb->get_input('submit')) || 
-	($mybb->input['action'] == "newthread" && isset($mybb->input['previewpost'])) || 
+if($mybb->settings['enableattachments'] == 1 &&
+	($mybb->get_input('newattachment') || $mybb->get_input('updateattachment') ||
+	((($mybb->input['action'] == "do_newthread" && $mybb->get_input('submit')) ||
+	($mybb->input['action'] == "newthread" && isset($mybb->input['previewpost'])) ||
 	isset($mybb->input['savedraft'])) && isset($_FILES['attachments']))))
 {
 	// Verify incoming POST request
@@ -447,18 +447,20 @@ if($mybb->input['action'] == "do_newthread" && $mybb->request_method == "post")
 		require_once MYBB_ROOT."inc/functions_indicators.php";
 		mark_thread_read($tid, $fid);
 
-		// We were updating a draft thread, send them back to the draft listing.
-		if($new_thread['savedraft'] == 1)
-		{
-			$lang->redirect_newthread = $lang->draft_saved;
-			$url = "usercp.php?action=drafts";
-		}
+		$thread = get_thread($tid);
 
 		// A poll was being posted with this thread, throw them to poll posting page.
-		else if($mybb->get_input('postpoll', MyBB::INPUT_INT) && $forumpermissions['canpostpolls'])
+		if($mybb->get_input('postpoll', MyBB::INPUT_INT) && $forumpermissions['canpostpolls'] && $visible != -1 && empty($thread['poll']))
 		{
 			$url = "polls.php?action=newpoll&tid=$tid&polloptions=".$mybb->get_input('numpolloptions', MyBB::INPUT_INT);
 			$lang->redirect_newthread .= $lang->redirect_newthread_poll;
+		}
+
+		// We were updating a draft thread, send them back to the draft listing.
+		else if($new_thread['savedraft'] == 1)
+		{
+			$lang->redirect_newthread = $lang->draft_saved;
+			$url = "usercp.php?action=drafts";
 		}
 
 		// This thread is stuck in the moderation queue, send them back to the forum.
@@ -1055,7 +1057,7 @@ if($mybb->input['action'] == "newthread" || $mybb->input['action'] == "editdraft
 	}
 
 	$newthread['showpollbox'] = false;
-	if($forumpermissions['canpostpolls'] != 0)
+	if(empty($thread['poll']) && $forumpermissions['canpostpolls'] != 0)
 	{
 		$newthread['showpollbox'] = true;
 	}

--- a/polls.php
+++ b/polls.php
@@ -59,7 +59,7 @@ if($mybb->input['action'] == "newpoll")
 	$ismod = is_moderator($thread['fid']);
 
 	// Make sure we are looking at a real thread here.
-	if(($thread['visible'] != 1 && $ismod == false) || ($thread['visible'] > 1 && $ismod == true))
+	if(($thread['visible'] != -2 && $thread['visible'] != 1 && $ismod == false) || ($thread['visible'] > 1 && $ismod == true))
 	{
 		error($lang->error_invalidthread);
 	}
@@ -84,7 +84,16 @@ if($mybb->input['action'] == "newpoll")
 	}
 	// Make navigation
 	build_forum_breadcrumb($fid);
-	add_breadcrumb(htmlspecialchars_uni($thread['subject']), get_thread_link($thread['tid']));
+
+	if($thread['visible'] == -2)
+	{
+		add_breadcrumb(htmlspecialchars_uni($thread['subject']), "usercp.php?action=drafts");
+	}
+	else
+	{
+		add_breadcrumb(htmlspecialchars_uni($thread['subject']), get_thread_link($thread['tid']));
+	}
+
 	add_breadcrumb($lang->nav_postpoll);
 
 	// No permission if: Not thread author; not moderator; no forum perms to view, post threads, post polls
@@ -352,6 +361,10 @@ if($mybb->input['action'] == "do_newpoll" && $mybb->request_method == "post")
 	{
 		redirect(get_thread_link($thread['tid']), $lang->redirect_pollposted);
 	}
+	else if($thread['visible'] == -2)
+	{
+		redirect("usercp.php?action=drafts", $lang->redirect_pollposted_draft);
+	}
 	else
 	{
 		redirect(get_forum_link($thread['fid']), $lang->redirect_pollpostedmoderated);
@@ -384,7 +397,16 @@ if($mybb->input['action'] == "editpoll")
 
 	// Make navigation
 	build_forum_breadcrumb($fid);
-	add_breadcrumb(htmlspecialchars_uni($thread['subject']), get_thread_link($thread['tid']));
+
+	if($thread['visible'] == -2)
+	{
+		add_breadcrumb(htmlspecialchars_uni($thread['subject']), "usercp.php?action=drafts");
+	}
+	else
+	{
+		add_breadcrumb(htmlspecialchars_uni($thread['subject']), get_thread_link($thread['tid']));
+	}
+
 	add_breadcrumb($lang->nav_editpoll);
 
 	$forumpermissions = forum_permissions($fid);
@@ -765,7 +787,7 @@ if($mybb->input['action'] == "showresults")
 
 	$tid = $poll['tid'];
 	$thread = get_thread($tid);
-	if(!$thread || ($thread['visible'] != 1 && ($thread['visible'] == 0 && !is_moderator($thread['fid'], "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($thread['fid'], "canviewdeleted"))))
+	if(!$thread || $thread['visible'] == -2 || ($thread['visible'] != 1 && ($thread['visible'] == 0 && !is_moderator($thread['fid'], "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($thread['fid'], "canviewdeleted"))))
 	{
 		error($lang->error_invalidthread);
 	}
@@ -790,7 +812,16 @@ if($mybb->input['action'] == "showresults")
 
 	// Make navigation
 	build_forum_breadcrumb($fid);
-	add_breadcrumb(htmlspecialchars_uni($thread['subject']), get_thread_link($thread['tid']));
+
+	if($thread['visible'] == -2)
+	{
+		add_breadcrumb(htmlspecialchars_uni($thread['subject']), "usercp.php?action=drafts");
+	}
+	else
+	{
+		add_breadcrumb(htmlspecialchars_uni($thread['subject']), get_thread_link($thread['tid']));
+	}
+
 	add_breadcrumb($lang->nav_pollresults);
 
 	$voters = $votedfor = $guest_voters = array();
@@ -946,7 +977,7 @@ if($mybb->input['action'] == "vote" && $mybb->request_method == "post")
 
 	$thread = get_thread($poll['tid']);
 
-	if(!$thread || ($thread['visible'] != 1 && ($thread['visible'] == 0 && !is_moderator($thread['fid'], "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($thread['fid'], "canviewdeleted"))))
+	if(!$thread || $thread['visible'] == -2 || ($thread['visible'] != 1 && ($thread['visible'] == 0 && !is_moderator($thread['fid'], "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($thread['fid'], "canviewdeleted"))))
 	{
 		error($lang->error_invalidthread);
 	}
@@ -1118,7 +1149,7 @@ if($mybb->input['action'] == "do_undovote")
 	// We do not have $forum_cache available here since no forums permissions are checked in undo vote
 	// Get thread ID and then get forum info
 	$thread = get_thread($poll['tid']);
-	if(!$thread || ($thread['visible'] != 1 && ($thread['visible'] == 0 && !is_moderator($thread['fid'], "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($thread['fid'], "canviewdeleted"))))
+	if(!$thread || $thread['visible'] == -2 || ($thread['visible'] != 1 && ($thread['visible'] == 0 && !is_moderator($thread['fid'], "canviewunapprove")) || ($thread['visible'] == -1 && !is_moderator($thread['fid'], "canviewdeleted"))))
 	{
 		error($lang->error_invalidthread);
 	}

--- a/usercp.php
+++ b/usercp.php
@@ -2756,7 +2756,7 @@ if($mybb->input['action'] == "drafts")
 	if($draftCount)
 	{
 		$query = $db->query("
-			SELECT p.subject, p.pid, t.tid, t.subject AS threadsubject, t.fid, f.name AS forumname, p.dateline, t.visible AS threadvisible, p.visible AS postvisible
+			SELECT p.subject, p.pid, t.tid, t.subject AS threadsubject, t.fid, f.name AS forumname, p.dateline, t.visible AS threadvisible, p.visible AS postvisible, t.poll, t.firstpost
 			FROM ".TABLE_PREFIX."posts p
 			LEFT JOIN ".TABLE_PREFIX."threads t ON (t.tid=p.tid)
 			LEFT JOIN ".TABLE_PREFIX."forums f ON (f.fid=t.fid)
@@ -2778,6 +2778,15 @@ if($mybb->input['action'] == "drafts")
 					$draft['editurl'] = "newthread.php?action=editdraft&amp;tid={$draft['tid']}";
 					$draft['type'] = 'thread';
 				}
+			}
+
+			if($draft['firstpost'] != $draft['pid'])
+			{
+				$draft['poll'] = 0;
+			}
+			else
+			{
+				$draft['canmanagepolls'] = is_moderator($draft['fid'], "canmanagepolls");
 			}
 
 			$drafts[] = $draft;


### PR DESCRIPTION
Partially implements #5312

This adds an indicator to thread drafts with existing polls (styling may be changed as work on #5312 progress).

<img width="706" height="87" alt="image" src="https://github.com/user-attachments/assets/2c5a02a0-1f3d-4f06-a795-57790d8dff9e" />

<details>
<summary>Generative AI Summary (Le Chat)</summary>
This feature allows authors to create polls for draft threads, ensuring a consistent save-edit-post flow and preventing premature visibility of polls. Polls attached to draft threads are only accessible by the thread author for editing. When the draft is posted, the poll becomes accessible to users normally. The draft list UI includes a "Has poll" indicator for drafts with a poll definition. Moderators can edit draft polls, but no votes can be cast while the draft is still a draft. The feature maintains backward compatibility, leaving live drafts and live polls unchanged. The testing plan includes creating a draft with a poll, editing the draft poll, and publishing the draft to ensure the poll is visible and functional.
</details>