### PR TITLE
Format usernames in portal

### DIFF
--- a/inc/themes/core.base/frontend/templates/portal/portal.twig
+++ b/inc/themes/core.base/frontend/templates/portal/portal.twig
@@ -87,7 +87,11 @@
                         </li>
                         <li class="list__item">
                             <span class="list__field">{{ lang.latest_member }}</span>
-                            <span class="list__value">{{ portal.newestmember|raw }}</span>
+                            {% if portal.newestmember > 0 %}
+                                <span class="list__value"><a href="{{ get_profile_link(portal.newestmember) }}">{{ portal.newestmember|format_name }}</a></span>
+                            {% else %}
+                                <span class="list__value">{{ lang.nobody }}</span>
+                            {% endif %}
                         </li>
                         <li class="list__item">
                             <span class="list__field">{{ lang.num_threads }}</span>

--- a/inc/themes/core.base/frontend/templates/portal/portal_announcement.twig
+++ b/inc/themes/core.base/frontend/templates/portal/portal_announcement.twig
@@ -8,7 +8,11 @@
                 {{ render_avatar(url=announcement.avatar, alt=announcement.username) }}
             </a>
             <h3 class="post__author">
-                {{ announcement.profilelink|raw }}
+                {% if announcement.uid > 0 %}
+                    <a href="{{ get_profile_link(announcement.uid) }}">{{ announcement|format_name }}</a>
+                {% else %}
+                    {{ announcement|format_name }}
+                {% endif %}
             </h3>
             {% if announcement.hasicon %}
                 <img src="{{ announcement.icon_path }}" alt="{{ announcement.icon_name }}" title="{{ announcement.icon_name }}" />

--- a/inc/themes/core.base/frontend/templates/portal/portal_announcement.twig
+++ b/inc/themes/core.base/frontend/templates/portal/portal_announcement.twig
@@ -4,9 +4,15 @@
     </h1>
     <div class="post portal-announcement__post">
         <div class="post__meta">
-            <a href="{{ get_profile_link(announcement.uid )}}" class="avatar-profile-link">
-                {{ render_avatar(url=announcement.avatar, alt=announcement.username) }}
-            </a>
+            {% if announcement.uid > 0 %}
+                <a href="{{ get_profile_link(announcement.uid )}}" class="avatar-profile-link">
+                    {{ render_avatar(url=announcement.avatar, alt=announcement.username) }}
+                </a>
+            {% else %}
+                <span class="avatar-profile-link">
+                    {{ render_avatar(url=announcement.avatar, alt=announcement.username) }}
+                </span>
+            {% endif %}
             <h3 class="post__author">
                 {% if announcement.uid > 0 %}
                     <a href="{{ get_profile_link(announcement.uid) }}">{{ announcement|format_name }}</a>

--- a/portal.php
+++ b/portal.php
@@ -576,15 +576,6 @@ if(!empty($mybb->settings['portal_announcementsfid']))
 				$announcement['threadusername'] = htmlspecialchars_uni($announcement['threadusername']);
 			}
 
-			if($announcement['uid'] == 0)
-			{
-				$announcement['profilelink'] = $announcement['threadusername'];
-			}
-			else
-			{
-				$announcement['profilelink'] = build_profile_link($announcement['username'], $announcement['uid']);
-			}
-
 			if(!$announcement['username'])
 			{
 				$announcement['username'] = $announcement['threadusername'];

--- a/portal.php
+++ b/portal.php
@@ -191,15 +191,7 @@ if($mybb->settings['portal_showstats'] != 0)
 	$portal['numthreads'] = my_number_format($stats['numthreads']);
 	$portal['numposts'] = my_number_format($stats['numposts']);
 	$portal['numusers'] = my_number_format($stats['numusers']);
-
-	if(!$stats['lastusername'])
-	{
-		$portal['newestmember'] = $lang->nobody;
-	}
-	else
-	{
-		$portal['newestmember'] = build_profile_link($stats['lastusername'], $stats['lastuid']);
-	}
+	$portal['newestmember'] = isset($stats['lastusername']) && $stats['lastusername'] != '' ? $stats['lastuid'] : 0;
 }
 
 $onlinemembers = $onlinebots = [];


### PR DESCRIPTION
### Changed

- Refactored parts of the portal templates to use `get_profile_link` and `format_name` (announcements and newest member in statistics).

Part of #5171
