### PR TITLE
Add hooks for latest threads in portal to enhance plugin integration

### DIFF
--- a/portal.php
+++ b/portal.php
@@ -355,16 +355,29 @@ if($mybb->settings['portal_showdiscussions'] != 0 && $mybb->settings['portal_sho
 		$excludeforums = "AND t.fid NOT IN ({$mybb->settings['portal_excludediscussion']})";
 	}
 
-	$query = $db->query("
-        SELECT t.tid, t.fid, t.uid, t.lastpost, t.lastposteruid, t.lastposter, t.subject, t.replies, t.views, u.username
-        FROM ".TABLE_PREFIX."threads t
-        LEFT JOIN ".TABLE_PREFIX."users u ON (u.uid=t.uid)
-        WHERE 1=1 {$excludeforums}{$tunviewwhere} AND t.visible='1' AND t.moved='0'
-        ORDER BY t.lastpost DESC
-        LIMIT 0, ".$mybb->settings['portal_showdiscussionsnum']
-	);
+    $latest_threads_fetch_query_definition = [
+        "tables" => "threads t LEFT JOIN ".TABLE_PREFIX."users u ON (u.uid=t.uid)",
+        "fields" => 't.tid, t.fid, t.uid, t.lastpost, t.lastposteruid, t.lastposter, t.subject, t.replies, t.views, u.username',
+        "where" => "1=1 {$excludeforums}{$tunviewwhere} AND t.visible='1' AND t.moved='0'",
+        "options" => [
+            "order_by" => "t.lastpost DESC",
+            "limit" => $mybb->settings['portal_showdiscussionsnum'],
+            "limit_start" => 0,
+        ],
+    ];
+
+    $plugins->run_hooks('portal_latest_threads');
+
+    $query = $db->simple_select(
+        $latest_threads_fetch_query_definition['tables'],
+        $latest_threads_fetch_query_definition['fields'],
+        $latest_threads_fetch_query_definition['where'],
+        $latest_threads_fetch_query_definition['options'],
+    );
 	while($thread = $db->fetch_array($query))
 	{
+		$plugins->run_hooks('portal_latest_threads_thread', $thread);
+
 		$forumpermissions[$thread['fid']] = forum_permissions($thread['fid']);
 
 		// Make sure we can view this thread


### PR DESCRIPTION
Since 1.6 plugins need to apply _nasty_ hacks or workarounds (i.e: `control_db` or `control_object`) to be able to modify the query for the portal latest threads content.

Adding a new hook `portal_latest_threads` before the query of threads to manipulate would allow plugins to dynamically modify the where clauses for the rendered threads based on custom conditions or settings.

Additionally, `portal_latest_threads_thread` would allow for plugins to dynamically parse fetched content before it is rendered to the user.

Part of #5313

<details>
<summary>Generative AI Summary (Le Chat)</summary>
This patch introduces two new plugin hooks in `portal.php` to customize the latest threads displayed on the portal page. The first hook, `portal_latest_threads`, is placed before the thread query and passes a structured `$query_definition` array containing SQL components (fields, joins, where clause, order by) by reference, allowing plugins to modify any part of the query. The second hook, `portal_latest_threads_thread`, is called for each fetched thread, passing the thread data by reference for per-thread manipulation. These hooks address the previous limitation of hard-coded SQL queries, enabling plugins to extend portal functionality cleanly and safely. The design ensures backward compatibility and minimal performance impact, with risks mitigated by plugin author responsibility. Testing involves verifying default behavior, hook presence, and modifications to query components and thread data. Documentation will cover the purpose and usage of each hook, emphasizing secure coding practices.
</details>