### PR TITLE
Expire awaitingactivation tokens after 24 hours

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -125,7 +125,7 @@ if($mybb->input['action'] == "unlock")
 	// Do we have the token? If so let's process it
 	if($mybb->input['token'] && $user['uid'])
 	{
-		$query = $db->simple_select("awaitingactivation", "COUNT(aid) AS num", "uid='".(int)$user['uid']."' AND code='".$db->escape_string($mybb->input['token'])."' AND type='l'");
+		$query = $db->simple_select("awaitingactivation", "COUNT(aid) AS num", "uid='".(int)$user['uid']."' AND code='".$db->escape_string($mybb->input['token'])."' AND type='l' AND dateline > '".(int)(TIME_NOW - 86400)."'");
 
 		$plugins->run_hooks("admin_unlock_end");
 
@@ -212,7 +212,7 @@ elseif($mybb->input['do'] == "login")
 				$lockout_array = array(
 					"uid" => $login_user['uid'],
 					"dateline" => TIME_NOW,
-					"code" => random_str(),
+					"code" => random_str(30),
 					"type" => "l"
 				);
 				$db->insert_query("awaitingactivation", $lockout_array);
@@ -372,7 +372,7 @@ elseif($mybb->input['do'] == "login")
 				$lockout_array = array(
 					"uid" => $login_user['uid'],
 					"dateline" => TIME_NOW,
-					"code" => random_str(),
+					"code" => random_str(30),
 					"type" => "l"
 				);
 				$db->insert_query("awaitingactivation", $lockout_array);
@@ -686,7 +686,7 @@ if($mybb->input['do'] == "do_2fa" && $mybb->request_method == "post")
 				$lockout_array = array(
 					"uid" => $mybb->user['uid'],
 					"dateline" => TIME_NOW,
-					"code" => random_str(),
+					"code" => random_str(30),
 					"type" => "l"
 				);
 				$db->insert_query("awaitingactivation", $lockout_array);

--- a/inc/languages/english/member.lang.php
+++ b/inc/languages/english/member.lang.php
@@ -211,6 +211,8 @@ $l['error_activated_by_admin'] = "You are unable to resend your account activati
 $l['error_alreadyregistered'] = "Sorry, but our system shows that you have already registered and the registration of multiple accounts has been disabled.";
 $l['error_alreadyregisteredtime'] = "We cannot process your registration because there has already been {1} new registration(s) from your ip address in the past {2} hours. Please try again later.";
 $l['error_badlostpwcode'] = "You have entered an invalid password reset code. Please re-read the email you were sent or contact the forum administrators for more help.";
+$l['error_resetpwcodeexpired'] = "This password reset code has expired. Please request a new password reset and use the link within 24 hours.";
+$l['error_activationexpired'] = "This email change confirmation link has expired. Please change your email address again and confirm it within 24 hours.";
 $l['error_badactivationcode'] = "You have entered an invalid account activation code. To resend all activation emails to the email address on file, please click <a href=\"member.php?action=resendactivation\">here</a>.";
 $l['error_alreadyactivated'] = "Your account has already been activated or does not require email validation.";
 $l['error_alreadyvalidated'] = "Your email has already been validated.";

--- a/inc/tasks/hourlycleanup.php
+++ b/inc/tasks/hourlycleanup.php
@@ -49,8 +49,7 @@ function task_hourlycleanup($task)
 	$cut = TIME_NOW-(60*60*24*7);
 	$db->delete_query("questionsessions", "dateline < '".(int)$time['question']."'");
 
-	// Delete expired password reset ('p'), email change ('e') and admin lockout ('l') tokens (older than 24 hours).
-	// Account activation ('r') and board validation ('b') tokens are intentionally left untouched.
+	// Delete expired password reset ('p'), email change ('e') and admin lockout ('l') tokens (older than 24 hours)
 	$db->delete_query("awaitingactivation", "type IN ('p','e','l') AND dateline < '".(int)(TIME_NOW-(60*60*24))."'");
 
 	add_task_log($task, $lang->task_hourlycleanup_ran);

--- a/inc/tasks/hourlycleanup.php
+++ b/inc/tasks/hourlycleanup.php
@@ -49,5 +49,9 @@ function task_hourlycleanup($task)
 	$cut = TIME_NOW-(60*60*24*7);
 	$db->delete_query("questionsessions", "dateline < '".(int)$time['question']."'");
 
+	// Delete expired password reset ('p'), email change ('e') and admin lockout ('l') tokens (older than 24 hours).
+	// Account activation ('r') and board validation ('b') tokens are intentionally left untouched.
+	$db->delete_query("awaitingactivation", "type IN ('p','e','l') AND dateline < '".(int)(TIME_NOW-(60*60*24))."'");
+
 	add_task_log($task, $lang->task_hourlycleanup_ran);
 }

