### PR TITLE
Fix: Auto-start PHP development server in CodeSpace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,5 @@
     },
     "forwardPorts": [8080],
     "postCreateCommand": "echo 'export PATH=/usr/local/php/current/bin:$PATH' >> ~/.bashrc",
-    "postStartCommand": "bash .devcontainer/mybb-install.sh && nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &"
+    "postStartCommand": "bash .devcontainer/mybb-install.sh && (nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &)"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,5 @@
     },
     "forwardPorts": [8080],
     "postCreateCommand": "echo 'export PATH=/usr/local/php/current/bin:$PATH' >> ~/.bashrc",
-    "postStartCommand": "bash .devcontainer/mybb-install.sh && php -S 0.0.0.0:8080"
+    "postStartCommand": "bash .devcontainer/mybb-install.sh && nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &"
 }


### PR DESCRIPTION
## Description

Fixes the issue where the PHP development server wasn't automatically starting when opening the repository in GitHub Codespaces.

## Changes

- Modified `.devcontainer/devcontainer.json` to run the PHP development server in the background using `nohup`
- Changed `postStartCommand` to run: `bash .devcontainer/mybb-install.sh && nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &`

## Why?

Previously, `php -S 0.0.0.0:8080` was a blocking command that would hang the terminal initialization. By using `nohup` and `&`, the server now runs in the background, allowing the terminal to initialize properly while the PHP development server continues running.

## Testing

- [x] PHP server starts automatically when CodeSpace opens
- [x] Application is accessible on `http://localhost:8080`
- [x] Server logs are available in `/tmp/php-server.log`