### PR TITLE
Add strict matching, corrections to type-dependent DB initialization

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -211,26 +211,32 @@ function run_shutdown()
 			require_once MYBB_ROOT . 'inc/AbstractPdoDbDriver.php';
 			require_once MYBB_ROOT . 'inc/DbException.php';
 
-			require_once MYBB_ROOT."inc/db_".$config['database']['type'].".php";
-			switch($config['database']['type'])
+			$db_type = $config['database']['type'];
+
+			if($db_type === 'mysql')
 			{
-				case "sqlite":
-					$db = new DB_SQLite;
-					break;
-				case "pgsql":
-					$db = new DB_PgSQL;
-					break;
-				case "pgsql_pdo":
-					$db = new PostgresPdoDbDriver();
-					break;
-				case "mysql_pdo":
-					$db = new MysqlPdoDbDriver();
-					break;
-				case "mysqli":
-				case "mysql":
-				default:
-					$db = new DB_MySQLi;
+				$db_type = 'mysqli';
 			}
+
+			try
+			{
+				$db_class = match($db_type)
+				{
+					'sqlite' => DB_SQLite::class,
+					'pgsql' => DB_PgSQL::class,
+					'pgsql_pdo' => PostgresPdoDbDriver::class,
+					'mysql_pdo' => MysqlPdoDbDriver::class,
+					'mysqli' => DB_MySQLi::class,
+				};
+			}
+			catch(UnhandledMatchError)
+			{
+				return;
+			}
+
+			require_once MYBB_ROOT."inc/db_".$db_type.".php";
+
+			$db = new $db_class();
 
 			$db->connect($config['database']);
 			if(!defined("TABLE_PREFIX"))

--- a/inc/init.php
+++ b/inc/init.php
@@ -131,27 +131,32 @@ require_once MYBB_ROOT."inc/db_base.php";
 require_once MYBB_ROOT . 'inc/AbstractPdoDbDriver.php';
 require_once MYBB_ROOT . 'inc/DbException.php';
 
-require_once MYBB_ROOT."inc/db_".$config['database']['type'].".php";
+$db_type = $config['database']['type'];
 
-switch($config['database']['type'])
+if($db_type === 'mysql')
 {
-	case "sqlite":
-		$db = new DB_SQLite;
-		break;
-	case "pgsql":
-		$db = new DB_PgSQL;
-		break;
-	case "pgsql_pdo":
-		$db = new PostgresPdoDbDriver();
-		break;
-	case "mysql_pdo":
-		$db = new MysqlPdoDbDriver();
-		break;
-	case "mysqli":
-	case "mysql":
-	default:
-		$db = new DB_MySQLi;
+	$db_type = 'mysqli';
 }
+
+try
+{
+	$db_class = match($db_type)
+	{
+		'sqlite' => DB_SQLite::class,
+		'pgsql' => DB_PgSQL::class,
+		'pgsql_pdo' => PostgresPdoDbDriver::class,
+		'mysql_pdo' => MysqlPdoDbDriver::class,
+		'mysqli' => DB_MySQLi::class,
+	};
+}
+catch(UnhandledMatchError)
+{
+	$mybb->trigger_generic_error("sql_load_error");
+}
+
+require_once MYBB_ROOT."inc/db_".$db_type.".php";
+
+$db = new $db_class();
 
 // Check if our DB engine is loaded
 if(!extension_loaded($db->engine))
@@ -176,7 +181,7 @@ require_once MYBB_ROOT."inc/datahandler.php";
 define("TABLE_PREFIX", $config['database']['table_prefix']);
 $db->connect($config['database']);
 $db->set_table_prefix(TABLE_PREFIX);
-$db->type = $config['database']['type'];
+$db->type = $db_type;
 
 // Language initialisation
 require_once MYBB_ROOT."inc/class_language.php";

--- a/inc/src/Maintenance/functions_core.php
+++ b/inc/src/Maintenance/functions_core.php
@@ -62,6 +62,11 @@ function getCorrectedConfigurationFileData(array $config): array
         $config['database']['type'] = 'sqlite';
     }
 
+    // removed in MyBB 1.9
+    if ($config['database']['type'] === 'mysql') {
+        $config['database']['type'] = 'mysqli';
+    }
+
     return $config;
 }
 

--- a/inc/src/Maintenance/functions_core.php
+++ b/inc/src/Maintenance/functions_core.php
@@ -13,6 +13,7 @@ use DB_Base;
 use Illuminate\Support\Str;
 use MyBB;
 use MyLanguage;
+use UnhandledMatchError;
 
 use function MyBB\app;
 
@@ -90,36 +91,36 @@ function getConfigurationFileModificationTime(): ?int
 
 function connectToDatabase(array $config): ?DB_Base
 {
-    $path = MYBB_ROOT . "inc/db_{$config['database']['type']}.php";
-
-    if (!file_exists($path)) {
-        return null;
-    } else {
-        require_once $path;
-
-        $db = match ($config['database']['type']) {
-            'sqlite' => new \DB_SQLite(),
-            'pgsql' => new \DB_PgSQL(),
-            'pgsql_pdo' => new \PostgresPdoDbDriver(),
-            'mysql_pdo' => new \MysqlPdoDbDriver(),
-            default => new \DB_MySQLi(),
+    try {
+        $db_class = match ($config['database']['type']) {
+            'sqlite' => \DB_SQLite::class,
+            'pgsql' => \DB_PgSQL::class,
+            'pgsql_pdo' => \PostgresPdoDbDriver::class,
+            'mysql_pdo' => \MysqlPdoDbDriver::class,
+            'mysqli' => \DB_MySQLi::class,
         };
-
-        // Connect to Database
-        if (!defined('TABLE_PREFIX')) {
-            define('TABLE_PREFIX', $config['database']['table_prefix']);
-        }
-
-        try {
-            $db->connect($config['database']);
-            $db->set_table_prefix(TABLE_PREFIX);
-            $db->type = $config['database']['type'];
-        } catch (\Exception) {
-            $db = null;
-        }
-
-        return $db;
+    } catch (UnhandledMatchError) {
+        return null;
     }
+
+    require_once MYBB_ROOT . "inc/db_{$config['database']['type']}.php";
+
+    $db = new $db_class();
+
+    // Connect to Database
+    if (!defined('TABLE_PREFIX')) {
+        define('TABLE_PREFIX', $config['database']['table_prefix']);
+    }
+
+    try {
+        $db->connect($config['database']);
+        $db->set_table_prefix(TABLE_PREFIX);
+        $db->type = $config['database']['type'];
+    } catch (\Exception) {
+        $db = null;
+    }
+
+    return $db;
 }
 
 function getCache(): ?datacache

--- a/inc/src/Maintenance/functions_db.php
+++ b/inc/src/Maintenance/functions_db.php
@@ -490,7 +490,11 @@ function getDatabaseHandle(bool $persistent = false): ?DB_Base
     if (isset($GLOBALS['db'])) {
         $db = $GLOBALS['db'];
     } else {
-        $config = $GLOBALS['config'] ?? getConfigurationFileData();
+        if (isset($GLOBALS['config'])) {
+            $config = getCorrectedConfigurationFileData($GLOBALS['config']);
+        } else {
+            $config = getConfigurationFileData(true);
+        }
 
         if ($config !== null) {
             $db = connectToDatabase($config);


### PR DESCRIPTION
Changes `switch` with potentially incorrect fallback and uncontrolled file inclusion to `match`, with added corrections to account for #4551.

Related:
- #5319