### PR TITLE
Fixes #5381 - portal.php Warning [2] Undefined array key "attachments"

### DIFF
--- a/portal.php
+++ b/portal.php
@@ -668,6 +668,8 @@ if(!empty($mybb->settings['portal_announcementsfid']))
 
 			$announcement['message'] = $parser->parse_message($announcement['message'], $parser_options);
 
+			$announcement['attachments'] = '';
+
 			if($mybb->settings['enableattachments'] != 0)
 			{
 				get_post_attachments($announcement['pid'], $announcement);


### PR DESCRIPTION
Resolves #5381 

