### PR TITLE
Fix: Prevent thread subscriptions from being deleted during quick/inline edits

### DIFF
--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -2000,7 +2000,6 @@ class PostDataHandler extends DataHandler
 		$db->update_query("posts", $this->post_update_data, "pid='".(int)$post['pid']."'");
 
 		// Automatic subscription to the thread
-		// Automatic subscription to the thread
 		if($post && !empty($post['options']['subscriptionmethod']) && $uid > 0)
 		{
 			switch($post['options']['subscriptionmethod'])

--- a/inc/datahandlers/post.php
+++ b/inc/datahandlers/post.php
@@ -2000,6 +2000,7 @@ class PostDataHandler extends DataHandler
 		$db->update_query("posts", $this->post_update_data, "pid='".(int)$post['pid']."'");
 
 		// Automatic subscription to the thread
+		// Automatic subscription to the thread
 		if($post && !empty($post['options']['subscriptionmethod']) && $uid > 0)
 		{
 			switch($post['options']['subscriptionmethod'])
@@ -2016,7 +2017,7 @@ class PostDataHandler extends DataHandler
 			require_once MYBB_ROOT."inc/functions_user.php";
 			add_subscribed_thread($post['tid'], $notification, $post['uid']);
 		}
-		else
+		else if(isset($post['options']['subscriptionmethod']) && $post['options']['subscriptionmethod'] === "none" && $uid > 0)
 		{
 			$db->delete_query("threadsubscriptions", "uid='".(int)$uid."' AND tid='".(int)$post['tid']."'");
 		}


### PR DESCRIPTION
### Description
This PR fixes a bug where a user's thread subscription is unexpectedly removed when a moderator (or the user themselves) performs a Quick Edit (`xmlhttp.php`) on a post.

### Cause
In `PostDataHandler::update_post()`, the subscription logic falls back to a destructive `else` block that deletes the user's subscription if `$post['options']['subscriptionmethod']` is empty. Since inline/quick edits do not submit subscription preferences, this condition is always triggered, wiping out the author's subscription if their `$uid` is present.

### Solution
Modified the fallback `else` block to an explicit `else if` statement. The subscription will now only be deleted from the database if `subscriptionmethod` is explicitly set to `"none"`. Missing subscription arrays (like those in AJAX quick edits) will safely bypass the deletion logic, preserving existing subscriptions.