### PR TITLE
Add `syndication_get_posts_before` and `syndication_post` hooks for syndication

### DIFF
--- a/syndication.php
+++ b/syndication.php
@@ -154,8 +154,27 @@ if(!empty($onlyusfids))
 	$permsql .= "AND ((fid IN(".implode(',', $onlyusfids).") AND uid='{$mybb->user['uid']}') OR fid NOT IN(".implode(',', $onlyusfids)."))";
 }
 
+$threads_fetch_query_definition = [
+    "tables" => "threads",
+    "fields" => 'subject, tid, dateline, firstpost',
+    "where" => "visible='1' AND moved='0' {$permsql} {$forumlist}",
+    "options" => [
+        "order_by" => "dateline",
+        "order_dir" => "desc",
+        "limit" => $thread_limit,
+    ],
+];
+
+$plugins->run_hooks('syndication_get_posts_before');
+
 // Get the threads to syndicate.
-$query = $db->simple_select("threads", "subject, tid, dateline, firstpost", "visible='1' AND moved='0' {$permsql} {$forumlist}", array('order_by' => 'dateline', 'order_dir' => 'DESC', 'limit' => $thread_limit));
+$query = $db->simple_select(
+    $threads_fetch_query_definition['tables'],
+    $threads_fetch_query_definition['fields'],
+    $threads_fetch_query_definition['where'],
+    $threads_fetch_query_definition['options'],
+);
+
 // Loop through all the threads.
 while($thread = $db->fetch_array($query))
 {
@@ -191,6 +210,8 @@ if(!empty($firstposts))
 	$query = $db->simple_select("posts", "message, edittime, tid, uid, username, fid, pid", $firstpostlist, array('order_by' => 'dateline DESC, pid DESC'));
 	while($post = $db->fetch_array($query))
 	{
+		$plugins->run_hooks('syndication_post', $post);
+
 		$parser_options = array(
 			"allow_html" => $forumcache[$post['fid']]['allowhtml'],
 			"allow_mycode" => $forumcache[$post['fid']]['allowmycode'],


### PR DESCRIPTION
Since 1.6 plugins need to apply _nasty_ hacks or workarounds (i.e: `control_db` or `control_object`) to be able to modify the query for the syndication content.

Adding a new hook `syndication_get_posts_before` before the query of threads to manipulate would allow plugins to dynamically modify the where clauses for the rendered threads based on custom conditions or settings.

Additionally, `syndication_post` would allow for plugins to dynamically parse fetched content before it is rendered to the user.

Part of #5313

<details>
<summary>Generative AI Summary (Le Chat)</summary>
This change introduces two new hooks in `syndication.php`: `syndication_get_posts_before` and `syndication_post`. The first hook allows plugins to modify the main thread query before execution, by altering a `$query_definition` array that includes the table, fields, WHERE clause, and query options. The second hook enables per-post manipulation during feed generation, by passing the `$post` array by reference. These hooks address the previous limitation of hard-coded syndication feed logic, providing a clean way for plugins to customize feed content without brittle workarounds. The design ensures backward compatibility and low risk, as the default behavior remains unchanged unless modified by plugins. Testing involves verifying default behavior, query and post modifications, and combined usage of both hooks. Documentation will cover the purpose and usage of each hook, emphasizing the need for secure coding practices.
</details>