### PR TITLE
Resolve TO DO comment in usercp/profile_menu.twig

### DIFF
--- a/inc/themes/core.base/frontend/templates/usercp/profile_menu.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/profile_menu.twig
@@ -13,14 +13,14 @@
             </a>
         </li>
     {% endif %}
-    {# TO DO: need to check if user can change signature #}
+    {% if not mybb.user.suspendsignature or (mybb.user.suspendsigtime != 0 and mybb.user.suspendsigtime < TIME_NOW) %}
         <li class="page-tabs__item{% if mybb.input.action == 'editsig' %} page-tabs__item--active{% endif %}">
             <a href="usercp.php?action=editsig" class="page-tabs__link">
                 {{ include('partials/icon.twig', {icon: 'edit', class: 'page-tabs__icon'}, with_context = false) }}
                 {{ lang.nav_editsig }}
             </a>
         </li>
-    {# #}
+    {% endif %}
     {% if mybb.usergroup.canchangename %}
         <li class="page-tabs__item{% if mybb.input.action == 'changename' %} page-tabs__item--active{% endif %}">
             <a href="usercp.php?action=changename" class="page-tabs__link">

--- a/inc/themes/core.base/frontend/templates/usercp/profile_menu.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/profile_menu.twig
@@ -13,7 +13,7 @@
             </a>
         </li>
     {% endif %}
-    {% if not mybb.user.suspendsignature or (mybb.user.suspendsigtime != 0 and mybb.user.suspendsigtime < TIME_NOW) %}
+    {% if not mybb.user.suspendsignature or (mybb.user.suspendsigtime != 0 and mybb.user.suspendsigtime < 'now'|date('U')) %}
         <li class="page-tabs__item{% if mybb.input.action == 'editsig' %} page-tabs__item--active{% endif %}">
             <a href="usercp.php?action=editsig" class="page-tabs__link">
                 {{ include('partials/icon.twig', {icon: 'edit', class: 'page-tabs__icon'}, with_context = false) }}

--- a/inc/themes/core.base/frontend/templates/usercp/profile_menu.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/profile_menu.twig
@@ -13,7 +13,7 @@
             </a>
         </li>
     {% endif %}
-    {% if not mybb.user.suspendsignature or (mybb.user.suspendsigtime != 0 and mybb.user.suspendsigtime < TIME_NOW) %}
+    {% if (not mybb.user.suspendsignature or (mybb.user.suspendsigtime != 0 and mybb.user.suspendsigtime < 'now'|date('U'))) and mybb.usergroup.canusesig and mybb.user.postnum >= mybb.usergroup.canusesigxposts %}
         <li class="page-tabs__item{% if mybb.input.action == 'editsig' %} page-tabs__item--active{% endif %}">
             <a href="usercp.php?action=editsig" class="page-tabs__link">
                 {{ include('partials/icon.twig', {icon: 'edit', class: 'page-tabs__icon'}, with_context = false) }}


### PR DESCRIPTION
## Description
This Pull Request addresses the pending `TO DO` comment inside the `usercp/profile_menu.twig` template, which is part of the template clean-up task tracked in #5268.

The original PHP logic for checking whether a user's signature is suspended (`$mybb->user['suspendsignature']` along with the expiration timestamp `suspendsigtime`) has been accurately ported into the Twig template. This ensures that the "Edit Signature" navigation tab is only displayed when the user is actually permitted to edit their signature.

## Related Issue
Partially addresses #5268 (Resolves `usercp/profile_menu.twig`)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have tested these changes locally and they work as expected.