### PR TITLE
Refactor moderation redirects to use unified redirect function

### DIFF
--- a/moderation.php
+++ b/moderation.php
@@ -3612,20 +3612,6 @@ function is_moderator_by_tids($threads, $permission = '')
 function moderation_redirect($url, $message = "", $title = "")
 {
 	global $mybb;
-	if(!empty($mybb->input['url']))
-	{
-		$url = htmlentities($mybb->input['url']);
-	}
 
-	if(my_strpos($url, $mybb->settings['bburl'].'/') !== 0)
-	{
-		if(my_strpos($url, '/') === 0)
-		{
-			$url = my_substr($url, 1);
-		}
-		$url_segments = explode('/', $url);
-		$url = $mybb->settings['bburl'].'/'.end($url_segments);
-	}
-
-	redirect($url, $message, $title);
+	redirect($mybb->get_input('url') === '' ? $url : $mybb->get_input('url'), $message, $title);
 }


### PR DESCRIPTION
Since 1.8 (perhaps 1.6), plugins may modify the forum URLs (i.e: Google SEO plugin), which have highlighted some fundamental issues with MyBB that, though not necessarily a problem in-core, conflict with the flexibility than plugins should have to modify the default app behavior.

When using complex URL schemas like `https://mybb/thread?forum/name/thread-prefix-subject` the redirection on `moderation.php` breaks.

More so, the usage of `htmlentities` needs to be removed for 1.9, otherwise the URL is incorrectly encoded because of the process in `moderation_redirect()`.

This process is superfluous and unnecessary, and thus fixing it causes no issue in core regardless of plugins.

<details>
<summary>Generative AI Summary (Le Chat)</summary>
This change simplifies the `moderation_redirect` function by removing redundant URL normalization and encoding, directly using the input URL if available. The previous implementation had issues with unnecessary `htmlentities()` application and flawed URL reconstruction logic. The new approach uses a straightforward null coalescing operator to determine the URL and relies on the underlying `redirect()` function to handle the URL appropriately. This patch improves code maintainability and fixes potential errors in URL handling. Testing involves verifying redirects with no user input, relative paths, absolute URLs, and special characters. The change has low risk and is backward compatible, as it removes incorrect behavior and aligns with expected redirect semantics. No documentation changes are required.
</details>