### PR TITLE
Prevent PM folder tampering to preserve non-removable defaults

### DIFF
--- a/private.php
+++ b/private.php
@@ -1556,6 +1556,7 @@ if($mybb->input['action'] == "do_folders" && $mybb->request_method == "post")
 	$folders = '';
 	$donefolders = array();
 	$mybb->input['folder'] = $mybb->get_input('folder', MyBB::INPUT_ARRAY);
+	$mybb->input['folder'] = array_replace(array_fill_keys(range(0, 4), ''), $mybb->input['folder']);
 	foreach($mybb->input['folder'] as $key => $val)
 	{
 		if(empty($donefolders[$val]) )// Probably was a check for duplicate folder names, but doesn't seem to be used now


### PR DESCRIPTION
### Changed

- Added a safeguard to prevent tampered PM folder update requests from removing non-removable default folders (IDs 0-4).
 
Resolves #3729

