### PR TITLE
Add `view:inspect` CLI command

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -5,6 +5,9 @@ use Symfony\Component\Console\Application;
 use MyBB\Console\Command\InstallCommand;
 use MyBB\Console\Command\StatusCommand;
 use MyBB\Console\Command\UpgradeCommand;
+use MyBB\Console\Command\View\ViewInspectCommand;
+
+use function MyBB\app;
 
 define("IN_MYBB", 1);
 define("IN_INSTALL", 1);
@@ -24,6 +27,7 @@ $app->addCommands([
     new InstallCommand(),
     new StatusCommand(),
     new UpgradeCommand(),
+    app(ViewInspectCommand::class),
 ]);
 
 $app->run();

--- a/inc/src/Console/Command/View/ViewInspectCommand.php
+++ b/inc/src/Console/Command/View/ViewInspectCommand.php
@@ -1,0 +1,1292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Console\Command\View;
+
+use Exception;
+use InvalidArgumentException;
+use LogicException;
+use MyBB;
+use MyBB\Console\Style;
+use MyBB\Database\Models\Theme as ThemeModel;
+use MyBB\Database\Repositories\ThemeRepository as ThemeModelRepository;
+use MyBB\Extensions\Contracts\HierarchicalExtensionInterface;
+use MyBB\Extensions\Contracts\ViewExtensionInterface;
+use MyBB\Extensions\Extension;
+use MyBB\Extensions\Plugin\Plugin;
+use MyBB\Extensions\Plugin\Repository as PluginRepository;
+use MyBB\Extensions\RepositoryRegistry as ExtensionRepositoryRegistry;
+use MyBB\Extensions\Theme\Repository as ThemeRepository;
+use MyBB\Extensions\Theme\Theme;
+use MyBB\Extensions\Theme\ThemeType;
+use MyBB\Maintenance\InstallationState;
+use MyBB\Twig\Inspection\FunctionExpressionInspection;
+use MyBB\Twig\Inspection\Inspector;
+use MyBB\Twig\ViewletLoader;
+use MyBB\View\Asset\Asset;
+use MyBB\View\Asset\Publication;
+use MyBB\View\Asset\StaticAsset;
+use MyBB\View\Asset\ViewletAsset;
+use MyBB\View\Locator\Exception as LocatorException;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\StaticLocator;
+use MyBB\View\Locator\ViewletLocator;
+use MyBB\View\Optimization;
+use MyBB\View\Resource;
+use MyBB\View\ResourceType;
+use MyBB\View\Viewlet\Decorator\CompositeViewlet;
+use MyBB\View\Viewlet\Decorator\Hierarchy\HierarchicalViewlet;
+use MyBB\View\Viewlet\Decorator\PublishableViewlet;
+use MyBB\View\Viewlet\Decorator\ViewletDecorator;
+use MyBB\View\Viewlet\NamespaceType;
+use MyBB\View\Viewlet\ViewletInterface;
+use MyLanguage;
+use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
+use Twig\Error\LoaderError;
+use Twig\Error\SyntaxError;
+use UnexpectedValueException;
+
+use function MyBB\app;
+
+use const MyBB\View\DEFAULT_THEME_PACKAGE;
+
+#[AsCommand(
+    name: 'view:inspect',
+    description: 'Displays information about Resources and Assets in given active Theme or Package',
+)]
+class ViewInspectCommand extends Command
+{
+    private readonly InputInterface $input;
+    private readonly OutputInterface $output;
+    private readonly Style $io;
+
+    private readonly ThemeModelRepository $themeModelRepository;
+
+
+    // resolution context
+
+    private readonly ThemeModel $themeModel;
+    private readonly Extension&ViewExtensionInterface $extension;
+
+    private readonly ViewletInterface $viewlet;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $namespaces;
+
+
+    public function __construct(
+        private readonly MyBB $mybb,
+        private readonly MyLanguage $lang,
+        private readonly Optimization $optimization,
+        private readonly ExtensionRepositoryRegistry $extensionRepositoryRegistry,
+        private readonly ThemeRepository $themeRepository,
+        private readonly PluginRepository $pluginRepository,
+    ) {
+        parent::__construct();
+
+        if (InstallationState::get() === InstallationState::INSTALLED) {
+            $this->themeModelRepository = app(ThemeModelRepository::class);
+        }
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            name: 'resource',
+            mode: InputOption::VALUE_REQUIRED,
+            description: 'Resource to inspect (Locator, absolute path, or relative path)',
+        );
+        $this->addOption(
+            name: 'asset',
+            mode: InputOption::VALUE_REQUIRED,
+            description: 'Asset to inspect (Locator, absolute path, relative path, or URL)',
+        );
+
+        $this->addOption(
+            name: 'package',
+            mode: InputOption::VALUE_REQUIRED,
+            description: 'Package name to use as resolution context',
+            suggestedValues: $this->getExtensionPackageNames(...),
+        );
+        $this->addOption(
+            name: 'theme',
+            mode: InputOption::VALUE_REQUIRED,
+            description: 'ID of an active Theme to use as resolution context',
+            suggestedValues: $this->getThemeIds(...),
+        );
+        $this->addOption(
+            name: 'namespace',
+            mode: InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            description: 'Namespaces to use as resolution context',
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->output = $output;
+        $this->io = new Style($input, $output);
+
+        $this->lang->load('global');
+
+        if (InstallationState::get() !== InstallationState::INSTALLED) {
+            $this->io->error(
+                sprintf(
+                    'This command must be used with an installed application (current state: %s)',
+                    strip_tags(InstallationState::getDescription($this->lang)),
+                ),
+            );
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $this->loadResolutionContext();
+
+            $subject = $this->getInspectionSubject();
+
+            $this->outputInspection($subject);
+
+            return Command::SUCCESS;
+        } catch (InvalidArgumentException $e) {
+            $this->io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+    }
+
+
+    /**
+     * @return list<string>
+     */
+    private function getExtensionPackageNames(): array
+    {
+        return array_map(
+            fn (Extension $extension): string => $extension->getPackageName(),
+            array_merge(
+                $this->themeRepository->getAll(),
+                $this->pluginRepository->getAll(),
+            ),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getThemeIds(): array
+    {
+        if (isset($this->themeModelRepository)) {
+            return array_keys(
+                $this->themeModelRepository->all()
+            );
+        } else {
+            return [];
+        }
+    }
+
+
+    /**
+     * Loads the Extension and configured Viewlet that will be queried for resolution.
+     *
+     * The Extension is determined in the following descending priority:
+     *  - explicit Theme Model by ID (--theme) and the associated Theme Package,
+     *  - explicit Extension Package by name (--package),
+     *  - default Theme Model and the associated Theme Package,
+     *  - default Theme Package.
+     *
+     * @throws Exception
+     */
+    private function loadResolutionContext(): void
+    {
+        if (
+            $this->input->getOption('theme') !== null &&
+            $this->input->getOption('package') !== null
+        ) {
+            throw new InvalidArgumentException('Provide either an active Theme ID or an Extension Package to use');
+        }
+
+        if ($this->input->getOption('theme') !== null) {
+            $this->loadThemeModel(
+                (int)$this->input->getOption('theme')
+            );
+
+            $this->extension = $this->themeModel->package;
+        } elseif ($this->input->getOption('package') !== null) {
+            $this->loadExtension(
+                $this->input->getOption('package')
+            );
+        } else {
+            try {
+                $this->loadThemeModel(null);
+
+                $this->extension = $this->themeModel->package;
+            } catch (RuntimeException) {
+                $this->loadExtension(null);
+            }
+        }
+
+
+        $this->loadViewlet($this->extension);
+
+
+        $this->loadNamespaces(
+            $this->input->getOption('namespace')
+        );
+    }
+
+    /**
+     * Loads the Theme Model by ID, or the default Theme Model if null.
+     *
+     * @throws Exception
+     */
+    private function loadThemeModel(?int $id): void
+    {
+        if ($id !== null) {
+            $themeModel = $this->themeModelRepository->find($id);
+
+            if ($themeModel === null) {
+                throw new InvalidArgumentException('Could not find an active Theme with the specified ID');
+            }
+        } else {
+            $themeModel = $this->themeModelRepository->findDefault();
+
+            if ($themeModel === null) {
+                throw new RuntimeException('Could not find active default Theme to use');
+            }
+        }
+
+        $this->themeModel = $themeModel;
+    }
+
+    /**
+     * Loads the Extension by Package name, or the default Theme Package if null.
+     *
+     * @throws Exception
+     */
+    private function loadExtension(?string $packageName): void
+    {
+        if ($packageName !== null) {
+            $extension = $this->extensionRepositoryRegistry->getExistingExtensionFromPackageName($packageName);
+
+            if ($extension === null) {
+                throw new InvalidArgumentException('Could not find Extension Package with the specified name');
+            }
+        } else {
+            $extension = $this->themeRepository->getExisting(DEFAULT_THEME_PACKAGE);
+
+            if ($extension === null) {
+                throw new RuntimeException('Could not find default Theme Package to use');
+            }
+        }
+
+        $this->extension = $extension;
+    }
+
+    private function loadViewlet(ViewExtensionInterface $extension): void
+    {
+        $viewlet = $extension->getViewlet();
+
+        if ($extension instanceof HierarchicalExtensionInterface) {
+            $viewlet = new HierarchicalViewlet(
+                $extension->getViewlet(),
+                $this->extensionRepositoryRegistry->getRepositoryForExtensionClass($extension::class),
+                $this->optimization,
+            );
+
+            $viewlet->setBaseViewlets(
+                array_map(
+                    fn (string $codename) => $this->pluginRepository->get($codename)->getViewlet(),
+                    $this->mybb->cache?->read('plugins')['active'] ?? [],
+                ),
+            );
+        }
+
+        if ($extension instanceof Theme) {
+            $viewlet = ViewletDecorator::decorate(
+                $viewlet,
+                [
+                    PublishableViewlet::class,
+                    CompositeViewlet::class,
+                ],
+            );
+        }
+
+        $this->viewlet = $viewlet;
+    }
+
+    /**
+     * Validates and sets names of namespaces to use.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function loadNamespaces(array $namespaces): void
+    {
+        $validatedNamespaces = [];
+
+        foreach ($namespaces as $value) {
+            $namespaceType = NamespaceType::tryFromNamespace($value);
+
+            if ($namespaceType === null) {
+                throw new InvalidArgumentException('Invalid namespace `' . OutputFormatter::escape($value) . '`');
+            }
+
+            $validatedNamespaces[] = $value;
+        }
+
+
+        $this->namespaces = $validatedNamespaces;
+
+        if (CompositeViewlet::decorates($this->viewlet)) {
+            array_map(
+                $this->viewlet->applyNamespace(...),
+                $this->namespaces,
+            );
+        }
+    }
+
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function getInspectionSubject(): Asset|Resource
+    {
+        if ($this->input->getOption('resource') && $this->input->getOption('asset')) {
+            throw new InvalidArgumentException('Provide either a Resource or an Asset to inspect');
+        }
+
+        $packageName = null;
+
+
+        if ($this->input->getOption('resource')) {
+            $locator = $this->getResourceLocatorFromSubjectInput(
+                $this->input->getOption('resource'),
+                $packageName,
+            );
+
+            $subject = $this->viewlet->getResource($locator);
+        } elseif ($this->input->getOption('asset')) {
+            $locator = $this->getAssetLocatorFromSubjectInput(
+                $this->input->getOption('asset'),
+                $packageName,
+            );
+
+            $subject = $this->viewlet->getAsset($locator);
+        } else {
+            throw new InvalidArgumentException('Provide either a Resource or an Asset to inspect');
+        }
+
+
+        if (
+            $packageName !== null &&
+            $packageName !== $this->extension->getPackageName()
+        ) {
+            $this->io->note(
+                sprintf(
+                    'Subject from Package `%s` given, but resolution context for inspection is `%s`',
+                    OutputFormatter::escape($packageName),
+                    OutputFormatter::escape($this->extension->getPackageName()),
+                )
+            );
+        }
+
+
+        return $subject;
+    }
+
+    /**
+     * Returns an Asset Locator from interpreted subject input, which may be one of:
+     * - HTTP path,
+     * - absolute path,
+     * - web root-relative path, or
+     * - Locator string.
+     *
+     * @param-out ?string $packageName The implied Package name.
+     */
+    private function getAssetLocatorFromSubjectInput(
+        string $value,
+        ?string &$packageName = null,
+    ): Locator {
+        $appRootAbsolutePath = realpath(MYBB_ROOT);
+        $urlPrefix = $this->mybb->settings['bburl'] . '/';
+
+        if (str_starts_with($value, $urlPrefix)) {
+            $webRootRelativePath = substr($value, strlen($urlPrefix));
+        } elseif (Path::isBasePath($appRootAbsolutePath, $value)) {
+            $webRootRelativePath = Path::makeRelative($value, $appRootAbsolutePath);
+        } elseif (Path::isBasePath('cache', $value)) {
+            $webRootRelativePath = $value;
+        } else {
+            $webRootRelativePath = null;
+        }
+
+        if ($webRootRelativePath !== null) {
+            if (Path::isBasePath('cache/themes', $webRootRelativePath)) {
+                throw new InvalidArgumentException(
+                    'Legacy assets published within `cache/themes/` are not handled by the View system',
+                );
+            } elseif ($path = ViewletAsset::getLocatorFromPublicPath($webRootRelativePath, $packageName)) {
+                return $path;
+            } else {
+                throw new InvalidArgumentException('Unrecognized Asset path');
+            }
+        } else {
+            try {
+                return Locator::fromString($value);
+            } catch (LocatorException $e) {
+                throw new InvalidArgumentException(
+                    sprintf('Invalid Locator string `%s`', $value),
+                    previous: $e,
+                );
+            }
+        }
+    }
+
+    /**
+     * Returns a Resource Locator from interpreted subject input, which may be one of:
+     * - absolute path,
+     * - application root-relative path, or
+     * - Locator string.
+     *
+     * @param-out ?string $packageName The implied Package name.
+     */
+    private function getResourceLocatorFromSubjectInput(
+        string $value,
+        ?string &$packageName = null,
+    ): ViewletLocator {
+        $appRootAbsolutePath = realpath(MYBB_ROOT);
+
+        if (Path::isBasePath($appRootAbsolutePath, $value)) {
+            $appRootRelativePath = Path::makeRelative($value, $appRootAbsolutePath);
+        } elseif (Path::isBasePath('inc', $value)) {
+            $appRootRelativePath = $value;
+        } else {
+            $appRootRelativePath = null;
+        }
+
+        if ($appRootRelativePath !== null) {
+            $locator = $this->getResourceLocatorFromAppRootRelativePath(
+                $appRootRelativePath,
+                $packageName,
+            );
+
+            if ($locator === null) {
+                throw new InvalidArgumentException('Unrecognized Resource path');
+            }
+
+            return $locator;
+        } else {
+            try {
+                $locator = ViewletLocator::fromString($value);
+            } catch (LocatorException $e) {
+                throw new InvalidArgumentException(
+                    sprintf('Invalid Locator string `%s`', $value),
+                    previous: $e,
+                );
+            }
+        }
+
+
+        return $locator;
+    }
+
+    /**
+     * @param-out ?string $packageName The implied Package name.
+     */
+    private function getResourceLocatorFromAppRootRelativePath(
+        string $path,
+        ?string &$packageName = null,
+    ): ?ViewletLocator {
+        try {
+            $extension = $this->extensionRepositoryRegistry->getExtensionFromPath($path);
+
+            if ($extension instanceof ViewExtensionInterface) {
+                $packageName = $extension->getPackageName();
+
+                $resource = $extension->getViewlet()->getResourceFromAbsolutePath(
+                    Path::makeAbsolute($path, MYBB_ROOT)
+                );
+
+                return $resource->getLocator();
+            }
+        } catch (InvalidArgumentException | LogicException) {
+        }
+
+        return null;
+    }
+
+
+    private function outputInspection(Asset|Resource $subject): void
+    {
+        $this->io->newLine();
+
+        $this->outputResolutionContext();
+
+        if ($subject instanceof Asset) {
+            $this->outputAssetMetadata($subject);
+            $this->outputAssetProperties($subject);
+
+            if ($subject instanceof ViewletAsset) {
+                $this->outputAssetSourceResources($subject);
+            }
+
+            $this->outputAssetReferencesInResources($subject);
+        } elseif ($subject instanceof Resource) {
+            $this->outputResourceMetadata($subject);
+
+            if ($subject->exists()) {
+                if ($this->extension instanceof HierarchicalExtensionInterface) {
+                    $this->outputResourceAncestry($subject);
+                }
+            } else {
+                $this->io->note('Resource not found in this resolution context');
+            }
+
+            if (PublishableViewlet::decorates($this->viewlet)) {
+                $this->outputAssetsPublishedUsingResource($subject);
+            }
+        }
+    }
+
+    private function outputResolutionContext(): void
+    {
+        $this->io->writeln('<block-title>Resolution Context</block-title>');
+
+        $definitionList = [];
+
+
+        if (isset($this->themeModel)) {
+            $definitionList[] = [
+                'Theme Model' => Style::inlineListing([
+                    OutputFormatter::escape($this->themeModel->name),
+                    '#' . $this->themeModel->id,
+                ]),
+            ];
+        }
+
+
+        $definitionList[] = [
+            'Extension Package' => Style::inlineListing([
+                OutputFormatter::escape($this->extension->getPackageName()),
+                $this->getExtensionDescription($this->extension),
+                Style::filesystemPath($this->extension->getAbsolutePath()),
+            ]),
+        ];
+
+        if ($this->extension instanceof HierarchicalExtensionInterface) {
+            $extensionPackageAncestors = $this->extension->getAncestors($this->themeRepository);
+
+            if ($extensionPackageAncestors) {
+                $ancestorsString = implode(
+                    ', ',
+                    array_map(
+                        fn (Extension $extension) =>
+                            '<' . Style::extensionStyle($extension) . '>' .
+                            OutputFormatter::escape($extension->getPackageName()) .
+                            '</>',
+                        $extensionPackageAncestors,
+                    ),
+                );
+            } else {
+                $ancestorsString = '<minor>None</minor>';
+            }
+
+            $definitionList[] = [
+                'Extension Ancestors' => $ancestorsString,
+            ];
+        }
+
+
+        if (HierarchicalViewlet::decorates($this->viewlet)) {
+            $baseViewlets = $this->viewlet->getBaseViewlets();
+
+            if ($baseViewlets) {
+                $baseViewletsString = implode(
+                    ', ',
+                    array_map(
+                        fn (ViewletInterface $viewlet) =>
+                            '<' . Style::extensionStyle($viewlet->getExtension()) . '>' .
+                            OutputFormatter::escape($viewlet->getIdentifier()) .
+                            '</>',
+                        $baseViewlets,
+                    ),
+                );
+            } else {
+                $baseViewletsString = '<minor>None</minor>';
+            }
+
+            $definitionList[] = [
+                'Base Viewlets' => $baseViewletsString,
+            ];
+        }
+
+
+        if ($this->namespaces !== []) {
+            $namespacesList = array_map(
+                fn (string $namespace) =>
+                    OutputFormatter::escape($namespace) .
+                    '<minor>(' .
+                    NamespaceType::tryFromNamespace($namespace)->name .
+                    ')</minor>',
+                $this->namespaces,
+            );
+
+            $definitionList[] = [
+                'Namespaces' => implode(', ', $namespacesList),
+            ];
+        }
+
+
+        $this->io->definitionList(...$definitionList);
+    }
+
+    private function outputAssetMetadata(Asset $asset): void
+    {
+        $this->io->writeln(
+            sprintf(
+                '<block-title>Asset</block-title> %s',
+                Style::locator($asset->getLocator()),
+            )
+        );
+
+
+        $definitionList = [
+            [
+                'Asset Class' => match ($asset::class) {
+                    StaticAsset::class => 'Static Asset',
+                    ViewletAsset::class => 'Viewlet Asset',
+                },
+            ],
+        ];
+
+        $definitionList = array_merge(
+            $definitionList,
+            $this->getLocatorDefinitionList($asset->getLocator()),
+        );
+
+        if (
+            $asset instanceof StaticAsset &&
+            $asset->getType()
+        ) {
+            $definitionList[] = [
+                'Type' => Style::inlineListing([
+                    '<generic>' . $asset->getType()->name . '</generic>',
+                ]),
+            ];
+        }
+
+
+        if (
+            $asset instanceof ViewletAsset ||
+            (
+                $asset instanceof StaticAsset &&
+                $asset->isInApplicationDirectory()
+            )
+        ) {
+            $definitionList = array_merge(
+                $definitionList,
+                $this->getFileDefinitionList($asset),
+            );
+        }
+
+
+        if ($asset instanceof ViewletAsset) {
+            $definitionList[] = [
+                'Source Resource' => Style::locator(
+                    $asset->getResource()->getLocator()
+                ),
+            ];
+            $definitionList[] = [
+                'Plain' => Publication::isPlain($asset)
+                    ? 'Yes'
+                    : 'No',
+            ];
+            $definitionList[] = [
+                'Publication' => match ($this->viewlet->getAssetPublicationBasis($asset)) {
+                    PublishableViewlet::PUBLICATION_BASIS_EXPLICIT => '<positive>Explicit</positive>',
+                    PublishableViewlet::PUBLICATION_BASIS_IMPLICIT => '<positive>Implicit</positive>',
+                    null => '<neutral>No</neutral>',
+                },
+            ];
+
+            if ($asset->exists()) {
+                $definitionList[] = [
+                    'Needs Update' => $this->assetNeedsUpdate($asset)
+                        ? '<warning>Yes</warning>'
+                        : 'No',
+                ];
+            }
+        }
+
+        $definitionList[] = [
+            'Public Path' => '<path>' . OutputFormatter::escape($asset->getPublicPath()) . '</path>',
+        ];
+        $definitionList[] = [
+            'URL' => Style::url(
+                $asset->getUrl(useCdn: false)
+            ),
+        ];
+        $definitionList[] = [
+            'CDN URL' => Style::url(
+                $asset->getUrl(useCdn: true)
+            ),
+        ];
+
+
+        $this->io->definitionList(...$definitionList);
+
+        $this->io->newLine();
+    }
+
+    private function outputAssetProperties(Asset $asset): void
+    {
+        if (CompositeViewlet::decorates($this->viewlet)) {
+            $this->io->writeln('<block-title>Asset Properties</block-title>');
+
+            $this->io->writeln(
+                '<code>' .
+                OutputFormatter::escape(
+                    json_encode(
+                        $this->viewlet->getCompositeAssetProperties($asset->getLocator()),
+                        JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+                    )
+                ) .
+                '</code>'
+            );
+
+            $this->io->newLine();
+        }
+    }
+
+    private function outputAssetSourceResources(ViewletAsset $asset): void
+    {
+        $sourceViewletIdentifiers = Publication::getPublishedAssetSourceViewletIdentifiers($asset);
+
+        $this->io->writeln('<block-title>Contributing Resources</block-title>');
+
+        if ($sourceViewletIdentifiers === [] || $sourceViewletIdentifiers === null) {
+            $this->io->writeln(
+                '<minor>None</minor>'
+            );
+            $this->io->newLine();
+        } else {
+            $rows = [];
+
+            foreach ($sourceViewletIdentifiers as $locatorString => $sourceViewletIdentifier) {
+                if (HierarchicalViewlet::decorates($this->viewlet)) {
+                    $sourceViewlet = $this->viewlet->getViewlets()[$sourceViewletIdentifier] ?? null;
+                } elseif ($this->viewlet->getIdentifier() === $sourceViewletIdentifier) {
+                    $sourceViewlet = $this->viewlet;
+                } else {
+                    $sourceViewlet = null;
+                }
+
+                $sourceViewletExtension = $sourceViewlet?->getExtension();
+
+                $rows[] = [
+                    Style::locator(ViewletLocator::fromString($locatorString)),
+                    '<' . Style::extensionStyle($sourceViewletExtension) . '>' .
+                    OutputFormatter::escape($sourceViewletIdentifier) .
+                    '</>',
+                ];
+            }
+
+            $this->io->table(
+                [
+                    'Locator',
+                    'Viewlet',
+                ],
+                $rows,
+            );
+        }
+    }
+
+    private function outputAssetReferencesInResources(Asset $asset): void
+    {
+        $this->io->writeln('<block-title>Asset References in Templates</block-title>');
+
+
+        $searchedTemplateCount = 0;
+        $unresolvedExpressionCount = 0;
+        $exceptions = [];
+
+        $startTime = microtime(true);
+
+        $results = $this->getAssetReferencesInTemplates(
+            $asset->getLocator(),
+            $searchedTemplateCount,
+            $unresolvedExpressionCount,
+            $exceptions,
+            outputProgress: $this->input->isInteractive(),
+        );
+
+        $endTime = microtime(true);
+
+        $searchTimeSeconds = $endTime - $startTime;
+
+
+        if ($results === []) {
+            $this->io->writeln(
+                '<minor>No matched references</minor>'
+            );
+        } else {
+            $rows = [];
+
+            foreach ($results as $result) {
+                $argument = OutputFormatter::escape($result['arguments']['locator']);
+
+                if (!empty($result['arguments']['static'])) {
+                    $argument .= ', static=true';
+                }
+
+                $rows[] = [
+                    Style::locator(
+                        ViewletLocator::fromResourceContextString(
+                            $result['template'],
+                            type: ResourceType::TEMPLATE,
+                            contextNamespace: null,
+                        ),
+                    ),
+                    $result['line'],
+                    '<generic>' . OutputFormatter::escape($result['function']) . '()</generic>',
+                    '<code>' . $argument . '</code>',
+                ];
+            }
+
+            $this->io->table(
+                [
+                    'Template',
+                    'Line',
+                    'Function',
+                    'Locator Argument',
+                ],
+                $rows,
+            );
+        }
+
+
+        $stats = [
+            sprintf(
+                'Searched %d Templates in %.4f s',
+                $searchedTemplateCount,
+                $searchTimeSeconds,
+            ),
+        ];
+
+        if ($unresolvedExpressionCount !== 0) {
+            $stats[] = sprintf(
+                '%d unresolved expressions',
+                $unresolvedExpressionCount,
+            );
+        }
+
+        if ($exceptions !== []) {
+            $stats[] = sprintf(
+                '%d Template processing errors',
+                count($exceptions),
+            );
+        }
+
+        $this->io->writeln(
+            '<minor>' . Style::inlineListing($stats) . '</minor>'
+        );
+
+
+        $this->io->newLine();
+    }
+
+    /**
+     * @throws LocatorException
+     */
+    private function outputResourceMetadata(Resource $resource): void
+    {
+        $this->io->newLine();
+
+        $this->io->writeln(
+            sprintf(
+                '<block-title>Resource</block-title> <value>%s</value>',
+                Style::locator($resource->getLocator()),
+            )
+        );
+
+
+        $definitionList = [
+            ...$this->getLocatorDefinitionList($resource->getLocator()),
+            ...$this->getFileDefinitionList($resource),
+            [
+                'Code Language' => OutputFormatter::escape($resource->getCodeLanguage()?->value),
+            ],
+        ];
+
+        if ($resource->exists()) {
+            $syntaxErrors = $resource->getCodeLanguage()?->getSyntaxErrors(
+                $resource->getContent(),
+                $resource->getLocator()->getString(),
+            );
+
+            if ($syntaxErrors !== null) {
+                $definitionList[] = [
+                    'Syntax Status' => $syntaxErrors === [] ? 'Valid' : '<negative>Invalid</negative>',
+                ];
+            }
+        } else {
+            $syntaxErrors = null;
+        }
+
+
+        if (PublishableViewlet::decorates($this->viewlet)) {
+            $definitionList[] = [
+                'Publishable' => match ($this->viewlet->getResourcePublicationBasis($resource)) {
+                    PublishableViewlet::PUBLICATION_BASIS_EXPLICIT => '<positive>Yes, Explicit</positive>',
+                    PublishableViewlet::PUBLICATION_BASIS_IMPLICIT => '<positive>Yes, Implicit</positive>',
+                    null => '<neutral>No</neutral>',
+                },
+            ];
+        }
+
+
+        $this->io->definitionList(...$definitionList);
+
+
+        if ($syntaxErrors) {
+            $this->io->writeln('<block-title>Resource Syntax Errors</block-title>');
+
+            foreach ($syntaxErrors as $exception) {
+                $this->io->warning(
+                    $exception->getMessage(),
+                );
+            }
+        }
+    }
+
+    private function outputResourceAncestry(Resource $resource): void
+    {
+        $resourceRepository = $resource->getRepository();
+        $key = $resource->getRepositoryKey();
+
+        $repositories = $resourceRepository->getRepositories();
+
+        $resolvedRepository = $resourceRepository->getResolvedRepository($key);
+
+        $rows = [];
+
+        $i = 0;
+
+        foreach (array_reverse($repositories) as $repository) {
+            $flags = [];
+
+            if ($repository->getHierarchicalIdentifier() === $resolvedRepository?->getHierarchicalIdentifier()) {
+                $flags[] = '<signal>✓ Effective</signal>';
+            }
+
+            if (!$repository->entityDeclaredInherited($key)) {
+                $flags[] = '<negative>✖ Not Inherited</negative>';
+            }
+
+            $extension = $repository->viewlet->getExtension();
+
+            $rows[] = [
+                ++$i,
+                Style::inlineListing([
+                    OutputFormatter::escape($extension->getPackageName()),
+                    $this->getExtensionDescription($extension),
+                ]),
+                $repository->has($key)
+                    ? Style::inlineListing([
+                        'Found',
+                        Style::filesystemPath(
+                            $repository->get($key)->getAbsolutePath()
+                        ),
+                    ])
+                    : '<minor>Not Found</minor>',
+                implode(', ', $flags),
+            ];
+        }
+
+
+        $this->io->writeln('<block-title>Resource Ancestry</block-title> <minor>(ascending priority)</minor>');
+
+        $this->io->table(
+            [
+                '#',
+                'Extension Package',
+                'Status',
+                'Resolution',
+            ],
+            $rows,
+        );
+
+        $this->io->newLine();
+    }
+
+    private function outputAssetsPublishedUsingResource(Resource $resource): void
+    {
+        $assets = $this->viewlet->getAssetsFromResource($resource);
+
+        $this->io->writeln('<block-title>Assets Published Using Resource</block-title>');
+
+        if ($assets === []) {
+            $this->io->writeln(
+                '<minor>None</minor>'
+            );
+        } else {
+            $rows = [];
+
+            foreach ($assets as $asset) {
+                $rows[] = [
+                    Style::locator($asset->getLocator()),
+                    Style::filesystemPath($asset->getPublicPath()),
+                ];
+            }
+
+            $this->io->table(
+                [
+                    'Locator',
+                    'Public Path',
+                ],
+                $rows,
+            );
+        }
+
+        $this->io->newLine();
+    }
+
+
+    /**
+     * Returns information about template expressions involving the given Asset.
+     *
+     * @param-out list<LoaderError|SyntaxError> $exceptions
+     * @return list<array{
+     *     template: string,
+     *     line: int,
+     *     function: string,
+     *     arguments: array,
+     * }>
+     */
+    private function getAssetReferencesInTemplates(
+        Locator $assetLocator,
+        int &$searchedTemplateCount = 0,
+        int &$unresolvedExpressionCount = 0,
+        array &$exceptions = [],
+        bool $outputProgress = false,
+    ): array {
+        $results = [];
+
+
+        $templateResources = $this->viewlet->getResources(
+            namespaces: $this->namespaces === [] ? null : $this->namespaces,
+            resourceTypes: [
+                ResourceType::TEMPLATE,
+            ],
+        );
+
+
+        $inspector = new Inspector(
+            new ViewletLoader($this->viewlet)
+        );
+
+        $inspection = new FunctionExpressionInspection();
+
+        $inspection->addTargetFunction('asset', [
+            0 => 'locator',
+            1 => 'static',
+        ]);
+        $inspection->addTargetFunction('asset_url', [
+            0 => 'locator',
+            1 => 'static',
+        ]);
+
+        $inspector->addInspection($inspection);
+
+
+        if ($outputProgress === true) {
+            $progressBar = $this->io->createProgressBar();
+
+            $progressBar->setRedrawFrequency(1);
+            $progressBar->maxSecondsBetweenRedraws(0.1);
+            $progressBar->minSecondsBetweenRedraws(0.1);
+        } else {
+            $progressBar = null;
+        }
+
+        try {
+            foreach ($progressBar?->iterate($templateResources) ?? $templateResources as $resource) {
+                try {
+                    $inspector->inspectTemplate(
+                        $resource->getLocator()->getString([
+                            'type' => ViewletLocator::COMPONENT_UNSET,
+                        ]),
+                    );
+                } catch (LoaderError | SyntaxError $e) {
+                    $exceptions[] = $e;
+                }
+            }
+        } finally {
+            $progressBar?->clear();
+        }
+
+
+        foreach ($inspection->getResults() as $call) {
+            if (
+                !isset($call['arguments']['locator']) ||
+                !is_string($call['arguments']['locator'])
+            ) {
+                continue;
+            }
+
+            try {
+                if (($call['arguments']['static'] ?? null) === true) {
+                    $locatorFromArgument = StaticLocator::fromString($call['arguments']['locator']);
+                } else {
+                    $resourceLocator = ViewletLocator::fromResourceContextString(
+                        $call['template'],
+                        ResourceType::TEMPLATE,
+                        contextNamespace: null,
+                    );
+
+                    $locatorFromArgument = Locator::fromString(
+                        $call['arguments']['locator'],
+                        [
+                            'type' => ViewletLocator::COMPONENT_SET,
+                            'namespace' => ViewletLocator::COMPONENT_CONTEXT,
+                        ],
+                        [
+                            'namespace' => $resourceLocator->getNamespace(),
+                        ],
+                    );
+                }
+
+                if ($assetLocator->getString() === $locatorFromArgument->getString()) {
+                    $results[] = $call;
+                }
+            } catch (LocatorException) {
+                continue;
+            }
+        }
+
+        $searchedTemplateCount = count($templateResources);
+        $unresolvedExpressionCount = $inspection->getUnresolvedExpressionCount();
+
+        return $results;
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function getLocatorDefinitionList(Locator $locator): array
+    {
+        if ($locator instanceof StaticLocator) {
+            if ($locator->isRemote()) {
+                $pathType = 'Remote';
+            } elseif ($locator->isCurrentDirectoryRelative()) {
+                $pathType = 'Current Directory-Relative';
+            } else {
+                $pathType = 'Absolute';
+            }
+
+            return [
+                [
+                    'Path Type' => $pathType,
+                ],
+            ];
+        } elseif ($locator instanceof ViewletLocator) {
+            $namespaceType = NamespaceType::tryFromNamespace($locator->getNamespace());
+
+            $namespaceStyle = match ($namespaceType) {
+                NamespaceType::GENERIC => 'generic',
+                NamespaceType::EXTENSION => 'extension',
+            };
+
+            return [
+                [
+                    'Namespace' => Style::inlineListing([
+                        $locator->getNamespace(),
+                        '<' . $namespaceStyle . '>' . OutputFormatter::escape($namespaceType->name) . '</>',
+                    ]),
+                ],
+                [
+                    'Type' => Style::inlineListing([
+                        '<generic>' . $locator->getType()->name . '</generic>',
+                        '<path>' . $locator->getType()->getDirectoryName() . '/' . '</path>',
+                    ]),
+                ],
+                [
+                    'Group' => $locator->getGroup()
+                        ? OutputFormatter::escape($locator->getGroup())
+                        : '<minor>-</minor>',
+                ],
+                [
+                    'Filename' => '<path>' . OutputFormatter::escape($locator->getFilename()) . '</path>',
+                ],
+            ];
+        } else {
+            throw new UnexpectedValueException();
+        }
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function getFileDefinitionList(Asset|Resource $subject): array
+    {
+        $definitionList = [
+            [
+                'Absolute Path' => Style::filesystemPath($subject->getAbsolutePath()),
+            ],
+            [
+                'Exists' => $subject->exists()
+                    ? '<positive>Yes</positive>'
+                    : '<neutral>No</neutral>',
+            ],
+        ];
+
+        if ($subject->exists()) {
+            $modificationTime = $subject->getModificationTime();
+
+            $definitionList[] = [
+                'Size' => get_friendly_size(filesize($subject->getAbsolutePath())),
+            ];
+            $definitionList[] = [
+                'Modification Time' => Style::inlineListing([
+                    date('c', $modificationTime),
+                    strip_tags(my_date('relative', $modificationTime)),
+                ]),
+            ];
+        }
+
+        return $definitionList;
+    }
+
+    private function assetNeedsUpdate(ViewletAsset $asset): bool
+    {
+        $publication = app()->make(Publication::class, [
+            'asset' => $asset,
+        ]);
+
+        return $publication->needsUpdate();
+    }
+
+    private function getExtensionDescription(Extension $extension): string
+    {
+        return match (get_class($extension)) {
+            Plugin::class => '<fg=yellow>Plugin</>',
+            Theme::class => match ($extension->getType()) {
+                ThemeType::CORE => '<core>Built-in Theme</core>',
+                ThemeType::ORIGINAL => '<extension>Imported Theme</extension>',
+                ThemeType::BOARD => '<theme-model>Custom Theme</theme-model>',
+            },
+        };
+    }
+}

--- a/inc/src/Console/Style.php
+++ b/inc/src/Console/Style.php
@@ -35,7 +35,9 @@ class Style extends SymfonyStyle
     {
         $applicationAbsolutePath = Path::canonicalize(MYBB_ROOT);
 
-        if ($relativePath = Path::makeRelative($path, $applicationAbsolutePath)) {
+        if (Path::isBasePath($applicationAbsolutePath, $path)) {
+            $relativePath = Path::makeRelative($path, $applicationAbsolutePath);
+
             return
                 '<base-path>' .  OutputFormatter::escape($applicationAbsolutePath) . '/' . '</base-path>' .
                 '<path>' . OutputFormatter::escape($relativePath) . '</path>';

--- a/inc/src/Console/Style.php
+++ b/inc/src/Console/Style.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Console;
+
+use MyBB\Extensions\Extension;
+use MyBB\Extensions\Plugin\Plugin;
+use MyBB\Extensions\Theme\Theme;
+use MyBB\Extensions\Theme\ThemeType;
+use MyBB\View\Locator\Exception as LocatorException;
+use MyBB\View\Locator\Locator;
+use MyBB\View\Locator\ViewletLocator;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Path;
+
+class Style extends SymfonyStyle
+{
+    /**
+     * @param string[] $items
+     */
+    public static function inlineListing(array $items): string
+    {
+        return implode(
+            ' <minor>·</minor> ',
+            $items,
+        );
+    }
+
+    public static function filesystemPath(string $path): string
+    {
+        $applicationAbsolutePath = Path::canonicalize(MYBB_ROOT);
+
+        if ($relativePath = Path::makeRelative($path, $applicationAbsolutePath)) {
+            return
+                '<base-path>' .  OutputFormatter::escape($applicationAbsolutePath) . '/' . '</base-path>' .
+                '<path>' . OutputFormatter::escape($relativePath) . '</path>';
+        } else {
+            return OutputFormatter::escape($path);
+        }
+    }
+
+    public static function url(string $url): string
+    {
+        $urlEscaped = OutputFormatter::escape($url);
+
+        return '<href="' . $urlEscaped . '">' . $urlEscaped . '</>';
+    }
+
+    /**
+     * @throws LocatorException
+     */
+    public static function locator(Locator $locator): string
+    {
+        if ($locator instanceof ViewletLocator) {
+            $decoratedString = OutputFormatter::escape($locator->getString());
+
+            $prefix =
+                ViewletLocator::NAMESPACE_PREFIX .
+                $locator->getNamespace() .
+                ViewletLocator::DIRECTORY_SEPARATOR .
+                $locator->getType()->getDirectoryName() .
+                ViewletLocator::DIRECTORY_SEPARATOR;
+
+            $prefixEscaped = OutputFormatter::escape($prefix);
+
+            if (str_starts_with($decoratedString, $prefixEscaped)) {
+                $decoratedString = substr_replace(
+                    $decoratedString,
+                    '<path>' . $prefixEscaped . '</path>',
+                    0,
+                    strlen($prefixEscaped),
+                );
+            }
+
+            return $decoratedString;
+        } else {
+            return '<base-path>' . OutputFormatter::escape($locator->getString()) . '</base-path>';
+        }
+    }
+
+    public static function extensionStyle(?Extension $extension): string
+    {
+        if ($extension === null) {
+            return 'minor';
+        }
+
+        return match ($extension::class) {
+            Plugin::class => 'plugin',
+            Theme::class => match ($extension->getType()) {
+                ThemeType::CORE => 'core',
+                ThemeType::ORIGINAL => 'extension',
+                ThemeType::BOARD => 'generic',
+            },
+            default => 'minor',
+        };
+    }
+
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        parent::__construct($input, $output);
+
+        $formatter = $output->getFormatter();
+
+        // structural elements
+        $formatter->setStyle(
+            'block-title',
+            new OutputFormatterStyle(options: ['bold']),
+        );
+
+        // generic elements
+        $formatter->setStyle(
+            'key',
+            new OutputFormatterStyle(options: ['bold']),
+        );
+        $formatter->setStyle(
+            'value',
+            new OutputFormatterStyle(),
+        );
+        $formatter->setStyle(
+            'base-path',
+            new OutputFormatterStyle('green'),
+        );
+        $formatter->setStyle(
+            'path',
+            new OutputFormatterStyle('bright-green'),
+        );
+        $formatter->setStyle(
+            'code',
+            new OutputFormatterStyle('green'),
+        );
+
+        // generic semantics
+        $formatter->setStyle(
+            'minor',
+            new OutputFormatterStyle('gray'),
+        );
+        $formatter->setStyle(
+            'neutral',
+            new OutputFormatterStyle('gray'),
+        );
+        $formatter->setStyle(
+            'negative',
+            new OutputFormatterStyle('bright-red'),
+        );
+        $formatter->setStyle(
+            'positive',
+            new OutputFormatterStyle('bright-green'),
+        );
+        $formatter->setStyle(
+            'signal',
+            new OutputFormatterStyle('cyan'),
+        );
+        $formatter->setStyle(
+            'warning',
+            new OutputFormatterStyle('yellow'),
+        );
+
+        // entity semantics
+        $formatter->setStyle(
+            'generic',
+            new OutputFormatterStyle('white'),
+        );
+        $formatter->setStyle(
+            'core',
+            new OutputFormatterStyle('bright-blue'),
+        );
+        $formatter->setStyle(
+            'extension',
+            new OutputFormatterStyle('bright-magenta'),
+        );
+        $formatter->setStyle(
+            'plugin',
+            new OutputFormatterStyle('bright-yellow'),
+        );
+        $formatter->setStyle(
+            'theme-model',
+            new OutputFormatterStyle('bright-cyan'),
+        );
+    }
+}

--- a/inc/src/Twig/Inspection/FunctionExpressionInspection.php
+++ b/inc/src/Twig/Inspection/FunctionExpressionInspection.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Twig\Inspection;
+
+use Twig\Environment;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\Node;
+use Twig\NodeVisitor\NodeVisitorInterface;
+
+/**
+ * Collects information about function calls in Twig templates.
+ */
+class FunctionExpressionInspection implements NodeVisitorInterface
+{
+    /**
+     * Mapping of argument Node keys (integer positions or string names) to target argument names, by function name.
+     *
+     * @var array<string, ?array<non-negative-int|string, string>>
+     */
+    private array $argumentNodeMapByFunction = [];
+
+    /**
+     * @var list<array{
+     *   template: string,
+     *   line: int,
+     *   function: string,
+     *   arguments: array<non-negative-int|string, mixed>,
+     * }>
+     */
+    private array $results = [];
+
+    /**
+     * A count of function calls with any unresolvable argument value.
+     */
+    private int $unresolvedExpressionCount = 0;
+
+    public function __construct(
+        /**
+         * Whether to resolve target argument values from their Node representations.
+         *
+         * Function expressions with unresolved argument values will be skipped.
+         */
+        public readonly bool $resolveTargetNodes = true,
+    ) {}
+
+    /**
+     * Registers a function to search for.
+     *
+     * @param ?array<non-negative-int, string> $arguments
+     *   A mapping of positions to names of target arguments.
+     *
+     *   If `null`, all of its arguments are included without position-name deduplication.
+     *
+     *   If any included argument's literal value cannot be resolved, the function call is skipped.
+     */
+    public function addTargetFunction(string $name, ?array $arguments): void
+    {
+        if ($arguments === null) {
+            $this->argumentNodeMapByFunction[$name] = null;
+        } else {
+            $this->argumentNodeMapByFunction[$name] = [];
+
+            foreach ($arguments as $argumentPosition => $argumentName) {
+                $this->argumentNodeMapByFunction[$name][$argumentPosition] = $argumentName;
+                $this->argumentNodeMapByFunction[$name][$argumentName] = $argumentName;
+            }
+        }
+    }
+
+    /**
+     * @return list<array{
+     *   template: string,
+     *   line: int,
+     *   function: string,
+     *   arguments: array<array-key, mixed>,
+     * }>
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    public function getUnresolvedExpressionCount(): int
+    {
+        return $this->unresolvedExpressionCount;
+    }
+
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        $this->inspectNode($node);
+
+        return $node;
+    }
+
+    public function leaveNode(Node $node, Environment $env): ?Node
+    {
+        return $node;
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    private function inspectNode(Node $node): void
+    {
+        if (!($node instanceof FunctionExpression)) {
+            return;
+        }
+
+        $name = $node->getAttribute('name');
+
+        if (!array_key_exists($name, $this->argumentNodeMapByFunction)) {
+            return;
+        }
+
+
+        $argumentNodeMap = $this->argumentNodeMapByFunction[$name];
+
+        $mappedArguments = $this->getMappedArguments($node, $argumentNodeMap);
+
+        if ($mappedArguments !== null) {
+            $this->results[] = [
+                'template' => $node->getTemplateName() ?? '',
+                'line' => $node->getTemplateLine(),
+                'function' => $name,
+                'arguments' => $mappedArguments,
+            ];
+        } else {
+            $this->unresolvedExpressionCount++;
+        }
+    }
+
+    /**
+     * @param Node $node The Node containing an arguments Node.
+     * @param ?array<non-negative-int|string, string> $argumentNodeMap
+     *   Mapping of argument Node keys (integer positions or string names) to target argument names.
+     * @return ?array<non-negative-int|string, mixed> Argument values, or `null` if an argument cannot be resolved.
+     */
+    private function getMappedArguments(Node $node, ?array $argumentNodeMap): ?array
+    {
+        $results = [];
+
+        foreach ($node->getNode('arguments') as $argumentNodeKey => $argumentNode) {
+            if (
+                $argumentNodeMap === null ||
+                array_key_exists($argumentNodeKey, $argumentNodeMap)
+            ) {
+                if ($this->resolveTargetNodes === true) {
+                    if (!($argumentNode instanceof ConstantExpression)) {
+                        return null;
+                    } else {
+                        $value = $argumentNode->getAttribute('value');
+                    }
+                } else {
+                    $value = $argumentNode;
+                }
+
+                $resultKey = $argumentNodeMap === null
+                    ? $argumentNodeKey
+                    : $argumentNodeMap[$argumentNodeKey];
+
+                $results[$resultKey] = $value;
+            }
+        }
+
+        return $results;
+    }
+}

--- a/inc/src/Twig/Inspection/Inspector.php
+++ b/inc/src/Twig/Inspection/Inspector.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyBB\Twig\Inspection;
+
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\SyntaxError;
+use Twig\Loader\LoaderInterface;
+use Twig\NodeVisitor\NodeVisitorInterface;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+/**
+ * Calls given Inspections by visiting Twig Nodes recursively.
+ */
+class Inspector
+{
+    private Environment $twig;
+
+    public function __construct(LoaderInterface $loader)
+    {
+        $this->twig = new Environment($loader);
+
+        // prevent hard errors for utilities unknown to the Environment
+        $this->twig->registerUndefinedFunctionCallback(static function ($name) {
+            return new TwigFunction($name, static function (...$args) {
+                return '';
+            });
+        });
+        $this->twig->registerUndefinedFilterCallback(static function ($name) {
+            return new TwigFilter($name, static function (...$args) {
+                return '';
+            });
+        });
+    }
+
+    public function addInspection(NodeVisitorInterface $visitor): void
+    {
+        $this->twig->addNodeVisitor($visitor);
+    }
+
+    /**
+     * @throws SyntaxError
+     * @throws LoaderError
+     */
+    public function inspectTemplate(string $name): void
+    {
+        $this->twig->parse(
+            $this->twig->tokenize(
+                $this->twig->getLoader()->getSourceContext($name)
+            )
+        );
+    }
+}

--- a/inc/src/Utilities/CodeLanguage.php
+++ b/inc/src/Utilities/CodeLanguage.php
@@ -4,6 +4,17 @@ declare(strict_types=1);
 
 namespace MyBB\Utilities;
 
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
+use ScssPhp\ScssPhp\Exception\SassException;
+use ScssPhp\ScssPhp\Syntax;
+use Throwable;
+use Twig\Environment;
+use Twig\Error\SyntaxError;
+use Twig\Loader\ArrayLoader;
+use Twig\Source;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
 enum CodeLanguage: string
 {
     case CSS = 'CSS';
@@ -29,5 +40,89 @@ enum CodeLanguage: string
             'twig' => self::TWIG,
             default => null,
         };
+    }
+
+    /**
+     * Returns whether syntax errors were detected, or `null` if no checks were performed.
+     */
+    public function syntaxValid(string $content): ?bool
+    {
+        $results = $this->getSyntaxErrors($content, null);
+
+        return $results === null
+            ? null
+            : $results === [];
+    }
+
+    /**
+     * Returns an array of detected errors, or `null` if no checks were performed.
+     *
+     * @return ?Throwable[]
+     *
+     * @note May call internal third-party features to ignore configuration-related issues.
+     */
+    public function getSyntaxErrors(string $content, ?string $path): ?array
+    {
+        return match ($this) {
+            self::CSS,
+            self::SASS,
+            self::SCSS,
+                => $this->getStyleSyntaxErrors($content),
+            self::TWIG,
+                => $this->getTwigSyntaxErrors($content, $path),
+            default => null,
+        };
+    }
+
+    private function getStyleSyntaxErrors(string $content): array
+    {
+        $syntax = match ($this) {
+            self::CSS => Syntax::CSS,
+            self::SASS => Syntax::SASS,
+            self::SCSS => Syntax::SCSS,
+        };
+
+        try {
+            Stylesheet::parse($content, $syntax);
+        } catch (SassException $e) {
+            if (!str_contains($e->getMessage(), 'Undefined')) {
+                return [$e];
+            }
+        }
+
+        return [];
+    }
+
+    private function getTwigSyntaxErrors(string $content, ?string $path): array
+    {
+        $twig = new Environment(
+            new ArrayLoader()
+        );
+
+        $twig->registerUndefinedFunctionCallback(function ($name) {
+            return new TwigFunction($name, static function (...$args) {
+                return '';
+            });
+        });
+        $twig->registerUndefinedFilterCallback(function ($name) {
+            return new TwigFilter($name, static function (...$args) {
+                return '';
+            });
+        });
+
+        try {
+            $twig->parse(
+                $twig->tokenize(
+                    new Source(
+                        $content,
+                        $path ?? '',
+                    )
+                )
+            );
+        } catch (SyntaxError $e) {
+            return [$e];
+        }
+
+        return [];
     }
 }

--- a/inc/src/View/Asset/Publication.php
+++ b/inc/src/View/Asset/Publication.php
@@ -76,6 +76,26 @@ class Publication
     }
 
     /**
+     * Returns an array of source Viewlet identifiers for a published Asset, indexed by the source Locator string,
+     *   or `null` if no source information is found.
+     *
+     * @return ?array<string, string>
+     */
+    public static function getPublishedAssetSourceViewletIdentifiers(ViewletAsset $asset): ?array
+    {
+        $sourceSignatures = self::getPublishedAssetSourceSignatures($asset);
+
+        if ($sourceSignatures === null) {
+            return null;
+        }
+
+        return array_combine(
+            array_keys($sourceSignatures),
+            array_column($sourceSignatures, 'viewlet'),
+        );
+    }
+
+    /**
      * Returns Assets published using the provided Resource, indexed by Locator string.
      *
      * @return array<string, ViewletAsset>

--- a/inc/src/View/Locator/ViewletLocator.php
+++ b/inc/src/View/Locator/ViewletLocator.php
@@ -16,8 +16,8 @@ class ViewletLocator extends Locator
     final public const COMPONENT_CONTEXT = 8;
     final public const COMPONENT_UNSET = 16;
 
-    private const NAMESPACE_PREFIX = '@';
-    private const DIRECTORY_SEPARATOR = '/';
+    final public const NAMESPACE_PREFIX = '@';
+    final public const DIRECTORY_SEPARATOR = '/';
 
     public readonly ?ResourceType $type;
     public readonly ?string $namespace;

--- a/inc/src/View/Viewlet/Decorator/Hierarchy/HierarchicalViewlet.php
+++ b/inc/src/View/Viewlet/Decorator/Hierarchy/HierarchicalViewlet.php
@@ -94,6 +94,14 @@ class HierarchicalViewlet extends ViewletDecorator
         $this->baseViewlets = $viewlets;
     }
 
+    /**
+     * @return ViewletInterface[]
+     */
+    public function getBaseViewlets(): array
+    {
+        return $this->baseViewlets;
+    }
+
     public function getOwnViewlet(): Viewlet
     {
         /** @var Viewlet */

--- a/inc/src/View/Viewlet/Decorator/PublishableViewlet.php
+++ b/inc/src/View/Viewlet/Decorator/PublishableViewlet.php
@@ -39,6 +39,18 @@ class PublishableViewlet extends ViewletDecorator
      */
     final public const PUBLISH_ALWAYS = 8;
 
+
+    /**
+     * The Asset/Resource is declared for publication in Asset Properties.
+     */
+    final public const PUBLICATION_BASIS_EXPLICIT = 2;
+
+    /**
+     * The publication of an Asset/Resource is implied by its Resource Type.
+     */
+    final public const PUBLICATION_BASIS_IMPLICIT = 4;
+
+
     /**
      * When to publish Asset files.
      *
@@ -269,6 +281,8 @@ class PublishableViewlet extends ViewletDecorator
     /**
      * Returns Assets referenced in the properties file.
      *
+     * @see self::PUBLICATION_BASIS_EXPLICIT
+     *
      * @param ?array<string, Resource> $sourceResources
      * @return ViewletAsset[]
      */
@@ -312,6 +326,8 @@ class PublishableViewlet extends ViewletDecorator
     /**
      * Returns Assets that could be published without being referenced in the properties file.
      *
+     * @see self::PUBLICATION_BASIS_IMPLICIT
+     *
      * @param ?array<string, Resource> $sourceResources
      * @return ViewletAsset[]
      */
@@ -347,6 +363,50 @@ class PublishableViewlet extends ViewletDecorator
     public function getPublishableResources(): array
     {
         return $this->getResources(resourceTypes: Publication::PUBLISHABLE_RESOURCE_TYPES);
+    }
+
+    /**
+     * Returns the current reason why the given Resource would be published directly as an Asset.
+     *
+     * @return ?self::PUBLICATION_BASIS_*
+     */
+    public function getResourcePublicationBasis(Resource $resource): ?int
+    {
+        if (Publication::resourcePublishable($resource)) {
+            $sourceResources = [
+                $resource->getLocator()->getString() => $resource,
+            ];
+
+            if ($this->getExplicitlyPublishableAssets($sourceResources) !== []) {
+                return self::PUBLICATION_BASIS_EXPLICIT;
+            }
+
+            if ($this->getImplicitlyPublishableAssets($sourceResources) !== []) {
+                return self::PUBLICATION_BASIS_IMPLICIT;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the current reason why the given Viewlet Asset would be published.
+     *
+     * @return ?self::PUBLICATION_BASIS_*
+     */
+    public function getAssetPublicationBasis(ViewletAsset $asset): ?int
+    {
+        $locatorString = $asset->getLocator()->getString();
+
+        if (array_key_exists($locatorString, $this->getExplicitlyPublishableAssets())) {
+            return self::PUBLICATION_BASIS_EXPLICIT;
+        }
+
+        if (array_key_exists($locatorString, $this->getImplicitlyPublishableAssets())) {
+            return self::PUBLICATION_BASIS_IMPLICIT;
+        }
+
+        return null;
     }
 
     /**

--- a/inc/src/View/Viewlet/NamespaceCargo/HierarchicalRepository.php
+++ b/inc/src/View/Viewlet/NamespaceCargo/HierarchicalRepository.php
@@ -205,7 +205,7 @@ class HierarchicalRepository extends \MyBB\Cargo\Decorator\HierarchicalRepositor
      *
      * @return RepositoryInterface[]
      */
-    protected function getRepositories(): array
+    public function getRepositories(): array
     {
         $results = [];
 


### PR DESCRIPTION
Adds the `bin/cli view:inspect` command for View entity & resolution diagnostics.

Accepts:
- `--resource <absolute path | relative path | Viewlet Locator>` or
- `--asset <URL | absolute path | relative path | Locator>`

for entities of interest, and
- - `--package <Extension Package name>` or
  - `--theme <database ID>`; and
- `--namespace <name>`

for customizing the resolution context.

Outputs:
- final resolution context,
- Assets:
  - Asset Class,
  - Locator-related details,
  - published file metadata,
  - primary source Resource,
  - processing complexity,
  - explicit/implicit basis,
  - freshness,
  - URLs,
  - composite Asset Properties,
  - contributing source Resources & Viewlets,
  - references in templates via `asset()`, `asset_url()` functions,
- Resources:
  - Locator-related details,
  - published file metadata,
  - Code Language,
  - syntax validation,
  - direct publishability,
  - syntax errors,
  - ancestry,
  - derived Assets.

<img height="150" alt="cli-view-inspect-resource" src="https://github.com/user-attachments/assets/537cd1bd-0f24-4817-b8d9-cda852a0b1f7" />
<img height="150" alt="cli-view-inspect-static-asset" src="https://github.com/user-attachments/assets/bec43e3e-e33d-461f-8c8a-45f403e1b35d" />
<img height="150" alt="cli-view-inspect-viewlet-asset" src="https://github.com/user-attachments/assets/b38fe6ef-e1d4-4772-bb89-7ef821dc8088" />

<br><br>

Currently uses hardcoded strings to keep internal terminology consistent.

Depends on #5402