### PR TITLE
Preserve draft post icon across draft edit and drafts list

### DIFF
--- a/inc/themes/core.base/frontend/templates/usercp/drafts/row.twig
+++ b/inc/themes/core.base/frontend/templates/usercp/drafts/row.twig
@@ -1,6 +1,11 @@
 <div class="row row--simple-columns draft">
     <div class="row__primary">
-        <h3 class="draft__subject"><a href="{{ draft.editurl|raw }}">{{ draft.subject }}</a></h3>
+        <h3 class="draft__subject">
+            {% if draft.iconpath is defined and draft.iconpath %}
+                <img src="{{ draft.iconpath|raw }}" alt="{{ draft.iconname|default('') }}" title="{{ draft.iconname|default('') }}" class="draft__icon" />
+            {% endif %}
+            <a href="{{ draft.editurl|raw }}">{{ draft.subject }}</a>
+        </h3>
         <p class="draft__location">
             {% if draft.type == 'post' %}
                 {{ lang.thread }}: <a href="{{ get_thread_link(draft.tid) }}">{{ draft.threadsubject }}</a>

--- a/newreply.php
+++ b/newreply.php
@@ -51,6 +51,13 @@ if(($mybb->input['action'] == "editdraft" || $mybb->input['action'] == "do_newre
 	}
 	$pid = (int)$post['pid'];
 	$tid = (int)$post['tid'];
+
+	// Only rehydrate the draft icon on the actual edit-draft page load.
+	// The do_newreply POST path must honor the most recent radio input selected by the user.
+	if($mybb->input['action'] == "editdraft" && isset($post['icon']))
+	{
+		$mybb->input['icon'] = (int)$post['icon'];
+	}
 }
 
 // Set up $thread and $forum for later use.

--- a/newthread.php
+++ b/newthread.php
@@ -41,6 +41,13 @@ if($mybb->input['action'] == "editdraft" || ($mybb->get_input('savedraft') && $m
 	$pid = $post['pid'];
 	$fid = $thread['fid'];
 	$tid = $thread['tid'];
+
+	// Only reconstruct a draft icon during the actual edit-draft page view.
+	// During do_newthread / do_newreply submits the selected request icon must be respected.
+	if($mybb->input['action'] == "editdraft" && isset($post['icon']))
+	{
+		$mybb->input['icon'] = (int)$post['icon'];
+	}
 }
 else
 {

--- a/usercp.php
+++ b/usercp.php
@@ -2761,12 +2761,18 @@ if($mybb->input['action'] == "drafts")
 
 	$deleteDraftsEnabled = $draftCount > 0;
 	$drafts = [];
+	$posticons_cache = (array)$cache->read("posticons");
+	$posticonmap = [];
+	foreach($posticons_cache as $posticon)
+	{
+		$posticonmap[$posticon['iid']] = $posticon;
+	}
 
 	// Show a listing of all of the current 'draft' posts or threads the user has.
 	if($draftCount)
 	{
 		$query = $db->query("
-			SELECT p.subject, p.pid, t.tid, t.subject AS threadsubject, t.fid, f.name AS forumname, p.dateline, t.visible AS threadvisible, p.visible AS postvisible
+			SELECT p.subject, p.pid, p.icon AS posticon, t.tid, t.subject AS threadsubject, t.fid, f.name AS forumname, p.dateline, t.visible AS threadvisible, p.visible AS postvisible
 			FROM ".TABLE_PREFIX."posts p
 			LEFT JOIN ".TABLE_PREFIX."threads t ON (t.tid=p.tid)
 			LEFT JOIN ".TABLE_PREFIX."forums f ON (f.fid=t.fid)
@@ -2788,6 +2794,14 @@ if($mybb->input['action'] == "drafts")
 					$draft['editurl'] = "newthread.php?action=editdraft&amp;tid={$draft['tid']}";
 					$draft['type'] = 'thread';
 				}
+			}
+
+			if((int)$draft['posticon'] > 0 && isset($posticonmap[(int)$draft['posticon']]))
+			{
+				$posticon = $posticonmap[(int)$draft['posticon']];
+				$draft['iconpath'] = str_replace('{theme}', $theme['imgdir'], $posticon['path']);
+				$draft['iconpath'] = $mybb->get_asset_url($draft['iconpath']);
+				$draft['iconname'] = $posticon['name'];
 			}
 
 			$drafts[] = $draft;


### PR DESCRIPTION
Fixes draft icon persistence so edit-draft restores the saved icon only for draft viewing, while POST submit flow keeps the latest selected icon. Also surfaces the saved icon in the usercp drafts list row.