### PR TITLE
Show Installation State for early SQL errors

### DIFF
--- a/inc/class_error.php
+++ b/inc/class_error.php
@@ -484,6 +484,16 @@ class errorHandler {
 		{
 			if($type == MYBB_SQL)
 			{
+				// If failure occurred on the first query, add Installation State details
+				if($GLOBALS['db']->query_count === 0)
+				{
+					require_once MYBB_ROOT.'inc/src/Maintenance/functions_db.php';
+					require_once MYBB_ROOT.'inc/src/Maintenance/functions_core.php';
+					require_once MYBB_ROOT.'inc/src/Maintenance/InstallationState.php';
+
+					$data['Installation State'] = \MyBB\Maintenance\InstallationState::getDescription($lang);
+				}
+
 				$data['SQL Error'] = $message['error_no'].' - '.$message['error'];
 
 				if($message['query'] != "")
@@ -613,7 +623,7 @@ class errorHandler {
 
 				foreach($data as $key => $value)
 				{
-					if(!in_array($key, ['Code', 'Backtrace']))
+					if(!in_array($key, ['Installation State', 'Code', 'Backtrace']))
 					{
 						$value = htmlspecialchars_uni($value);
 					}

--- a/inc/db_pgsql.php
+++ b/inc/db_pgsql.php
@@ -549,27 +549,11 @@ class DB_PgSQL implements DB_Base
 	{
 		if($this->error_reporting)
 		{
-			if(class_exists("errorHandler"))
-			{
-				global $error_handler;
-
-				if(!is_object($error_handler))
-				{
-					require_once MYBB_ROOT."inc/class_error.php";
-					$error_handler = new errorHandler();
-				}
-
-				$error = array(
-					"error_no" => $this->error_number($query),
-					"error" => $this->error_string($query),
-					"query" => $string
-				);
-				$error_handler->error(MYBB_SQL, $error);
-			}
-			else
-			{
-				trigger_error("<strong>[SQL] [".$this->error_number()."] ".$this->error_string()."</strong><br />{$string}", E_USER_ERROR);
-			}
+			throw new DbException(
+				$this->error_string($query),
+				$this->error_number($query),
+				$string,
+			);
 		}
 	}
 

--- a/inc/init.php
+++ b/inc/init.php
@@ -177,16 +177,16 @@ $plugins = new pluginSystem;
 // Include our base data handler class
 require_once MYBB_ROOT."inc/datahandler.php";
 
+// Language initialisation
+require_once MYBB_ROOT."inc/class_language.php";
+$lang = new MyLanguage;
+$lang->set_path(MYBB_ROOT."inc/languages");
+
 // Connect to Database
 define("TABLE_PREFIX", $config['database']['table_prefix']);
 $db->connect($config['database']);
 $db->set_table_prefix(TABLE_PREFIX);
 $db->type = $db_type;
-
-// Language initialisation
-require_once MYBB_ROOT."inc/class_language.php";
-$lang = new MyLanguage;
-$lang->set_path(MYBB_ROOT."inc/languages");
 
 // Load cache
 $cache->cache();

--- a/inc/src/Maintenance/InstallationState.php
+++ b/inc/src/Maintenance/InstallationState.php
@@ -41,6 +41,8 @@ enum InstallationState: int
 
     public static function getDescription(\MyLanguage $lang, bool $correctOldConfigFormat = false): string
     {
+        $lang->load('maintenance');
+
         return match (self::get($correctOldConfigFormat)) {
             self::CONFIGURATION_FILE => $lang->installation_state_configuration_file,
             self::DATABASE_CONNECTION => $lang->installation_state_database_connection,


### PR DESCRIPTION
Show an _Installation State_ entry when the first database query fails, providing a hint when the overall problem lies in missing database data.

<img width="1531" height="957" alt="mybb-sql-error-installation-state" src="https://github.com/user-attachments/assets/a2250df1-4305-42ca-9fb7-e2594e08615b" />

---

Relies on https://github.com/mybb/mybb/blob/70500291ca640dc71ef7f51789cd0d9c037298fe/inc/src/Maintenance/functions_core.php#L138-L140
 with `DB_PgSQL` now also implementing `DbException`.

Related improvements: https://github.com/mybb/mybb/issues/4564#issuecomment-1206836141