### PR TITLE
Use setsid for devcontainer PHP process

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,5 @@
     },
     "forwardPorts": [8080],
     "postCreateCommand": "echo 'export PATH=/usr/local/php/current/bin:$PATH' >> ~/.bashrc",
-    "postStartCommand": "bash .devcontainer/mybb-install.sh && (nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &)"
+    "postStartCommand": "bash .devcontainer/mybb-install.sh && exec php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1"
 }


### PR DESCRIPTION
### Changed

- Start PHP server in foreground with `setsid` to ensure it remains running in Codespaces.

Following #5333 