### PR TITLE
Block posting until warnings are acknowledged

### DIFF
--- a/global.php
+++ b/global.php
@@ -649,7 +649,7 @@ if($warnings_count > 0)
 
 	if(in_array($current_page, array('newthread.php', 'newreply.php'), true))
 	{
-		error($headerMessages['warningsnotice']['message']);
+		error($lang->unacknowledged_warnings_posting, $lang->unacknowledged_warnings_posting_title);
 	}
 }
 

--- a/global.php
+++ b/global.php
@@ -646,6 +646,11 @@ if($warnings_count > 0)
 	$headerMessages['warningsnotice']['id'] = 'warning_notice';
 	$headerMessages['warningsnotice']['class'] = 'alert--danger';
 	$headerMessages['warningsnotice']['message'] = $lang->sprintf($lang->unacknowledged_warnings_notice, $warnings_count);
+
+	if(in_array($current_page, array('newthread.php', 'newreply.php'), true))
+	{
+		error($headerMessages['warningsnotice']['message']);
+	}
 }
 
 if(isset($mybb->user['avatartype']) && ($mybb->user['avatartype'] === 'remote' || $mybb->user['avatartype'] === 'gravatar') && !$mybb->settings['allowremoteavatars'])

--- a/global.php
+++ b/global.php
@@ -649,7 +649,7 @@ if($warnings_count > 0)
 
 	if(in_array($current_page, array('newthread.php', 'newreply.php'), true))
 	{
-		error($lang->unacknowledged_warnings_posting, $lang->unacknowledged_warnings_posting_title);
+		error($lang->unacknowledged_warnings_posting, $lang->unacknowledged_warnings_posting_title, "", 403);
 	}
 }
 

--- a/inc/languages/english/global.lang.php
+++ b/inc/languages/english/global.lang.php
@@ -432,6 +432,8 @@ $l['quickrestore_confirm'] = "Are you sure you want to restore this post?";
 $l['newpm_notice_one'] = "<strong>You have one unread private message</strong> from {1} titled <a href=\"{2}/private.php?action=read&amp;pmid={3}\" style=\"font-weight: bold;\">{4}</a>";
 $l['newpm_notice_multiple'] = "<strong>You have {1} unread private messages.</strong> The most recent is from {2} titled <a href=\"{3}/private.php?action=read&amp;pmid={4}\" style=\"font-weight: bold;\">{5}</a>";
 $l['unacknowledged_warnings_notice'] = "<strong>You have {1} unacknowledged warning(s).</strong> Please check your <strong><a href=\"usercp.php?action=warninglog\">control panel</a></strong> for more information.";
+$l['unacknowledged_warnings_posting_title'] = "Posting Restricted";
+$l['unacknowledged_warnings_posting'] = "You have a warning that requires your acknowledgement. You cannot post replies or create new threads until you acknowledge it. Please review your <a href=\"usercp.php?action=warninglog\">warning log</a>.";
 $l['deleteevent_confirm'] = "Are you sure you want to delete this event?";
 $l['removeattach_confirm'] = "Are you sure you want to remove the selected attachment from this post?";
 

