### PR TITLE
Fix logic flaw in usercp.php regarding 'invisible' status permission validation

### DIFF
--- a/usercp.php
+++ b/usercp.php
@@ -785,7 +785,7 @@ if($mybb->input['action'] == "do_options" && $mybb->request_method == "post")
 		"allownotices" => $mybb->get_input('allownotices', MyBB::INPUT_INT),
 		"hideemail" => $mybb->get_input('hideemail', MyBB::INPUT_INT),
 		"subscriptionmethod" => $mybb->get_input('subscriptionmethod', MyBB::INPUT_INT),
-		"invisible" => $mybb->get_input('invisible', MyBB::INPUT_INT),
+		"invisible" => 0,
 		"dstcorrection" => $mybb->get_input('dstcorrection', MyBB::INPUT_INT),
 		"threadmode" => $mybb->get_input('threadmode'),
 		"showimages" => $mybb->get_input('showimages', MyBB::INPUT_INT),
@@ -805,6 +805,11 @@ if($mybb->input['action'] == "do_options" && $mybb->request_method == "post")
 		"showredirect" => $mybb->get_input('showredirect', MyBB::INPUT_INT),
 		"classicpostbit" => $mybb->get_input('classicpostbit', MyBB::INPUT_INT)
 	);
+
+	if($mybb->usergroup['canbeinvisible'] == 1)
+	{
+		$user['options']['invisible'] = $mybb->get_input('invisible', MyBB::INPUT_INT);
+	}
 
 	if($mybb->settings['usertppoptions'])
 	{


### PR DESCRIPTION
Set default value for 'invisible' option if usergroup allows it.

Resolves #5339 for 1.8

Currently, usercp.php updates a user's invisible status without verifying if their usergroup has the canbeinvisible permission. While the default MyBB 1.8 templates use conditional variables to hide the option in the UI, there is no backend validation. This allows users to bypass the restriction by sending direct POST requests or using custom themes that might have the option hardcoded.

This PR adds a backend check to ensure that the invisible status is only updated if the user has the required permission. If not, the value is forced to 0. This ensures consistent permission enforcement regardless of the theme or method used to submit the form.