### PR TITLE
Allow configuring spiders display order in WOL

### DIFF
--- a/inc/seeds/settings.xml
+++ b/inc/seeds/settings.xml
@@ -1923,7 +1923,10 @@ min=0]]></optionscode>
 			<title>Who's Online Displays Spiders?</title>
 			<description><![CDATA[Display spiders in the online list. Note: This setting only takes effect on the portal and index pages.]]></description>
 			<disporder>5</disporder>
-			<optionscode><![CDATA[yesno]]></optionscode>
+			<optionscode><![CDATA[select
+0=Do not display spiders
+1=Display spiders before users
+2=Display spiders after users]]></optionscode>
 			<settingvalue><![CDATA[1]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>

--- a/inc/themes/core.base/frontend/templates/index/index.twig
+++ b/inc/themes/core.base/frontend/templates/index/index.twig
@@ -18,21 +18,32 @@
                 <div class="board-info__content">
                     <p class="board-info__body board-info__body--active-note">{{ lang.online_note }}</p>
                     <p class="board-info__body board-info__body--users">
-                        {% set has_bot = false %}
-                        {% for bot in bots %}
-                            {{ bot }}{% if not loop.last %}{{ lang.comma }}{% endif %}
+                        {% set visible_users = users|filter(user =>
+                            user.invisible == 0
+                            or mybb.usergroup.canviewwolinvis == 1
+                            or user.uid == mybb.user.uid
+                        ) %}
 
-                            {% set has_bot = true %}
-                        {% endfor %}
-                        {% for user in users %}
-                            {% if loop.first and has_bot %}
-                                {{ lang.comma }}
-                            {% endif %}
+                        {% set has_bots = mybb.settings.woldisplayspiders > 0 and bots is not empty %}
+                        {% set has_users = visible_users is not empty %}
 
-                            {% if user.invisible == 0 or mybb.usergroup.canviewwolinvis == 1 or user.uid == mybb.user.uid %}
-                                <a href="{{ get_profile_link(user.uid) }}">{{ user.uid|format_name }}</a>{% if user.invisible == 1 %}*{% endif %}{% if loop.last != true %}{{ lang.comma }}{% endif %}
-                            {% endif %}
-                        {% endfor %}
+                        {% set bots_list %}
+                            {{ bots|join(lang.comma) }}
+                        {% endset %}
+
+                        {% set users_list %}
+                            {% for user in visible_users %}
+                                <a href="{{ get_profile_link(user.uid) }}">{{ user|format_name }}</a>{% if user.invisible == 1 %}*{% endif %}{% if not loop.last %}{{ lang.comma }}{% endif %}
+                            {% endfor %}
+                        {% endset %}
+
+                        {% if mybb.settings.woldisplayspiders == 1 %}
+                            {{ bots_list }}{% if has_bots and has_users %}{{ lang.comma }}{% endif %}{{ users_list }}
+                        {% elseif mybb.settings.woldisplayspiders == 2 %}
+                            {{ users_list }}{% if has_users and has_bots %}{{ lang.comma }}{% endif %}{{ bots_list }}
+                        {% else %}
+                            {{ users_list }}
+                        {% endif %}
                     </p>
                     {% if mybb.settings.showgroupslegend and groups %}
                         <p class="board-info__body board-info__body--groups">

--- a/inc/themes/core.base/frontend/templates/portal/portal.twig
+++ b/inc/themes/core.base/frontend/templates/portal/portal.twig
@@ -106,19 +106,32 @@
                     <ul class="list list--divided list--stats">
                         <li class="list__item">{{ lang.online_users|raw }} ({{ lang.online_counts|raw }})</li>
                         <li class="list__item">
-                            {% set has_bot = false %}
-                            {% for bot in onlinebots %}
-                                {{ bot }}{% if not loop.last %}{{ lang.comma }}{% endif %}
+                            {% set visible_users = onlinemembers|filter(user =>
+                                user.invisible == 0
+                                or mybb.usergroup.canviewwolinvis == 1
+                                or user.uid == mybb.user.uid
+                            ) %}
 
-                                {% set has_bot = true %}
-                            {% endfor %}
-                            {% for online in onlinemembers %}
-                                {% if loop.first and has_bot %}
-                                    {{ lang.comma }}
-                                {% endif %}
+                            {% set has_bots = mybb.settings.woldisplayspiders > 0 and onlinebots is not empty %}
+                            {% set has_users = visible_users is not empty %}
 
-                                <a href="{{ mybb.settings.bburl }}/{{ online.profilelink|raw }}">{{ online.username|raw }}</a>{{ online.invisiblemark }}{% if not loop.last %}{{ lang.comma }}{% endif %}
-                            {% endfor %}
+                            {% set bots_list %}
+                                {{ onlinebots|join(lang.comma) }}
+                            {% endset %}
+
+                            {% set users_list %}
+                                {% for user in visible_users %}
+                                    <a href="{{ get_profile_link(user.uid) }}">{{ user|format_name }}</a>{% if user.invisible == 1 %}*{% endif %}{% if not loop.last %}{{ lang.comma }}{% endif %}
+                                {% endfor %}
+                            {% endset %}
+
+                            {% if mybb.settings.woldisplayspiders == 1 %}
+                                {{ bots_list }}{% if has_bots and has_users %}{{ lang.comma }}{% endif %}{{ users_list }}
+                            {% elseif mybb.settings.woldisplayspiders == 2 %}
+                                {{ users_list }}{% if has_users and has_bots %}{{ lang.comma }}{% endif %}{{ bots_list }}
+                            {% else %}
+                                {{ users_list }}
+                            {% endif %}
                         </li>
                     </ul>
                 </section>

--- a/index.php
+++ b/index.php
@@ -139,7 +139,7 @@ if($mybb->settings['showwol'] != 0 && $mybb->usergroup['canviewonline'] != 0)
 				$doneusers[$user['uid']] = $user;
 			}
 		}
