### PR TITLE
Ensure devcontainer PHP server is ready before exiting postStartCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,5 @@
     },
     "forwardPorts": [8080],
     "postCreateCommand": "echo 'export PATH=/usr/local/php/current/bin:$PATH' >> ~/.bashrc",
-    "postStartCommand": "bash .devcontainer/mybb-install.sh && (nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &)"
+    "postStartCommand": "bash .devcontainer/mybb-install.sh && (nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &) && until curl -fsS http://127.0.0.1:8080/ >/dev/null; do sleep 1; done"
 }


### PR DESCRIPTION
### Added

- Ensured PHP server is running before exiting `postStartCommand`.

Following #5333 