--- a/inc/themes/core.base/frontend/styles/pages/_compose.scss
+++ b/inc/themes/core.base/frontend/styles/pages/_compose.scss
@@ -126,6 +126,10 @@
 
 .quick-reply {
 
+    &__warning {
+        margin: var(--spacing-4) var(--spacing-4) 0;
+    }
+
     &__options {
         @extend .container;
         display: none;

--- a/inc/themes/core.base/frontend/styles/pages/_compose.scss
+++ b/inc/themes/core.base/frontend/styles/pages/_compose.scss
@@ -127,7 +127,7 @@
 .quick-reply {
 
     &__warning {
-        margin: var(--spacing-4) var(--spacing-4) 0;
+        margin: var(--spacing-4);
     }
 
     &__options {

--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -325,14 +325,18 @@
                     </div>
                     {% if mybb.user.unacknowledgedwarnings %}
                         <div class="alert alert--danger quick-reply__warning">
-                            {{ trans('unacknowledged_warnings_notice', mybb.user.unacknowledgedwarnings)|raw }}
+                            {{ include('partials/icon.twig', {icon: 'exclamation-triangle', class: 'alert__icon'}, with_context = false) }}
+                            <div class="alert__message">
+                                <h3 class="alert__title">{{ lang.unacknowledged_warnings_posting_title }}</h3>
+                                <p class="alert__description">{{ lang.unacknowledged_warnings_posting|raw }}</p>
+                            </div>
                         </div>
                     {% else %}
                         <div class="post__body">
                             <textarea class="textarea" rows="8" cols="80" name="message" id="message" tabindex="1" placeholder="{{ lang.quick_reply_message }}"></textarea>
                         </div>
                     {% endif %}
-                    {% if (mybb.usergroup.canusesig and mybb.user.suspendsignature != 1) or forum.allowsmilies or modpermissions.canopenclosethreads or modpermissions.canstickunstickthreads %}
+                    {% if not mybb.user.unacknowledgedwarnings and ((mybb.usergroup.canusesig and mybb.user.suspendsignature != 1) or forum.allowsmilies or modpermissions.canopenclosethreads or modpermissions.canstickunstickthreads) %}
                         <input type="checkbox" class="compose__checkbox" id="show-quick-reply-options">
                         <div class="quick-reply__options">
                             {% if mybb.usergroup.canusesig and mybb.user.suspendsignature != 1 %}
@@ -349,6 +353,7 @@
                             {% endif %}
                         </div>
                     {% endif %}
+                    {% if not mybb.user.unacknowledgedwarnings %}
                     {{ captcha|raw }}
                     <div class="post__foot">
                         <button type="submit" class="button button--full-width" tabindex="2" accesskey="s" id="quick_reply_submit">
@@ -366,6 +371,7 @@
                             <span class="button__text">{{ lang.preview_post }}</span>
                         </button>
                     </div>
+                    {% endif %}
                 </form>
             </div>
         {% endif %}

--- a/inc/themes/core.base/frontend/templates/showthread/showthread.twig
+++ b/inc/themes/core.base/frontend/templates/showthread/showthread.twig
@@ -323,9 +323,15 @@
                         <h3 class="post__author"><a href="{{ get_profile_link(mybb.user.uid) }}">{{ mybb.user|format_name }}</a></h3>
                         <span class="post__date">{{ lang.quick_reply }}</span>
                     </div>
-                    <div class="post__body">
-                        <textarea class="textarea" rows="8" cols="80" name="message" id="message" tabindex="1" placeholder="{{ lang.quick_reply_message }}"></textarea>
-                    </div>
+                    {% if mybb.user.unacknowledgedwarnings %}
+                        <div class="alert alert--danger quick-reply__warning">
+                            {{ trans('unacknowledged_warnings_notice', mybb.user.unacknowledgedwarnings)|raw }}
+                        </div>
+                    {% else %}
+                        <div class="post__body">
+                            <textarea class="textarea" rows="8" cols="80" name="message" id="message" tabindex="1" placeholder="{{ lang.quick_reply_message }}"></textarea>
+                        </div>
+                    {% endif %}
                     {% if (mybb.usergroup.canusesig and mybb.user.suspendsignature != 1) or forum.allowsmilies or modpermissions.canopenclosethreads or modpermissions.canstickunstickthreads %}
                         <input type="checkbox" class="compose__checkbox" id="show-quick-reply-options">
                         <div class="quick-reply__options">


### PR DESCRIPTION
## Summary

Prevent users from posting until they acknowledge required warnings.

## Changes

- Block `newthread.php` and `newreply.php` while the user has unacknowledged warnings.
- Keep the User CP warning log and acknowledgement flow available.
- Replace the quick-reply textarea with the existing warning notice until acknowledgement.
- Add spacing around the quick-reply warning notice.

## Validation

- `php -l global.php`
- `php -l showthread.php`
- `git diff --check`

This is a WIP PR focused only on the posting restriction.