### PR TITLE
Fix TO DO in private item template and refactor bbcusers typo to bccusers

### DIFF
--- a/inc/themes/core.base/frontend/templates/private/private/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/private/item.twig
@@ -30,7 +30,6 @@
         {% else %}
             <span class="thread__label thread__label--from">{{ lang.from }}</span>
         {% endif %}
-        {# TO DO: Multiple recipients dropdown #}
         {% if message.multiplerecipients %}
             <a href="private.php?action=read&amp;pmid={{ message.pmid }}" id="private_message_{{ message.pmid }}">{{ lang.multiple_recipients|raw }}</a>
             <div id="private_message_{{ message.pmid }}_popup" class="popup_menu" style="display: none;">
@@ -38,10 +37,10 @@
                 {% for user in messages.tousers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
-                {% if message.bbcusers %}
+                {% if message.bccusers %}
                     <div class="tcat"><strong>{{ lang.bcc }}</strong></div>
                 {% endif %}
-                {% for user in messages.bbcusers %}
+                {% for user in messages.bccusers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
             </div>

--- a/inc/themes/core.base/frontend/templates/private/results/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/results/item.twig
@@ -40,10 +40,10 @@
                 {% for user in messages.tousers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
-                {% if message.bbcusers %}
+                {% if message.bccusers %}
                     <div class="tcat"><strong>{{ lang.bcc }}</strong></div>
                 {% endif %}
-                {% for user in messages.bbcusers %}
+                {% for user in messages.bccusers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
             </div>

--- a/private.php
+++ b/private.php
@@ -404,7 +404,7 @@ if($mybb->input['action'] == "results")
 			)
 			{
 				$message['multiplerecipients'] = true;
-				$message['tousers'] = $message['bbcusers'] = [];
+				$message['tousers'] = $message['bccusers'] = [];
 				foreach($recipients['to'] as $uid)
 				{
 					$user = $cached_users[$uid];
@@ -421,7 +421,7 @@ if($mybb->input['action'] == "results")
 						$user['profilelink'] = get_profile_link($uid);
 						$user['username_raw'] = $user['username'];
 						$user['username'] = format_name($user['username'], $user['usergroup'], $user['displaygroup']);
-						$message['bbcusers'][] = $user;
+						$message['bccusers'][] = $user;
 					}
 				}
 			}
@@ -2258,7 +2258,7 @@ if(!$mybb->input['action'])
 				if(isset($recipients['to']) && count($recipients['to']) > 1 || (isset($recipients['to']) && count($recipients['to']) == 1 && isset($recipients['bcc']) && count($recipients['bcc']) > 0))
 				{
 					$message['multiplerecipients'] = true;
-					$message['tousers'] = $message['bbcusers'] = [];
+					$message['tousers'] = $message['bccusers'] = [];
 					foreach($recipients['to'] as $uid)
 					{
 						if(!isset($cached_users[$uid]))
@@ -2285,7 +2285,7 @@ if(!$mybb->input['action'])
 							$user['profilelink'] = get_profile_link($uid);
 							$user['username_raw'] = $user['username'];
 							$user['username'] = format_name($user['username'], $user['usergroup'], $user['displaygroup']);
-							$message['bbcusers'][] = $user;
+							$message['bccusers'][] = $user;
 						}
 					}
 				}


### PR DESCRIPTION
## Description
This PR addresses two minor cleanups in the 1.9 branch:
1. Removed the completed `{# TO DO: Multiple recipients dropdown #}` comment block from `private/private/item.twig` as the dropdown functionality has already been implemented. (Partially addresses #5268)
2. Refactored the `bbcusers` typo to `bccusers` across the codebase (both in templates and PHP core files) to prevent confusion with the BCC (Blind Carbon Copy) feature.

## Related Issue
Partially addresses #5268

## How Has This Been Tested?
Tested locally in the 1.9 environment. Private messages with multiple recipients and BCC headers render correctly without any issues.