### PR TITLE
Fix #5267: Remove empty avatar margin when avatars are disabled

### DIFF
--- a/inc/themes/core.base/frontend/templates/postbit/postbit.twig
+++ b/inc/themes/core.base/frontend/templates/postbit/postbit.twig
@@ -46,7 +46,7 @@
 {% endif %}
 
 {# Post bit #}
-<div class="post {{ post.unapproved_shade }}" style="{{ post.visibility }}" id="post_{{ post.pid }}">
+<div class="post {{ post.unapproved_shade }} {% if not post.showavatar %}post--no-avatar{% endif %}" style="{{ post.visibility }}" id="post_{{ post.pid }}">
     <div class="post__meta">
         {# Author avatar #}
         {% if post.showavatar %}


### PR DESCRIPTION
Resolves #5267

Summary
This PR resolves the issue where an empty space is left in the postbit when avatars are disabled. Currently, even if avatars are not displayed, the layout retains the left margin intended for the avatar, which results in wasted space and a misaligned look.

Changes

Templates: Modified postbit to conditionally apply the .post--no-avatar class when post.showavatar is false.

Technical Details
The current CSS uses a fixed margin on the .post container to make room for the avatar which is positioned via negative margins. By adding the .post--no-avatar class, we effectively negate these margins only when the avatar is absent, preventing any "ghost" spacing.