### PR TITLE
Restore the keyboard focus indicator on links and buttons

### DIFF
--- a/inc/themes/core.base/frontend/styles/components/layout/_page.scss
+++ b/inc/themes/core.base/frontend/styles/components/layout/_page.scss
@@ -35,11 +35,6 @@ a:active {
     text-decoration: underline;
 }
 
-a:focus,
-button:focus {
-    outline: 0;
-}
-
 hr {
     display: block;
     height: var(--border-width-base);


### PR DESCRIPTION
### The problem

`inc/themes/core.base/frontend/styles/components/layout/_page.scss` has:

```scss
a:focus,
button:focus {
    outline: 0;
}
```

Nothing puts a ring back. Every link and every button in core.base therefore
has no visible focus state, so a keyboard user tabbing through the board gets
no indication of where they are. This is a WCAG 2.4.7 (Focus Visible) Level AA
failure, and it applies to the whole front end — the index, thread lists,
posts, profiles, the UserCP.

Form fields are unaffected: `components/_form-fields.scss` removes the outline
too, but replaces it with its own border and shadow treatment. It is only
links and buttons that are left bare.

### Why deleting is the fix

The rule predates `:focus-visible`. Suppressing `:focus` was the standard way
to stop a ring appearing on mouse clicks, back when `:focus` matched pointer
and keyboard alike.

Browsers now draw their default ring on `:focus-visible` only. Removing this
rule therefore restores the keyboard indicator **without** bringing the
mouse-click ring back — the thing the rule was written to prevent is now the
browser's own default behaviour.

### Why not a themed ring

Replacing it with something like `outline: 2px solid var(--primary-color)`
looks tidier, but is not usable as an indicator in the dark scheme:

| | ring vs background | ratio |
|---|---|---|
| dark | `#004c7d` on `--background-default` `#282b2c` | **1.58:1** |
| dark | `#004c7d` on `--content-background` `#1d1f20` | **1.84:1** |
| light | `#007fd0` on `#ffffff` | 4.25:1 |
| light | `#007fd0` on `#f9f9f9` | 4.03:1 |

WCAG 1.4.11 asks for 3:1 on a focus indicator, so the dark scheme would still
fail. `var(--font-color)` would clear it (14.26:1 light, 11.59:1 dark) but
reads oddly as an accent, and either choice imposes a look on third-party
themes.

The browser default ring is contrast-aware by design — Chromium draws a
dual-tone ring specifically so it stays visible on any background — which
makes it the safer default for a theme other people build on.

### Testing

Tab through the board with and without the patch. Before: focus is invisible
outside form fields. After: each link and button shows the browser's focus
ring, and clicking with a mouse still shows nothing.
