### PR TITLE
Fix incorrect formatted name display in messenger item templates

### DIFF
--- a/inc/themes/core.base/frontend/templates/private/private/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/private/item.twig
@@ -67,9 +67,8 @@
             // -->
             </script>
         {% else %}
-            {% set formatted_name = message.tofromuid|format_name %}
-            {% if formatted_name %}
-                <a href="{{ get_profile_link(message.tofromuid) }}" class="thread__overflow">{{ formatted_name }}</a>
+            {% if message.tofromuid > 0 and message.tofromusername %}
+                <a href="{{ get_profile_link(message.tofromuid) }}" class="thread__overflow">{{ message.tofromuid|format_name }}</a>
             {% else %}
                 <span class="thread__overflow">{{ message.tofromusername ?? lang.guest }}</span>
             {% endif %}

--- a/inc/themes/core.base/frontend/templates/private/results/item.twig
+++ b/inc/themes/core.base/frontend/templates/private/results/item.twig
@@ -67,9 +67,8 @@
             // -->
             </script>
         {% else %}
-            {% set formatted_name = message.tofromuid|format_name %}
-            {% if formatted_name %}
-                <a href="{{ get_profile_link(message.tofromuid) }}" class="thread__overflow">{{ formatted_name }}</a>
+            {% if message.tofromuid > 0 and message.tofromusername %}
+                <a href="{{ get_profile_link(message.tofromuid) }}" class="thread__overflow">{{ message.tofromuid|format_name }}</a>
             {% else %}
                 <span class="thread__overflow">{{ message.tofromusername ?? lang.guest }}</span>
             {% endif %}


### PR DESCRIPTION
### Fixed

- Fixed username display in messenger item templates. Following Copilot's suggestion in the previous PR caused the raw username to be displayed. The template now checks both `tofromuid` and `tofromusername`.