### PR TITLE
Enforce 'canbeinvisible' permission in UserCP (Logic & UI)

### DIFF
--- a/inc/themes/core.base/frontend/templates/usercp/options.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/options.twig
@@ -21,7 +21,9 @@
                 <h2 class="title title--section">{{ lang.login_cookies_privacy }}</h2>
                 <div class="section__container">
                     <div class="row row--form field">
-                        <p class="option-field option-field--compact"><label><input type="checkbox" class="checkbox" name="invisible" id="invisible" value="1"{% if user.invisible %} checked{% endif %} /> {{ lang.invisible_mode }}</label></p>
+                        {% if mybb.usergroup.canbeinvisible %}
+                            <p class="option-field option-field--compact"><label><input type="checkbox" class="checkbox" name="invisible" id="invisible" value="1"{% if user.invisible %} checked{% endif %} /> {{ lang.invisible_mode }}</label></p>
+                        {% endif %}
                         <p class="option-field option-field--compact"><label><input type="checkbox" class="checkbox" name="showtimespentonline" id="showtimespentonline" value="1"{% if user.showtimespentonline %} checked{% endif %} /> {{ lang.show_time_spent_online }}</label></p>
                     </div>
                 </div>

--- a/usercp.php
+++ b/usercp.php
@@ -414,10 +414,10 @@ if($mybb->input['action'] == "do_options" && $mybb->request_method == "post")
 	));
 
 	$user['options'] = array(
+		"invisible" => 0,
 		"allownotices" => $mybb->get_input('allownotices', MyBB::INPUT_INT),
 		"hideemail" => $mybb->get_input('hideemail', MyBB::INPUT_INT),
 		"subscriptionmethod" => $mybb->get_input('subscriptionmethod', MyBB::INPUT_INT),
-		"invisible" => $mybb->get_input('invisible', MyBB::INPUT_INT),
 		"showtimespentonline" => $mybb->get_input('showtimespentonline', MyBB::INPUT_INT),
 		"dstcorrection" => $mybb->get_input('dstcorrection', MyBB::INPUT_INT),
 		"threadmode" => $mybb->get_input('threadmode'),
@@ -438,6 +438,11 @@ if($mybb->input['action'] == "do_options" && $mybb->request_method == "post")
 		"showredirect" => $mybb->get_input('showredirect', MyBB::INPUT_INT),
 		"classicpostbit" => $mybb->get_input('classicpostbit', MyBB::INPUT_INT)
 	);
+
+	if($mybb->usergroup['canbeinvisible'] == 1)
+	{
+	    $user['options']['invisible'] = $mybb->get_input('invisible', MyBB::INPUT_INT);
+	}
 
 	if($mybb->settings['usertppoptions'])
 	{

--- a/usercp.php
+++ b/usercp.php
@@ -441,7 +441,7 @@ if($mybb->input['action'] == "do_options" && $mybb->request_method == "post")
 
 	if($mybb->usergroup['canbeinvisible'] == 1)
 	{
-	    $user['options']['invisible'] = $mybb->get_input('invisible', MyBB::INPUT_INT);
+		$user['options']['invisible'] = $mybb->get_input('invisible', MyBB::INPUT_INT);
 	}
 
 	if($mybb->settings['usertppoptions'])


### PR DESCRIPTION
**Description:**
This PR addresses a missing permission check in the User Control Panel. Currently, a user can manually send a POST request to enable "Invisible Mode" even if their usergroup does not have the `canbeinvisible` permission.

**Changes:**
- Backend (usercp.php): Added a logic check to ensure the invisible status is only updated if the user's group has the required permission. It now defaults to 0 if the permission is missing.
- Frontend (Template): Wrapped the invisible mode option with an if condition to hide it from users who are not allowed to use it.

**Why this is important:**
- Prevents users from bypassing group restrictions via simple HTML manipulation or manual POST requests.
- Improves UX by not showing options that the user cannot actually change.

**Testing:**
- Verified that the option is hidden when canbeinvisible is set to 0.
- Verified that manual POST requests to usercp.php?action=do_options do not update the invisible field without permission.

Closes #5339