--- a/member.php
+++ b/member.php
@@ -1668,8 +1668,7 @@ if($mybb->input['action'] == "resetpassword")
 	{
 		$query = $db->simple_select("awaitingactivation", "code, dateline", "uid='".$user['uid']."' AND type='p'");
 		$activation = $db->fetch_array($query);
-		$activationcode = $activation['code'];
-		if(!$activationcode || $activationcode !== $mybb->get_input('code'))
+		if(!$activation || $activation['code'] !== $mybb->get_input('code'))
 		{
 			error($lang->error_badlostpwcode);
 		}

--- a/member.php
+++ b/member.php
@@ -1311,6 +1311,12 @@ if($mybb->input['action'] == "activate")
 		}
 		if($activation['type'] == "e")
 		{
+			// Email change confirmation links expire after 24 hours.
+			if((int)$activation['dateline'] < TIME_NOW - 86400)
+			{
+				error($lang->error_activationexpired);
+			}
+
 			$newemail = array(
 				"email" => $db->escape_string($activation['misc']),
 			);
@@ -1660,12 +1666,18 @@ if($mybb->input['action'] == "resetpassword")
 
 	if(isset($mybb->input['code']) && $user)
 	{
-		$query = $db->simple_select("awaitingactivation", "code", "uid='".$user['uid']."' AND type='p'");
-		$activationcode = $db->fetch_field($query, 'code');
-		$now = TIME_NOW;
+		$query = $db->simple_select("awaitingactivation", "code, dateline", "uid='".$user['uid']."' AND type='p'");
+		$activation = $db->fetch_array($query);
+		$activationcode = $activation['code'];
 		if(!$activationcode || $activationcode !== $mybb->get_input('code'))
 		{
 			error($lang->error_badlostpwcode);
+		}
+		// Password reset codes expire after 24 hours.
+		if((int)$activation['dateline'] < TIME_NOW - 86400)
+		{
+			$db->delete_query("awaitingactivation", "uid='".$user['uid']."' AND type='p'");
+			error($lang->error_resetpwcodeexpired);
 		}
 		$db->delete_query("awaitingactivation", "uid='".$user['uid']."' AND type='p'");
 		$username = $user['username'];


### PR DESCRIPTION
# Expire awaitingactivation tokens after 24 hours

## Problem

Password reset (`type='p'`), email-change confirmation (`type='e'`) and ACP
unlock (`type='l'`) codes are stored in `awaitingactivation` together with a
`dateline`, but the `dateline` was never checked when the code was consumed.
Every such code therefore stayed valid **forever** (single-use, but with an
unlimited window) and there was no task cleaning the rows up.

The dead `$now = TIME_NOW;` in the reset-password handler (member.php) shows an
age check was once intended but never finished.

Impact:
- A password-reset link works a year later — a stale/leaked link is a permanent
  account-takeover primitive.
- An email-change confirmation link works indefinitely. If the pending address
  is later abandoned and re-registered by someone else, they can complete the
  change and take over the account.
- A stale ACP unlock link clears an admin lockout at any time, and the unlock
  endpoint runs before the login rate-limiter, so the 8-char token could be
  ground on.

For reference, WordPress expires reset links after 24h, phpBB after 1h.

## Changes

- **member.php (`resetpassword`)** — fetch `dateline` alongside the code,
  reject + delete codes older than 24h, and remove the dead `$now = TIME_NOW;`.
- **member.php (`activate`, type `e`)** — reject email-change confirmations
  older than 24h before applying the new address. Scoped to `type='e'` only, so
  account-activation (`r`) and board-validation (`b`) links — which can
  legitimately be days old — are unaffected.
- **admin/index.php (`unlock`)** — add a 24h `dateline` bound to the unlock
  token lookup, and raise the lockout token from `random_str()` (8 chars) to
  `random_str(30)` to match the reset-code length.
- **inc/tasks/hourlycleanup.php** — purge stale `p`/`e`/`l` rows hourly; `r`/`b`
  are intentionally left untouched.
- **inc/languages/english/member.lang.php** — two new error strings.

The 24h lifetime is hardcoded (matches phpBB/WP/Discourse). Happy to convert it
to a board setting if preferred.

## Not included / follow-ups

- **Rate limiting on the ACP unlock endpoint.** The `action=unlock` block runs
  before the `do=login` limiter. With the token now 30 chars brute force is
  infeasible, but a dedicated limiter on the unlock action is still worth
  considering and is an architectural decision better left to maintainers.
- **Login-key rotation on logout** (separate report item) is intentionally NOT
  touched here, as it's tracked in #3662 and slated for a session-key redesign.

## Testing

Installed MyBB 1.8 (this branch) in Docker (PHP 8.1 + MariaDB) and verified, via
direct HTTP requests, that for each of the three token types a 1-year-old code
is now rejected while a fresh code still works, that legitimate account
activation (`r`) is unaffected, and that hourly cleanup removes stale `p`/`e`/`l`
rows while keeping `r`/`b`. Reverse-applying the patch reproduces the original
indefinite-validity behaviour (password reset, email hijack, lockout clear all
succeed with a year-old token).

## Disclosure

This change was prepared with AI assistance and has been reviewed and tested by
the @unknownhad , per the MyBB contribution policy on generated content.
