### PR TITLE
Refactor bbcusers typo to bccusers

### DIFF
--- a/inc/themes/core.base/frontend/templates/private/private/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/private/item.twig
@@ -38,10 +38,10 @@
                 {% for user in messages.tousers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
-                {% if message.bccuser %}
+                {% if message.bccusers %}
                     <div class="tcat"><strong>{{ lang.bcc }}</strong></div>
                 {% endif %}
-                {% for user in messages.bccuser %}
+                {% for user in messages.bccusers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
             </div>

--- a/inc/themes/core.base/frontend/templates/private/private/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/private/item.twig
@@ -38,10 +38,10 @@
                 {% for user in messages.tousers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
-                {% if message.bbcusers %}
+                {% if message.bccuser %}
                     <div class="tcat"><strong>{{ lang.bcc }}</strong></div>
                 {% endif %}
-                {% for user in messages.bbcusers %}
+                {% for user in messages.bccuser %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
             </div>

--- a/inc/themes/core.base/frontend/templates/private/results/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/results/item.twig
@@ -40,10 +40,10 @@
                 {% for user in messages.tousers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
-                {% if message.bbcusers %}
+                {% if message.bccuser %}
                     <div class="tcat"><strong>{{ lang.bcc }}</strong></div>
                 {% endif %}
-                {% for user in messages.bbcusers %}
+                {% for user in messages.bccuser %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
             </div>

--- a/inc/themes/core.base/frontend/templates/private/results/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/results/item.twig
@@ -40,10 +40,10 @@
                 {% for user in messages.tousers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
-                {% if message.bccuser %}
+                {% if message.bccusers %}
                     <div class="tcat"><strong>{{ lang.bcc }}</strong></div>
                 {% endif %}
-                {% for user in messages.bccuser %}
+                {% for user in messages.bccusers %}
                     <div class="popup_item_container"><a href="{{ user.profilelink|raw }}" class="popup_item">{{ user.username|raw }}</a></div>
                 {% endfor %}
             </div>

--- a/private.php
+++ b/private.php
@@ -404,7 +404,7 @@ if($mybb->input['action'] == "results")
 			)
 			{
 				$message['multiplerecipients'] = true;
-				$message['tousers'] = $message['bccuser'] = [];
+				$message['tousers'] = $message['bccusers'] = [];
 				foreach($recipients['to'] as $uid)
 				{
 					$user = $cached_users[$uid];
@@ -421,7 +421,7 @@ if($mybb->input['action'] == "results")
 						$user['profilelink'] = get_profile_link($uid);
 						$user['username_raw'] = $user['username'];
 						$user['username'] = format_name($user['username'], $user['usergroup'], $user['displaygroup']);
-						$message['bccuser'][] = $user;
+						$message['bccusers'][] = $user;
 					}
 				}
 			}
@@ -2258,7 +2258,7 @@ if(!$mybb->input['action'])
 				if(isset($recipients['to']) && count($recipients['to']) > 1 || (isset($recipients['to']) && count($recipients['to']) == 1 && isset($recipients['bcc']) && count($recipients['bcc']) > 0))
 				{
 					$message['multiplerecipients'] = true;
-					$message['tousers'] = $message['bccuser'] = [];
+					$message['tousers'] = $message['bccusers'] = [];
 					foreach($recipients['to'] as $uid)
 					{
 						if(!isset($cached_users[$uid]))
@@ -2285,7 +2285,7 @@ if(!$mybb->input['action'])
 							$user['profilelink'] = get_profile_link($uid);
 							$user['username_raw'] = $user['username'];
 							$user['username'] = format_name($user['username'], $user['usergroup'], $user['displaygroup']);
-							$message['bccuser'][] = $user;
+							$message['bccusers'][] = $user;
 						}
 					}
 				}

--- a/private.php
+++ b/private.php
@@ -404,7 +404,7 @@ if($mybb->input['action'] == "results")
 			)
 			{
 				$message['multiplerecipients'] = true;
-				$message['tousers'] = $message['bbcusers'] = [];
+				$message['tousers'] = $message['bccuser'] = [];
 				foreach($recipients['to'] as $uid)
 				{
 					$user = $cached_users[$uid];
@@ -421,7 +421,7 @@ if($mybb->input['action'] == "results")
 						$user['profilelink'] = get_profile_link($uid);
 						$user['username_raw'] = $user['username'];
 						$user['username'] = format_name($user['username'], $user['usergroup'], $user['displaygroup']);
-						$message['bbcusers'][] = $user;
+						$message['bccuser'][] = $user;
 					}
 				}
 			}
@@ -2258,7 +2258,7 @@ if(!$mybb->input['action'])
 				if(isset($recipients['to']) && count($recipients['to']) > 1 || (isset($recipients['to']) && count($recipients['to']) == 1 && isset($recipients['bcc']) && count($recipients['bcc']) > 0))
 				{
 					$message['multiplerecipients'] = true;
-					$message['tousers'] = $message['bbcusers'] = [];
+					$message['tousers'] = $message['bccuser'] = [];
 					foreach($recipients['to'] as $uid)
 					{
 						if(!isset($cached_users[$uid]))
@@ -2285,7 +2285,7 @@ if(!$mybb->input['action'])
 							$user['profilelink'] = get_profile_link($uid);
 							$user['username_raw'] = $user['username'];
 							$user['username'] = format_name($user['username'], $user['usergroup'], $user['displaygroup']);
-							$message['bbcusers'][] = $user;
+							$message['bccuser'][] = $user;
 						}
 					}
 				}


### PR DESCRIPTION
## Description
This PR fixes a legacy typo found across the 1.9 codebase where the variable for Blind Carbon Copy (`BCC`) users was incorrectly named `bbcusers` (reminiscent of the British television network) instead of `bccusers`. 

This refactor updates all instances in both core PHP files and Twig templates to ensure semantic correctness and proper alignment with the language variables (`lang.bcc`).

## Related Issue
Found and addressed during a general 1.9 template/code review.

## How Has This Been Tested?
Tested locally in the 1.9 environment. Private messages containing BCC recipients function as expected and render correctly with the updated variable name.