### PR TITLE
Fix undefined array key in get_post_attachments after portal.php

### DIFF
--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -1026,9 +1026,20 @@ function get_post_attachments($id, &$post)
 	];
 	$post['hasattachments'] = false;
 
-	if(!isset($forumpermissions))
+	// $forumpermissions may be unset, a flat permission array, or (as built by
+	// portal.php) an array keyed by forum ID. Resolve this post's permissions
+	// from whichever shape is present so a missing key does not warn.
+	if(isset($forumpermissions[$post['fid']]) && is_array($forumpermissions[$post['fid']]))
 	{
-		$forumpermissions = forum_permissions($post['fid']);
+		$postpermissions = $forumpermissions[$post['fid']];
+	}
+	elseif(isset($forumpermissions['candlattachments']))
+	{
+		$postpermissions = $forumpermissions;
+	}
+	else
+	{
+		$postpermissions = forum_permissions($post['fid']);
 	}
 
 	if(!(isset($attachcache[$id]) && is_array($attachcache[$id])))
@@ -1076,7 +1087,7 @@ function get_post_attachments($id, &$post)
 			} elseif (
 				$isImage
 				&& (
-					($attachment['thumbnail'] == 'SMALL' && $forumpermissions['candlattachments'] == 1)
+					($attachment['thumbnail'] == 'SMALL' && $postpermissions['candlattachments'] == 1)
 					|| $mybb->settings['attachthumbnails'] == 'no'
 				)
 			) {
@@ -1104,7 +1115,7 @@ function get_post_attachments($id, &$post)
 			} elseif (
 				$isImage
 				 && (
-					($attachment['thumbnail'] == 'SMALL' && $forumpermissions['candlattachments'] == 1)
+					($attachment['thumbnail'] == 'SMALL' && $postpermissions['candlattachments'] == 1)
 					|| $mybb->settings['attachthumbnails'] == 'no'
 				)
 			) {


### PR DESCRIPTION
Resolves #5386

When `portal.php` runs first it populates the global `$forumpermissions` as an array keyed by forum ID, but `get_post_attachments()` treats it as a flat permission row. Its `isset($forumpermissions)` guard then sees the nested array and skips the lookup, so reading `$forumpermissions['candlattachments']` warns. This resolves the permissions for the post's own forum from whichever shape the global currently holds.
