### PR TITLE
Use all supported PHP versions in PHPUnit

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
     phpunit:
       runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          php-versions: ['8.2', '8.3', '8.4', '8.5']
       steps:
           - name: Checkout
             uses: actions/checkout@v2
@@ -12,7 +15,7 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: '8.4'
+                php-version: ${{ matrix.php-versions }}
                 tools: composer:v2
 
           - name: Setup problem matchers for PHP
@@ -21,7 +24,7 @@ jobs:
             run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
           - name: Install dependencies
-            run: composer install --prefer-dist --no-progress --no-suggest
+            run: composer install --prefer-dist --no-progress
 
           - name: Set permissions
             run: chmod +x bin/cli

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
         "vendor-dir": "inc/vendor",
         "bin-dir": "inc/vendor/bin",
         "optimize-autoloader": true,
+        "platform": {
+            "php": "8.2"
+        },
         "sort-packages": true
     },
     "scripts": {


### PR DESCRIPTION
### Changed

- Enforced 8.2 in dependency resolution.
- Updated PHPUnit workflow to test 8.2->8.5.
- Removed the deprecated `--no-suggest` from composer install in the PHPUnit workflow.

Resolves #5327

