### PR TITLE
Implement pre-hook for portal announcements query

### DIFF
--- a/portal.php
+++ b/portal.php
@@ -450,7 +450,13 @@ if(!empty($mybb->settings['portal_announcementsfid']))
 		}
 	}
 
-	$query = $db->simple_select("threads t", "COUNT(t.tid) AS threads", "t.visible='1'{$annfidswhere}{$tunviewwhere} AND t.moved='0'", array('limit' => 1));
+	$query_definition = [
+		"where" => "t.visible='1'{$annfidswhere}{$tunviewwhere} AND t.moved='0'",
+	];
+
+	$plugins->run_hooks('portal_announcements_start', $query_definition);
+
+	$query = $db->simple_select("threads t", "COUNT(t.tid) AS threads", $query_definition['where'], array('limit' => 1));
 	$announcementcount = $db->fetch_field($query, "threads");
 
 	$numannouncements = (int)$mybb->settings['portal_numannouncements'];
@@ -488,7 +494,7 @@ if(!empty($mybb->settings['portal_announcementsfid']))
         SELECT p.pid, p.message, p.tid, p.smilieoff, t.attachmentcount
         FROM ".TABLE_PREFIX."posts p
         LEFT JOIN ".TABLE_PREFIX."threads t ON (t.tid=p.tid)
-        WHERE t.visible='1'{$annfidswhere}{$tunviewwhere} AND t.moved='0' AND t.firstpost=p.pid
+        WHERE {$query_definition['where']} AND t.firstpost=p.pid
         ORDER BY t.dateline DESC
         LIMIT {$start}, {$numannouncements}"
 	);


### PR DESCRIPTION
Since 1.6 plugins need to apply _nasty_ hacks or workarounds (i.e: `control_db` or `control_object`) to be able to modify the query for the portal announcements.

More so, because of the changes in 1.9, some of these workarounds may not work at all anymore.

Adding a new hook `portal_announcements_start` before the count of threads to manipulate would allow plugins to dynamically modify the where clauses for the portal announcements based on custom conditions or settings.

Part of #5313

<details>
<summary>Generative AI Summary (Le Chat)</summary>
This change introduces a new hook, `portal_announcements_start`, in `portal.php` to allow plugins to modify the WHERE clause used when fetching announcements on the portal page. Previously, the SQL queries for counting and retrieving announcements were hard-coded, making it difficult for plugins to filter announcements without fragile workarounds. The new hook receives a `$query_definition` array with a `'where'` key containing the complete WHERE clause, enabling plugins to add or alter conditions. The same WHERE clause is used for both the count and data retrieval queries, ensuring consistency. The original WHERE clause includes visibility, forum restrictions, and permission checks. Plugins can append conditions or modify the logic, with examples showing how to filter announcements by date. The change is backward compatible and has low risk, as it only adds a hook without altering existing behavior. Testing involves verifying default behavior, hook invocation, and modifications to the WHERE clause. Documentation will include details about the hook and its usage, emphasizing the need for proper SQL escaping.
</details>