### PR TITLE
Fix SQLite relative database path handling

### DIFF
--- a/inc/db_sqlite.php
+++ b/inc/db_sqlite.php
@@ -145,9 +145,11 @@ class DB_SQLite implements DB_Base
 		get_execution_time();
 
 		require_once MYBB_ROOT."inc/db_pdo.php";
+		$db_path = (string)($config['database'] ?? '');
+		$db_path = mk_path_abs($db_path);
 
 		try {
-			$this->db = new dbpdoEngine("sqlite:{$config['database']}");
+			$this->db = new dbpdoEngine("sqlite:$db_path");
 		} catch (Exception $ex) {
 			$this->error("[READ] Unable to open the SQLite database");
 

--- a/inc/src/Maintenance/functions_db.php
+++ b/inc/src/Maintenance/functions_db.php
@@ -332,6 +332,12 @@ function testDatabaseParameters(array $parameters, float $timeoutSeconds = 5): a
         if ($driverData !== null) {
             $results['checks']['engine'] = true;
 
+            if (strcasecmp($parameters['engine'], 'sqlite') === 0) {
+                if (isset($parameters['path']) && $parameters['path'] !== '') {
+                    $parameters['path'] = mk_path_abs($parameters['path']);
+                }
+            }
+
             $dsn = getDsn($parameters);
 
             if ($dsn !== null) {

--- a/inc/src/Maintenance/functions_db.php
+++ b/inc/src/Maintenance/functions_db.php
@@ -332,10 +332,8 @@ function testDatabaseParameters(array $parameters, float $timeoutSeconds = 5): a
         if ($driverData !== null) {
             $results['checks']['engine'] = true;
 
-            if (strcasecmp($parameters['engine'], 'sqlite') === 0) {
-                if (isset($parameters['path']) && $parameters['path'] !== '') {
-                    $parameters['path'] = mk_path_abs($parameters['path']);
-                }
+            if (!empty($parameters['path'])) {
+                $parameters['path'] = mk_path_abs($parameters['path']);
             }
 
             $dsn = getDsn($parameters);


### PR DESCRIPTION
This fixes an issue where relative SQLite database paths were resolved relative to the currently executing script, leading to inconsistent behavior across entry points (installer, frontend, Admin CP) and potentially multiple database files being created.

Relative SQLite database paths are now resolved against `MYBB_ROOT` at connection time. Absolute paths (Unix-style, Windows drive letters, and UNC paths) are left unchanged.

The configuration value is not modified ensuring consistent behavior.

Resolves #4988