### PR TITLE
[php] MyCode parsing returns empty string in PHP 8.3+ due to HTML validation failure

### DIFF
--- a/inc/class_parser.php
+++ b/inc/class_parser.php
@@ -1151,14 +1151,17 @@ class postParser
 		if($added_end_tag)
 		{
 			$code = str_replace("?&gt;</span></code>", "</span></code>", $code);
-			// Wait a minute. It fails highlighting? Stupid highlighter.
 			$code = str_replace("?&gt;</code>", "</code>", $code);
+			$code = str_replace("?&gt;</span></pre>", "</span></pre>", $code);
 		}
-
+		
 		$code = preg_replace("#<span style=\"color: \#([A-Z0-9]{6})\"></span>#", "", $code);
+		// PHP 8.3+ compatibility: remove stray wrapping <pre> tags leftover from new highlight_string format
+		$code = str_replace("<pre>", "", $code);
+		$code = str_replace("</pre>", "", $code);
+		
 		$code = str_replace("<code>", "<div dir=\"ltr\"><code>", $code);
 		$code = str_replace("</code>", "</code></div>", $code);
-		$code = preg_replace("# *$#", "", $code);
 
 		if($bare_return)
 		{


### PR DESCRIPTION
[php] MyCode parsing returns empty string in PHP 8.3+ due to HTML validation failure

https://community.mybb.com/thread-245393.html

[Resolves #ISSUE_ID
](https://github.com/mybb/mybb/issues/5005)