-		elseif(my_strpos($user['sid'], 'bot=') !== false && $spiders[$botkey] && $mybb->settings['woldisplayspiders'] == 1)
+		elseif(my_strpos($user['sid'], 'bot=') !== false && isset($spiders[$botkey]) && $mybb->settings['woldisplayspiders'] > 0)
 		{
 			if($mybb->settings['wolorder'] == 'username')
 			{

--- a/portal.php
+++ b/portal.php
@@ -257,26 +257,14 @@ if($mybb->settings['portal_showwol'] != 0 && $mybb->usergroup['canviewonline'] !
 					++$anoncount;
 				}
 
-				if($user['invisible'] == 1)
-				{
-					$user['invisiblemark'] = "*";
-				}
-				else
-				{
-					$user['invisiblemark'] = '';
-				}
-
 				if(($user['invisible'] == 1 && ($mybb->usergroup['canviewwolinvis'] == 1 || $user['uid'] == $mybb->user['uid'])) || $user['invisible'] != 1)
 				{
 					$user['isbot'] = false;
-					$user['username'] = format_name(htmlspecialchars_uni($user['username']), $user['usergroup'], $user['displaygroup']);
-					$user['profilelink'] = get_profile_link($user['uid']);
-
 					$onlinemembers[] = $user;
 				}
 			}
 		}
-		elseif(my_strpos($user['sid'], 'bot=') !== false && $spiders[$botkey] && $mybb->settings['woldisplayspiders'] == 1)
+		elseif(my_strpos($user['sid'], 'bot=') !== false && isset($spiders[$botkey]) && $mybb->settings['woldisplayspiders'] > 0)
 		{
 			// The user is a search bot.
 			if($mybb->settings['wolorder'] == 'username')


### PR DESCRIPTION
### Changed

- Updated the `woldisplayspiders` setting to allow configuring display order.
- Refactored the WOL section of the portal and index templates to be able to display spiders before or after users.
- Removed code setting `profilelink`, `invisiblemark` and raw `username` since this is now handled in the template.

Part of #3935 
Part of #5171

