### PR TITLE
Fix ban user form username prefill

### DIFF
--- a/modcp.php
+++ b/modcp.php
@@ -3743,10 +3743,12 @@ if($mybb->input['action'] == "banuser")
 
 			if($user['uid'] == $mybb->user['uid'])
 			{
+				$lang->load('datahandler_user');
 				$errors = inline_error([$lang->userdata_ban_self]);
 			}
 			elseif(!modcp_can_manage_user($user['uid']))
 			{
+				$lang->load('datahandler_user');
 				$errors = inline_error([$lang->userdata_no_perm_to_ban]);
 			}
 		}

--- a/modcp.php
+++ b/modcp.php
@@ -3734,6 +3734,14 @@ if($mybb->input['action'] == "banuser")
 			"usergroup" => $mybb->get_input('usergroup', MyBB::INPUT_INT)
 		);
 	}
+	elseif($mybb->get_input('uid', MyBB::INPUT_INT))
+	{
+		$user = get_user($mybb->get_input('uid', MyBB::INPUT_INT));
+		if($user)
+		{
+			$banned['username'] = $user['username'];
+		}
+	}
 
 	// Generate the banned times dropdown
 	$liftlist = $lifttime = [];

--- a/modcp.php
+++ b/modcp.php
@@ -3740,6 +3740,15 @@ if($mybb->input['action'] == "banuser")
 		if($user)
 		{
 			$banned['username'] = $user['username'];
+
+			if($user['uid'] == $mybb->user['uid'])
+			{
+				$errors = inline_error([$lang->userdata_ban_self]);
+			}
+			elseif(!modcp_can_manage_user($user['uid']))
+			{
+				$errors = inline_error([$lang->userdata_no_perm_to_ban]);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Populate the ban user form username field when opening it with a user ID in the URL.

## Changes

- Resolve the `uid` query parameter on the initial `banuser` page load.
- Pre-fill the username search field with the resolved user's username.
- Preserve the existing submitted value when returning after validation errors.

## Validation

- `php -l modcp.php`