### PR TITLE
#5365: Add random password generator to registration form

### DIFF
--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -78,6 +78,7 @@ $l['username'] = "Username";
 $l['username1'] = "Email";
 $l['username2'] = "Username/Email";
 $l['password'] = "Password";
+$l['random_password'] = "Or generate random password";
 $l['login_username'] = "Username";
 $l['login_username1'] = "Email";
 $l['login_username2'] = "Username/Email";

--- a/inc/themes/core.base/frontend/templates/member/register.twig
+++ b/inc/themes/core.base/frontend/templates/member/register.twig
@@ -2,6 +2,32 @@
 
 {% block head %}
     <title>{{ lang.registration }} - {{ mybb.settings.bbname }}</title>
+    <style>
+.field-container {
+    position: relative;
+}
+
+[data-password-peek] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 1px;
+    padding: 8px 9px;
+    cursor: pointer;
+}
+
+[data-password-peek] .icon {
+    color: #aaa;
+}
+
+[data-password-peek][aria-pressed="true"] .icon {
+    color: #222;
+}
+
+input[data-password-peekable] {
+    padding-right: 35px;
+}
+    </style>
 {% endblock head %}
 
 {% block body %}
@@ -24,15 +50,21 @@
                         {% if registration.showpassword %}
                             <div class="row row--form field">
                                 <h3 class="field__name"><label for="password"><label for="password">{{ lang.password|raw }}</label></h3>
-                                <p class="field__description">{{ lang.confirm_password_desc }}</p>
+                                <p class="field__description">{{ lang.confirm_password_desc }} [<label id="newrandompassword">{{ lang.random_password }}</label>]</p>
                                 <div class="confirm-field">
                                     <div class="confirm-field__field">
                                         <h4 class="visually-hidden"><label for="password">{{ lang.password }}</label></h4>
-                                        <input type="password" class="textbox" name="password" id="password" autocomplete="new-password"/>
+                                        <div class="field-container">
+                                        <input type="password" class="textbox" name="password" id="password" autocomplete="new-password" data-password-peekable data-password-revealed="0" />
+                                        <div class="password-score"><div></div></div>
+                                        </div>
                                     </div>
                                     <div class="confirm-field__field">
                                         <h4 class="visually-hidden"><label for="password2">{{ lang.confirm_password }}</label></h4>
-                                        <input type="password" class="textbox" name="password2" id="password2" autocomplete="new-password" />
+                                        <div class="field-container">
+                                        <input type="password" class="textbox" name="password2" id="password2" autocomplete="new-password" data-password-peekable data-password-revealed="0" />
+                                        <div class="password-score"><div></div></div>
+                                        </div>
                                     </div>
                                 </div>
                                 <div style="display: none;" id="password_status">&nbsp;</div>
@@ -257,6 +289,18 @@
             <input type="hidden" name="step" value="registration" />
             <input type="hidden" name="action" value="do_register" />
         </form>
+
+        <script>
+            const $ = (selector, $context) => ($context ?? document).querySelector(selector);
+            const $$ = (selector, $context) => ($context ?? document).querySelectorAll(selector);
+        </script>
+        
+        <script src="{{ relative_asset_path }}/jscripts/maintenance/form.js"></script>
+
+        <script>
+        document.getElementById("newrandompassword").addEventListener("click", onClick_newRandomPassword);
+        </script>
+        
         {{ validator_javascript|raw }}
         {{ asset('jscripts/regvalidator.js', static=true) }}
     </div>

--- a/jscripts/maintenance/form.js
+++ b/jscripts/maintenance/form.js
@@ -64,3 +64,69 @@ $$('form[data-submit-on-change] :is(input, select)').forEach($e => {
 		e.target.closest('form').submit();
 	});
 });
+
+
+/*
+ * The following section implements random password
+ * generation for user sign-up.
+ */
+
+function random_str(length = 8) {
+    const set = [
+        ..."0123456789",
+        ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        ..."abcdefghijklmnopqrstuvwxyz"
+    ];
+    
+    let str = [];
+    
+    // better than Math.random()
+    const randomInt = (min, max) => {
+        const range = max - min + 1;
+        const limit = Math.floor(0x100000000 / range) * range;
+        const array = new Uint32Array(1);
+        do {
+            crypto.getRandomValues(array);
+        } while (array[0] >= limit);
+        return min + (array[0] % range);
+    };
+    
+    // at least one character '0', '1', ..., '9'
+    str.push(set[randomInt(0, 9)]);
+
+    // at least one character 'A', 'B', ..., 'Z'
+    str.push(set[randomInt(10, 35)]);
+
+    // at least one character 'a', 'b', ..., 'z'
+    str.push(set[randomInt(36, 61)]);
+
+    length -= 3;
+
+    for (let i = 0; i < length; i++) {
+        str.push(set[randomInt(0, 61)]);
+    }
+
+    // Fisher-Yates Shuffle
+    for (let i = str.length - 1; i > 0; i--) {
+        const j = randomInt(0, i);
+        [str[i], str[j]] = [str[j], str[i]];
+    }
+    
+    return str.join('');
+}
+
+function onClick_newRandomPassword(event) {
+    let checkbox = document.getElementById("randompassword");
+    let newpw = random_str();
+
+    event.preventDefault();
+    
+    document.getElementById('password').value = newpw;
+    document.getElementById('password2').value = newpw;
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change"));
+}
+
+
+                                    


### PR DESCRIPTION
This PR adds a random password generator to the registration form.

A new control allows users to generate a secure random password without leaving the registration page. The generated password is automatically applied to both password fields and can be regenerated as needed.


(1) Uses the browser's cryptographically secure random number generator (crypto.getRandomValues)

(2) The JavaScript random_str() implementation follows the same approach as the existing PHP random_str() in inc/functions.php

(3) Ensures at least one digit, one uppercase letter, and one lowercase letter are present in the generated password
Users can toggle the visibility of the generated password to make it easier to save or record

(4) Additional passwords can be generated with a single click if the user prefers a different one

(5) Does not change the existing registration workflow


Resolves #5365