### PR TITLE
Preserve plugin stylesheets on theme import

### DIFF
--- a/admin/inc/functions_themes.php
+++ b/admin/inc/functions_themes.php
@@ -218,10 +218,12 @@ function import_theme_xml($xml, $options=array())
 		}
 		$theme_id = build_new_theme($name, $properties, $options['parent']);
 	}
-	// Overriding an existing - delete refs.
+	// Overriding an existing theme. Stylesheets are replaced per-name in the
+	// import loop below (instead of wiping them ALL here) so that plugin-added
+	// stylesheets for this theme (e.g. isango.css) are preserved on a core
+	// upgrade / Master re-import. Fixes #4265.
 	else
 	{
-		$db->delete_query("themestylesheets", "tid='{$options['tid']}'");
 		$db->update_query("themes", array("properties" => $db->escape_string(my_serialize($properties))), "tid='{$options['tid']}'");
 		$theme_id = $options['tid'];
 	}
@@ -296,6 +298,10 @@ function import_theme_xml($xml, $options=array())
 				"lastmodified" => (int)$stylesheet['attributes']['lastmodified'],
 				"cachefile" => $db->escape_string($stylesheet['attributes']['name'])
 			);
+			// Replace ONLY this stylesheet (by tid+name), leaving any plugin-added
+			// stylesheets for this theme intact rather than wiping them all on
+			// import. Fixes #4265.
+			$db->delete_query("themestylesheets", "tid='{$theme_id}' AND name='".$db->escape_string($stylesheet['attributes']['name'])."'");
 			$sid = $db->insert_query("themestylesheets", $new_stylesheet);
 			$css_url = "css.php?stylesheet={$sid}";
 			$cached = cache_stylesheet($theme_id, $stylesheet['attributes']['name'], $stylesheet['value']);


### PR DESCRIPTION
Resolves #4265

`import_theme_xml()` unconditionally deleted **all** stylesheets attached to the target theme before re-inserting the imported ones:

```php
$db->delete_query("themestylesheets", "tid='{$options['tid']}'");
```

Because `upgradethemes()` (`install/upgrade.php`) calls `import_theme_xml()` against the Master theme (`tid=1`) on every core upgrade, any plugin-added Master stylesheet the admin had not overridden was permanently deleted.

### Change
Delete only the stylesheets the import actually re-creates, matched by `tid` + `name`, inside the existing insert loop. Stylesheets whose names are not present in the imported XML — i.e. plugin stylesheets — are never touched. One file, +8/-2, no schema change.

### Approach note
The issue suggests flagging each stylesheet as core vs plugin and deleting only the core ones. This PR takes a smaller route that needs no schema/data change: it scopes the delete to exactly what is being re-imported. The one behavioural difference: if a future core version *removes* a core stylesheet, this approach leaves it as a harmless orphan instead of cleaning it up (the per-name delete is never triggered for a name no longer in the import). Happy to switch to the marking approach if that is preferred.

### Testing
Verified on a live MyBB 1.8 board running a plugin (Isango) that installs a Master stylesheet (`isango.css`):

| Core | `import_theme_xml(tid=1)` result |
|------|----------------------------------|
| Stock | `isango.css` deleted (1 -> 0 rows) — bug reproduced |
| Patched | `isango.css` preserved (1 -> 1, original `sid` intact), imported Master stylesheets still replaced per-name |
