### PR TITLE
Fix #5292: Add error message when uploading avatar while avatar is suspended

### DIFF
--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -631,123 +631,132 @@ if($mybb->input['action'] == "edit")
 			// Are we uploading a new avatar?
 			if($_FILES['avatar_upload']['name'])
 			{
-				if($user['suspendavatar'])
+				if($mybb->get_input('suspendavatar'))
 				{
-					flash_message($lang->suspendavatar_upload_error, 'error');
-					admin_redirect("index.php?module=user-users&action=edit&uid={$user['uid']}");
-				}
-				$avatar = upload_avatar($_FILES['avatar_upload'], $user['uid']);
-				if($avatar['error'])
-				{
-					$errors = array($avatar['error']);
+					$errors[] = $lang->suspendavatar_upload_error;
 				}
 				else
 				{
-					if($avatar['width'] > 0 && $avatar['height'] > 0)
+					$avatar = upload_avatar($_FILES['avatar_upload'], $user['uid']);
+					if($avatar['error'])
 					{
-						$avatar_dimensions = $avatar['width']."|".$avatar['height'];
+						$errors = array($avatar['error']);
 					}
-					$extra_user_updates = array(
-						"avatar" => $avatar['avatar'].'?dateline='.TIME_NOW,
-						"avatardimensions" => $avatar_dimensions,
-						"avatartype" => "upload"
-					);
+					else
+					{
+						if($avatar['width'] > 0 && $avatar['height'] > 0)
+						{
+							$avatar_dimensions = $avatar['width']."|".$avatar['height'];
+						}
+						$extra_user_updates = array(
+							"avatar" => $avatar['avatar'].'?dateline='.TIME_NOW,
+							"avatardimensions" => $avatar_dimensions,
+							"avatartype" => "upload"
+						);
+					}
 				}
 			}
 			// Are we setting a new avatar from a URL?
 			else if(!empty($mybb->input['avatar_url']) && $mybb->input['avatar_url'] != $user['avatar'])
 			{
-				if(!$mybb->settings['allowremoteavatars'])
+				if($mybb->get_input('suspendavatar'))
 				{
-					$errors = array($lang->error_remote_avatar_not_allowed);
+					$errors[] = $lang->suspendavatar_upload_error;
 				}
 				else
 				{
-					if(filter_var($mybb->input['avatar_url'], FILTER_VALIDATE_EMAIL) !== false)
+					if(!$mybb->settings['allowremoteavatars'])
 					{
-						// Gravatar
-						$email = md5(strtolower(trim($mybb->input['avatar_url'])));
-
-						$s = '';
-						if(!$mybb->settings['maxavatardims'])
-						{
-							$mybb->settings['maxavatardims'] = '100x100'; // Hard limit of 100 if there are no limits
-						}
-
-						// Because Gravatars are square, hijack the width
-						list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
-
-						$s = "?s={$maxwidth}";
-						$maxheight = (int)$maxwidth;
-
-						$extra_user_updates = array(
-							"avatar" => "https://www.gravatar.com/avatar/{$email}{$s}",
-							"avatardimensions" => "{$maxheight}|{$maxheight}",
-							"avatartype" => "gravatar"
-						);
+						$errors = array($lang->error_remote_avatar_not_allowed);
 					}
 					else
 					{
-						$mybb->input['avatar_url'] = preg_replace("#script:#i", "", $mybb->input['avatar_url']);
-						$ext = get_extension($mybb->input['avatar_url']);
-
-						// Copy the avatar to the local server (work around remote URL access disabled for getimagesize)
-						$file = fetch_remote_file($mybb->input['avatar_url']);
-						if(!$file)
+						if(filter_var($mybb->input['avatar_url'], FILTER_VALIDATE_EMAIL) !== false)
 						{
-							$avatar_error = $lang->error_invalidavatarurl;
+							// Gravatar
+							$email = md5(strtolower(trim($mybb->input['avatar_url'])));
+
+							$s = '';
+							if(!$mybb->settings['maxavatardims'])
+							{
+								$mybb->settings['maxavatardims'] = '100x100'; // Hard limit of 100 if there are no limits
+							}
+
+							// Because Gravatars are square, hijack the width
+							list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
+
+							$s = "?s={$maxwidth}";
+							$maxheight = (int)$maxwidth;
+
+							$extra_user_updates = array(
+								"avatar" => "https://www.gravatar.com/avatar/{$email}{$s}",
+								"avatardimensions" => "{$maxheight}|{$maxheight}",
+								"avatartype" => "gravatar"
+							);
 						}
 						else
 						{
-							$tmp_name = "../".$mybb->settings['avataruploadpath']."/remote_".md5(random_str());
-							$fp = @fopen($tmp_name, "wb");
-							if(!$fp)
+							$mybb->input['avatar_url'] = preg_replace("#script:#i", "", $mybb->input['avatar_url']);
+							$ext = get_extension($mybb->input['avatar_url']);
+
+							// Copy the avatar to the local server (work around remote URL access disabled for getimagesize)
+							$file = fetch_remote_file($mybb->input['avatar_url']);
+							if(!$file)
 							{
 								$avatar_error = $lang->error_invalidavatarurl;
 							}
 							else
 							{
-								fwrite($fp, $file);
-								fclose($fp);
-								list($width, $height, $type) = @getimagesize($tmp_name);
-								@unlink($tmp_name);
-								echo $type;
-								if(!$type)
+								$tmp_name = "../".$mybb->settings['avataruploadpath']."/remote_".md5(random_str());
+								$fp = @fopen($tmp_name, "wb");
+								if(!$fp)
 								{
 									$avatar_error = $lang->error_invalidavatarurl;
 								}
-							}
-						}
-
-						if(empty($avatar_error))
-						{
-							if($width && $height && $mybb->settings['maxavatardims'] != "")
-							{
-								list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
-								if(($maxwidth && $width > $maxwidth) || ($maxheight && $height > $maxheight))
+								else
 								{
-									$lang->error_avatartoobig = $lang->sprintf($lang->error_avatartoobig, $maxwidth, $maxheight);
-									$avatar_error = $lang->error_avatartoobig;
+									fwrite($fp, $file);
+									fclose($fp);
+									list($width, $height, $type) = @getimagesize($tmp_name);
+									@unlink($tmp_name);
+									echo $type;
+									if(!$type)
+									{
+										$avatar_error = $lang->error_invalidavatarurl;
+									}
 								}
 							}
-						}
 
-						if(empty($avatar_error))
-						{
-							if($width > 0 && $height > 0)
+							if(empty($avatar_error))
 							{
-								$avatar_dimensions = (int)$width."|".(int)$height;
+								if($width && $height && $mybb->settings['maxavatardims'] != "")
+								{
+									list($maxwidth, $maxheight) = preg_split('/[|x]/', my_strtolower($mybb->settings['maxavatardims']));
+									if(($maxwidth && $width > $maxwidth) || ($maxheight && $height > $maxheight))
+									{
+										$lang->error_avatartoobig = $lang->sprintf($lang->error_avatartoobig, $maxwidth, $maxheight);
+										$avatar_error = $lang->error_avatartoobig;
+									}
+								}
 							}
-							$extra_user_updates = array(
-								"avatar" => $db->escape_string($mybb->input['avatar_url'].'?dateline='.TIME_NOW),
-								"avatardimensions" => $avatar_dimensions,
-								"avatartype" => "remote"
-							);
-							remove_avatars($user['uid']);
-						}
-						else
-						{
-							$errors = array($avatar_error);
+
+							if(empty($avatar_error))
+							{
+								if($width > 0 && $height > 0)
+								{
+									$avatar_dimensions = (int)$width."|".(int)$height;
+								}
+								$extra_user_updates = array(
+									"avatar" => $db->escape_string($mybb->input['avatar_url'].'?dateline='.TIME_NOW),
+									"avatardimensions" => $avatar_dimensions,
+									"avatartype" => "remote"
+								);
+								remove_avatars($user['uid']);
+							}
+							else
+							{
+								$errors = array($avatar_error);
+							}
 						}
 					}
 				}

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -634,7 +634,7 @@ if($mybb->input['action'] == "edit")
 				if($user['suspendavatar'])
 				{
 					flash_message($lang->suspendavatar_upload_error, 'error');
-					admin_redirect("index.php?module=user-users");
+					admin_redirect("index.php?module=user-users&action=edit&uid={$user['uid']}");
 				}
 				$avatar = upload_avatar($_FILES['avatar_upload'], $user['uid']);
 				if($avatar['error'])

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -631,7 +631,7 @@ if($mybb->input['action'] == "edit")
 			// Are we uploading a new avatar?
 			if($_FILES['avatar_upload']['name'])
 			{
-				if($user['suspendavatar']
+				if($user['suspendavatar'])
 				{
 					flash_message($lang->suspendavatar_upload_error, 'error');
 					admin_redirect("index.php?module=user-users");

--- a/admin/modules/user/users.php
+++ b/admin/modules/user/users.php
@@ -631,6 +631,11 @@ if($mybb->input['action'] == "edit")
 			// Are we uploading a new avatar?
 			if($_FILES['avatar_upload']['name'])
 			{
+				if($user['suspendavatar']
+				{
+					flash_message($lang->suspendavatar_upload_error, 'error');
+					admin_redirect("index.php?module=user-users");
+				}
 				$avatar = upload_avatar($_FILES['avatar_upload'], $user['uid']);
 				if($avatar['error'])
 				{

--- a/inc/languages/english/admin/user_users.lang.php
+++ b/inc/languages/english/admin/user_users.lang.php
@@ -265,6 +265,7 @@ $l['suspend_pm'] = "Suspend private messaging";
 $l['suspend_pm_info'] = "Suspend {1} from sending and receiving new private messages.";
 
 $l['suspendavatar_error'] = "You selected to suspend this user's avatar privileges, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
+$l['suspendavatar_upload_error'] = "You are trying to upload a new avatar, but the 'Suspend Avatar' option is checked. Please untick this option to continue with the upload.";
 $l['suspendsignature_error'] = "You selected to suspend this user's signature, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['moderateposting_error'] = "You selected to moderate this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendposting_error'] = "You selected to suspend this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";

--- a/inc/languages/english/admin/user_users.lang.php
+++ b/inc/languages/english/admin/user_users.lang.php
@@ -265,7 +265,7 @@ $l['suspend_pm'] = "Suspend private messaging";
 $l['suspend_pm_info'] = "Suspend {1} from sending and receiving new private messages.";
 
 $l['suspendavatar_error'] = "You selected to suspend this user's avatar privileges, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
-$l['suspendavatar_upload_error'] = "You are trying to upload a new avatar, but the 'Suspend Avatar' option is checked. Please untick this option to continue with the upload.";
+$l['suspendavatar_upload_error'] = "You are trying to upload a new avatar, but avatar use is currently suspended. Please untick this option to continue with the upload.";
 $l['suspendsignature_error'] = "You selected to suspend this user's signature, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['moderateposting_error'] = "You selected to moderate this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";
 $l['suspendposting_error'] = "You selected to suspend this user's posts, but didn't enter a valid time period. Please enter a valid time to continue or untick the option to cancel.";


### PR DESCRIPTION
### Resolves
Closes #5292 

### Description
This PR addresses the silent failure issue that occurs when an admin attempts to upload a new avatar for a user while the "Suspend Avatar" option is checked in the AdminCP. 

Previously, the system would successfully upload the new avatar, but the subsequent moderation block would immediately delete it without throwing any errors, misleading the admin into thinking the process was entirely successful.

While the original issue suggested dynamically hiding the avatar tab using CSS, I believe a backend validation approach is much more robust and provides better UX by explicitly informing the admin of the conflict.

### Changes Made
* Added a new language string `suspendavatar_upload_error` to `admin/user_users.lang.php`.
* Added validation in `admin/modules/user/users.php` to check if an avatar file/URL is being submitted concurrently with the `suspendavatar` action. 
* If a conflict is detected, it now halts the process and throws an explicit inline error, prompting the admin to untick the suspend option before proceeding with the upload.