### PR TITLE
Allow filtering forum threads by clicking thread prefixes

### DIFF
--- a/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
+++ b/inc/themes/core.base/frontend/templates/forumdisplay/thread.twig
@@ -7,7 +7,9 @@
     <div class="thread__title">
         {# Thread prefix #}
         {% if thread.threadprefix %}
-            <span class="thread__prefix thread-prefix thread-prefix--prefix-{{ thread.prefix }}">{{ thread.threadprefix|raw }}</span>
+            <span class="thread__prefix thread-prefix thread-prefix--prefix-{{ thread.prefix }}">
+                <a href="{{ url(get_forum_link(thread.fid), {prefix: thread.prefix}) }}">{{ thread.threadprefix|raw }}</a>
+            </span>
         {% endif %}
         <h3 class="thread__subject">
             {# Thread title #}


### PR DESCRIPTION
### Added

- Added links to thread prefixes to allow quick filtering by prefix within the current forum.

Resolves #5294

